### PR TITLE
agnosticdev/AckBundling: SwiftQUIC: Improve ACK Bundling

### DIFF
--- a/Sources/SwiftNetwork/QUIC/Ack.swift
+++ b/Sources/SwiftNetwork/QUIC/Ack.swift
@@ -497,7 +497,7 @@ final class Ack: PrefixedLoggable, TimerUser {
                 setAckFrame: connection.scheduleAckFrame,
                 ecn: connection.ecn
             ) {
-                connection.sendFrames()
+                connection.sendFrames(delayedACK: true)
             }
         }
 
@@ -718,7 +718,7 @@ final class Ack: PrefixedLoggable, TimerUser {
         )
     }
 
-    private func scheduleDelayedAck() {
+    func scheduleDelayedAck() {
         // ACK timer is already scheduled
         if timerScheduled {
             return

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -2923,12 +2923,19 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
     }
 
     @discardableResult
-    func sendFrames(ignoreCongestionWindow: Bool = false) -> Bool {
-        // Make sure there is something to send first
+    func sendFrames(ignoreCongestionWindow: Bool = false, delayedACK: Bool = false) -> Bool {
+        // Make sure there are packets to send
         guard
-            initialPendingItems.hasPendingItems || handshakePendingItems.hasPendingItems
+            initialPendingItems.hasPendingItems
+                || handshakePendingItems.hasPendingItems
                 || applicationPendingItems.hasPendingItems
         else {
+            return false
+        }
+        // For ACK bundling purposes make sure to rely on the ACK-delay timer as much as possible
+        guard !applicationPendingItems.isAckOnly || delayedACK else {
+            // Make sure the ack-delay timer is armed if returning early
+            ack.scheduleDelayedAck()
             return false
         }
         return withCurrentPath { path in

--- a/Tests/SwiftNetworkTests/QUICTestHarness.swift
+++ b/Tests/SwiftNetworkTests/QUICTestHarness.swift
@@ -990,7 +990,7 @@ final class QUICTestHarness {
                     generator = TestDataGenerator(
                         blockSize: blockSize,
                         numberOfBlocks: blockCount,
-                        uniqueBits: UInt8(index),
+                        uniqueBits: UInt8(clamping: index),
                         sendFIN: sendFIN
                     )
                 }

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICEarlyDataTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICEarlyDataTests.swift
@@ -413,15 +413,21 @@ final class SwiftNetworkQUICEarlyDataTests: NetTestCase {
                 let receiveExpectation = XCTestExpectation()
                 context.async {
                     Logger.test.info("Trying to read data")
-                    for _ in 0..<10 {
+                    func attemptServerRead() {
                         if pairedPathsArray.first?.transferPackets() == 0 {
-                            break
+                            // Wait for new writes from the client to be sent
+                            context.async {
+                                attemptServerRead()
+                            }
+                            return
                         }
+                        Logger.test.info("Trying to read data")
                         if let readData = serverUpperHarness?.upperHarnesses.first?.read() {
                             XCTAssertEqual(readData, dataToSend)
                             receiveExpectation.fulfill()
                         }
                     }
+                    attemptServerRead()
                 }
                 wait(for: [receiveExpectation], timeout: 5.0)
             }

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICHarnessTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICHarnessTests.swift
@@ -293,6 +293,17 @@ final class SwiftNetworkQUICHarnessTests: NetTestCase {
         )
     }
 
+    func testQUIC1000BidirectionalStreamsEcho1k() {
+        let serverOptions = QUICProtocol.options()
+        serverOptions.connectionOptions.initialMaxStreamsBidirectional = 1000
+        QUICTestHarness().runQUICTest(
+            streamCount: 1000,
+            blockSize: 1000,
+            blockCount: 1,
+            serverOptions: serverOptions
+        )
+    }
+
     func testQUICConnectionCloseError() {
         QUICTestHarness().runQUICTest(
             streamCount: 2,


### PR DESCRIPTION
This change utilizes the ACK delay timer to pickup and send one-off ACKs that were not previously being bundled with stream frames in the same packet.
I did some analysis when SwiftQUIC was being used on the server and found that when h2load makes 5000 HTTP3 GET requests for 1k we are sending back 7557 packets back to h2load.
For example:
```
7557 packets are sent back to h2load 
2552 of these packets are single ACK packets
2450 of those 7557 response packets contain bundled ACKs with stream frames
```
This did not seem correct because the 1k stream frames should not have taken up the entire packet. Upon evaluating the packet trace I found that we were not bundling ACK frames as efficiently as we could. This change improves that situation and now I see:
```
5059 packets are sent back to h2load
Only 54 of these packets are single ACK packets without stream frames
4947 of those 5059 packets now contain bundled ACKs with stream frames
```
So almost all of the QUIC packets that carry the HTTP3 response also contain a bundle ACK ase well.