### PR TITLE
Added listener-side support bits for QUIC connection migration

### DIFF
--- a/Sources/SwiftNetwork/Path/PathProperties.swift
+++ b/Sources/SwiftNetwork/Path/PathProperties.swift
@@ -242,6 +242,7 @@ public struct PathProperties: CustomStringConvertible {
         static public let useLinkHeuristics = Flags(rawValue: 1 << 31)
         static public let hasOverrideTrafficClass = Flags(rawValue: 1 << 32)
         static public let fallbackIsOpportunistic = Flags(rawValue: 1 << 33)
+        static public let hasMigrationInfoFlag = Flags(rawValue: 1 << 34)
     }
 
     /// The link quality measurement of the link-layer network attachment.
@@ -358,6 +359,12 @@ public struct PathProperties: CustomStringConvertible {
         get { flags.contains(.fallbackIsOpportunistic) }
         set { if newValue { flags.insert(.fallbackIsOpportunistic) } else { flags.remove(.fallbackIsOpportunistic) } }
     }
+#if !(NETWORK_PRIVATE || NETWORK_DRIVERKIT)
+    var hasMigrationInfo: Bool {
+        get { flags.contains(.hasMigrationInfoFlag) }
+        set { if newValue { flags.insert(.hasMigrationInfoFlag) } else { flags.remove(.hasMigrationInfoFlag) } }
+    }
+#endif
     var fallbackIsForced: Bool {
         get { flags.contains(.fallbackIsForced) }
         set { if newValue { flags.insert(.fallbackIsForced) } else { flags.remove(.fallbackIsForced) } }

--- a/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
@@ -240,6 +240,7 @@ public protocol MultiplexingPath: UpperProtocolHandler {
     var identifier: MultiplexingPathIdentifier { get }
     init(parent: ParentProtocol)
     var pathIsPrimary: Bool { get set }
+    var pathHasMigrationInfo: Bool { get set }
 }
 
 @_spi(ProtocolProvider)
@@ -932,8 +933,13 @@ extension ManyToManyDatapathProtocol where Path.ParentProtocol == Self, Path: In
             parameters: parameters,
             path: path
         )
-        if multiplexingPaths.isEmpty { newPath.pathIsPrimary = true }
+        let isFirstPath = multiplexingPaths.isEmpty
+        if isFirstPath { newPath.pathIsPrimary = true }
+        if path?.hasMigrationInfo == true { newPath.pathHasMigrationInfo = true }
         multiplexingPaths[newPath.identifier] = newPath
+        if !isFirstPath {
+            handlePathChanged(path: newPath.identifier, event: .available, isPrimary: newPath.pathIsPrimary)
+        }
     }
 }
 
@@ -1953,6 +1959,7 @@ open class MultiplexingDatagramPath<ParentProtocol: ManyToManyOutboundDatagramPr
     public var lowerReceiveQueue = FrameArray()
 
     public var pathIsPrimary: Bool = false
+    public var pathHasMigrationInfo: Bool = false
 
     @_optimize(speed)
     public var reference: ProtocolInstanceReference {

--- a/Sources/SwiftNetwork/QUIC/Migration.swift
+++ b/Sources/SwiftNetwork/QUIC/Migration.swift
@@ -156,8 +156,7 @@ extension QUICConnection {
         event: MultiplexingPathEvent,
         isPrimary: Bool
     ) {
-        guard !migration.activeMigrationDisabled else {
-            // Ignore if migration is disabled
+        guard !migration.activeMigrationDisabled || isServer else {
             return
         }
 
@@ -183,6 +182,13 @@ extension QUICConnection {
             if !path.isRouteEstablished {
                 path.changeState(to: .routeEstablished)
             }
+            if isServer, path != currentPath, !path.isValidated {
+                if path.pathHasMigrationInfo {
+                    path.useSlowProbeInterval = true
+                }
+                path.beginValidation()
+                sendFrames(on: path)
+            }
             break
         case .unavailable:
             if path.isOpenForSending, let dcid = path.dcid,
@@ -197,6 +203,12 @@ extension QUICConnection {
             }
             path.changeState(to: .routeUnavailable)
             break
+        }
+
+        if isServer {
+            for (id, path) in multiplexingPaths where path.state == .routeUnavailable {
+                multiplexingPaths.removeValue(forKey: id)
+            }
         }
 
         log.debug("Existing paths:")


### PR DESCRIPTION
- Declared new `hasMigrationInfo` flag on `PathProperties` and wired it in `ManyToManyProtocol`
- Propagated new path event to QUIC via `attachLowerDatagramProtocolForNewPath`