### PR TITLE
agnosticdev/CheaperIPv6Address: Provide cheap(er) IPv6Address init

### DIFF
--- a/Sources/SwiftNetwork/Endpoint/IPv6Address.swift
+++ b/Sources/SwiftNetwork/Endpoint/IPv6Address.swift
@@ -110,7 +110,7 @@ public struct IPv6Address: IPAddress, Hashable, CustomDebugStringConvertible {
         address
     }
 
-    init(_ tuple: (UInt32, UInt32, UInt32, UInt32)) {
+    public init(_ tuple: (UInt32, UInt32, UInt32, UInt32)) {
         self.address = tuple
     }
 


### PR DESCRIPTION
Provide an interface to create a `IPv6Address` without taking a heap hit from using an array.
This change exposes the a tuple of `UInt32` that can be used to extract a `IPv6Address` value from the C-struct value `sockaddr_in6`.
For example:
```
extension IPv6Address
    static func getAddressTuple(_ sockaddr_in6: sockaddr_in6) -> (UInt32, UInt32, UInt32, UInt32) {
        #if os(Linux)
        return (
            sockaddr_in6.sin6_addr.__in6_u.__u6_addr32.0,
            sockaddr_in6.sin6_addr.__in6_u.__u6_addr32.1,
            sockaddr_in6.sin6_addr.__in6_u.__u6_addr32.2,
            sockaddr_in6.sin6_addr.__in6_u.__u6_addr32.3
        )
        #elseif canImport(Darwin)
        return (
            sa.sin6_addr.__u6_addr.__u6_addr32.0,
            sa.sin6_addr.__u6_addr.__u6_addr32.1,
            sa.sin6_addr.__u6_addr.__u6_addr32.2,
            sa.sin6_addr.__u6_addr.__u6_addr32.3
        )
        #endif
    }
}

```