### PR TITLE
agnosticdev/FixTestQUICDrop10ServerPackets: SwiftQUIC Fix testQUICDrop10ServerPackets when datapath logging is enabled

### DIFF
--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -2988,8 +2988,9 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         else {
             return false
         }
-        // For ACK bundling purposes make sure to rely on the ACK-delay timer as much as possible
-        guard !applicationPendingItems.isAckOnly || delayedACK else {
+        // For ACK bundling purposes make sure to rely on the ACK-delay timer as much as possible,
+        // unless an immediate ACK needs to be processed.
+        guard !applicationPendingItems.isAckOnly || delayedACK || ack.immediateAcks > 0 else {
             // Make sure the ack-delay timer is armed if returning early
             ack.scheduleDelayedAck()
             return false


### PR DESCRIPTION
I uncovered a situation where the test for `testQUICDrop10ServerPackets` would fail only when data path logging was enabled.  This fix now takes into account the case when `ackAgressively` is called when receiving inbound packets and `sendFrames` will respect `ack.immediateAcks`.