### PR TITLE
SwiftQUIC: PERF: acknowledgedSendDataInner is using too much CPU

### DIFF
--- a/Sources/SwiftNetwork/QUIC/StreamSendBuffer.swift
+++ b/Sources/SwiftNetwork/QUIC/StreamSendBuffer.swift
@@ -161,7 +161,7 @@ struct StreamSendBuffer: ~Copyable {
         return totalLengthCopied
     }
 
-    var acknowledgedDataRanges = AcknowledgedRanges()
+    var acknowledgedDataRanges = RangeSet<StreamOffset>()
 
     mutating private func acknowledgedSendDataInner(
         offset acknowledgedOffset: StreamOffset,
@@ -204,7 +204,7 @@ struct StreamSendBuffer: ~Copyable {
             }
             // Remove the consumed in one shot
             if consumed > 0 {
-                acknowledgedDataRanges.ranges.removeSubrange(0..<consumed)
+                acknowledgedDataRanges.remove(contentsOf: 0..<UInt64(consumed))
             }
             let difference = newStartOffset - storageStartOffset
             storageStartOffset = newStartOffset
@@ -235,54 +235,6 @@ struct StreamSendBuffer: ~Copyable {
         let allDataAcknowledged = (storage.isEmpty && hasLast)
         log.datapath("All data acknowleged: \(allDataAcknowledged)")
         return allDataAcknowledged
-    }
-}
-
-// Sorted list of ACK byte ranges. Used to track out of order ACKs.
-struct AcknowledgedRanges {
-    var ranges: [Range<StreamOffset>] = []
-
-    var isEmpty: Bool {
-        ranges.isEmpty
-    }
-
-    // Insert a range and merge with any overlapping or adjacent existing ranges.
-    mutating func insert(contentsOf newRange: Range<StreamOffset>) {
-        guard !newRange.isEmpty else { return }
-
-        let lower = newRange.lowerBound
-        let upper = newRange.upperBound
-
-        // startIndex is the first range where upperBound >= lower.
-        var low = 0
-        var high = ranges.count
-        while low < high {
-            let mid = low + (high - low) / 2
-            if ranges[mid].upperBound < lower {
-                low = mid + 1
-            } else {
-                high = mid
-            }
-        }
-        let startIndex = low
-
-        // endIndex is the first range where lowerBound > upper.
-        high = ranges.count
-        while low < high {
-            let mid = low + (high - low) / 2
-            if ranges[mid].lowerBound <= upper {
-                low = mid + 1
-            } else {
-                high = mid
-            }
-        }
-        let endIndex = low
-
-        // Merge the new range with all existing ranges in [startIndex, endIndex) by
-        // taking the minimum lower bound and maximum upper bound across the whole set.
-        let mergedLower = startIndex < endIndex ? min(lower, ranges[startIndex].lowerBound) : lower
-        let mergedUpper = startIndex < endIndex ? max(upper, ranges[endIndex - 1].upperBound) : upper
-        ranges.replaceSubrange(startIndex..<endIndex, with: CollectionOfOne(mergedLower..<mergedUpper))
     }
 }
 

--- a/Sources/SwiftNetwork/QUIC/StreamSendBuffer.swift
+++ b/Sources/SwiftNetwork/QUIC/StreamSendBuffer.swift
@@ -219,35 +219,9 @@ struct StreamSendBuffer: ~Copyable {
             return
         }
 
-        // Out of order ACK, buffer it and check if the gap is closed.
+        // Out of order ACK. The gap will be consumed when the in-order
+        // path above processes an ACK that fits this range.
         acknowledgedDataRanges.insert(contentsOf: acknowledgedOffset..<totalAcknowledgedOffset)
-
-        guard acknowledgedDataRanges.ranges[0].lowerBound == storageStartOffset else {
-            // We can't increment the storageStartOffset due to a gap. Return.
-            return
-        }
-
-        // The first buffered range is now contiguous with storageStartOffset.
-        // Consume any subsequent ranges that are also contiguous.
-        let oldStartOffset = storageStartOffset
-        var newStartOffset = acknowledgedDataRanges.ranges[0].upperBound
-        var consumed = 1
-        while consumed < acknowledgedDataRanges.ranges.count
-            && acknowledgedDataRanges.ranges[consumed].lowerBound <= newStartOffset
-        {
-            newStartOffset = max(newStartOffset, acknowledgedDataRanges.ranges[consumed].upperBound)
-            consumed += 1
-        }
-        acknowledgedDataRanges.ranges.removeSubrange(0..<consumed)
-
-        storageStartOffset = newStartOffset
-        let difference = newStartOffset - oldStartOffset
-        if !storage.isEmpty {
-            guard storage.claim(fromStart: Int(difference)) else {
-                log.fault("Failed to claim \(difference) bytes from start of stream send buffer storage")
-                return
-            }
-        }
     }
 
     // Returns true if it acknowledged to the end of the data now, i.e. end of stream.
@@ -293,7 +267,6 @@ struct AcknowledgedRanges {
         let startIndex = low
 
         // endIndex is the first range where lowerBound > upper.
-        low = startIndex
         high = ranges.count
         while low < high {
             let mid = low + (high - low) / 2

--- a/Sources/SwiftNetwork/QUIC/StreamSendBuffer.swift
+++ b/Sources/SwiftNetwork/QUIC/StreamSendBuffer.swift
@@ -161,7 +161,7 @@ struct StreamSendBuffer: ~Copyable {
         return totalLengthCopied
     }
 
-    var acknowledgedDataRanges = RangeSet<StreamOffset>()
+    var acknowledgedDataRanges = AcknowledgedRanges()
 
     mutating private func acknowledgedSendDataInner(
         offset acknowledgedOffset: StreamOffset,
@@ -192,7 +192,34 @@ struct StreamSendBuffer: ~Copyable {
             acknowledgedOffset = storageStartOffset
         }
 
-        // Record the newly acked range
+        // ACK is contiguous with storageStartOffset and in-order
+        if acknowledgedOffset == storageStartOffset {
+            var newStartOffset = totalAcknowledgedOffset
+            var consumed = 0
+            while consumed < acknowledgedDataRanges.ranges.count
+                && acknowledgedDataRanges.ranges[consumed].lowerBound <= newStartOffset
+            {
+                newStartOffset = max(newStartOffset, acknowledgedDataRanges.ranges[consumed].upperBound)
+                consumed += 1
+            }
+            // Remove the consumed in one shot
+            if consumed > 0 {
+                acknowledgedDataRanges.ranges.removeSubrange(0..<consumed)
+            }
+            let difference = newStartOffset - storageStartOffset
+            storageStartOffset = newStartOffset
+            if !storage.isEmpty {
+                guard storage.claim(fromStart: Int(difference)) else {
+                    log.fault(
+                        "Failed to claim \(difference) bytes from start of stream send buffer storage"
+                    )
+                    return
+                }
+            }
+            return
+        }
+
+        // Out of order ACK, buffer it and check if the gap is closed.
         acknowledgedDataRanges.insert(contentsOf: acknowledgedOffset..<totalAcknowledgedOffset)
 
         guard acknowledgedDataRanges.ranges[0].lowerBound == storageStartOffset else {
@@ -200,25 +227,22 @@ struct StreamSendBuffer: ~Copyable {
             return
         }
 
-        // The first acked data range is contiguous with previous data. The end of that
-        // range will be the new start offset.
+        // The first buffered range is now contiguous with storageStartOffset.
+        // Consume any subsequent ranges that are also contiguous.
         let oldStartOffset = storageStartOffset
-        let newStartOffset = acknowledgedDataRanges.ranges[0].upperBound
-
-        guard newStartOffset > oldStartOffset else {
-            // No change, ignore
-            return
+        var newStartOffset = acknowledgedDataRanges.ranges[0].upperBound
+        var consumed = 1
+        while consumed < acknowledgedDataRanges.ranges.count
+            && acknowledgedDataRanges.ranges[consumed].lowerBound <= newStartOffset
+        {
+            newStartOffset = max(newStartOffset, acknowledgedDataRanges.ranges[consumed].upperBound)
+            consumed += 1
         }
+        acknowledgedDataRanges.ranges.removeSubrange(0..<consumed)
 
-        // Update stored ranges
-        acknowledgedDataRanges.remove(contentsOf: oldStartOffset..<newStartOffset)
-
-        // Update offset cursor
         storageStartOffset = newStartOffset
-
+        let difference = newStartOffset - oldStartOffset
         if !storage.isEmpty {
-            // Drop frame data for newly acked data
-            let difference = newStartOffset - oldStartOffset
             guard storage.claim(fromStart: Int(difference)) else {
                 log.fault("Failed to claim \(difference) bytes from start of stream send buffer storage")
                 return
@@ -237,6 +261,55 @@ struct StreamSendBuffer: ~Copyable {
         let allDataAcknowledged = (storage.isEmpty && hasLast)
         log.datapath("All data acknowleged: \(allDataAcknowledged)")
         return allDataAcknowledged
+    }
+}
+
+// Sorted list of ACK byte ranges. Used to track out of order ACKs.
+struct AcknowledgedRanges {
+    var ranges: [Range<StreamOffset>] = []
+
+    var isEmpty: Bool {
+        ranges.isEmpty
+    }
+
+    // Insert a range and merge with any overlapping or adjacent existing ranges.
+    mutating func insert(contentsOf newRange: Range<StreamOffset>) {
+        guard !newRange.isEmpty else { return }
+
+        let lower = newRange.lowerBound
+        let upper = newRange.upperBound
+
+        // startIndex is the first range where upperBound >= lower.
+        var low = 0
+        var high = ranges.count
+        while low < high {
+            let mid = low + (high - low) / 2
+            if ranges[mid].upperBound < lower {
+                low = mid + 1
+            } else {
+                high = mid
+            }
+        }
+        let startIndex = low
+
+        // endIndex is the first range where lowerBound > upper.
+        low = startIndex
+        high = ranges.count
+        while low < high {
+            let mid = low + (high - low) / 2
+            if ranges[mid].lowerBound <= upper {
+                low = mid + 1
+            } else {
+                high = mid
+            }
+        }
+        let endIndex = low
+
+        // Merge the new range with all existing ranges in [startIndex, endIndex) by
+        // taking the minimum lower bound and maximum upper bound across the whole set.
+        let mergedLower = startIndex < endIndex ? min(lower, ranges[startIndex].lowerBound) : lower
+        let mergedUpper = startIndex < endIndex ? max(upper, ranges[endIndex - 1].upperBound) : upper
+        ranges.replaceSubrange(startIndex..<endIndex, with: CollectionOfOne(mergedLower..<mergedUpper))
     }
 }
 


### PR DESCRIPTION
In `StreamSendBuffer` acknowledgedSendDataInner does a insert and removal operation for almost all ACKs that are processed.  This is very costly based on the CPU metrics below.
The new change uses a custom struct that holds an array of `Range<StreamOffset>` to not pay the overhead of dealing with Set operations on each ACK. acknowledgedSendDataInner now has two branches, a in-order branch that only does a remove operation, and an out of order path that still falls back to using both an insert and remove operation.  The result of this is about a **7.3 gigacycle reduction** in CPU for QUICTransfer:

Baseline:
```
7.46 G  7.4%	-	         StreamSendBuffer.acknowledgedSendData(offset:length:log:)
7.42 G  7.3%	52.13 M	        StreamSendBuffer.acknowledgedSendDataInner(offset:length:log:)
2.91 G  2.9%	31.01 M	           specialized RangeSet.insert(contentsOf:)
2.80 G  2.8%	135.26 M	       RangeSet.Ranges._remove(contentsOf:)
639.99 M  0.6%	33.00 M	           RangeSet.Ranges.subscript.getter
567.07 M  0.6%	9.00 M	           RangeSet.remove(contentsOf:)
132.83 M  0.1%	-	               FrameArrayQueue.claim(fromStart:)
61.00 M  0.1%	4.00 M	           swift_release
```



With this change:
```
161.49 M  96.2%	1.87 M	        StreamSendBuffer.acknowledgedSendData(offset:length:log:)
159.62 M  95.1%	2.00 M	          StreamSendBuffer.acknowledgedSendDataInner(offset:length:log:)
151.62 M  90.3%	22.00 M	          specialized StreamSendBuffer.acknowledgedSendDataInner(offset:length:log:)
129.62 M  77.2%	-	              FrameArrayQueue.claim(fromStart:)
97.76 M  58.2%	20.00 M	          Frame.claim(fromStart:fromEnd:adjustSingleIPAggregate:)
31.86 M  19.0%	-	              FrameArray._claim(fromStart:existingLength:removeClaimedFrames:)
6.00 M   3.6%	6.00 M	  Frame.claim(fromStart:fromEnd:adjustSingleIPAggregate:)
```
