### PR TITLE
Support watchOS arm64_32 build variants for String.UTF8View

### DIFF
--- a/Sources/SwiftNetwork/Utilities/Serializer.swift
+++ b/Sources/SwiftNetwork/Utilities/Serializer.swift
@@ -542,7 +542,15 @@ public struct InPlaceSerializer<Factory: SerializerSpanFactory & ~Copyable & ~Es
             return
         }
 
+        #if os(watchOS) && arch(arm64_32)
+        // Fix for Span not being available on 32-bit watchOS
+        // This surfaces when build with the arm64_32 toolchain
+        // https://github.com/swiftlang/swift/blob/51b0b4aa41f28eae7d96af6f98c1fbd2b4b63958/stdlib/public/core/StringUTF8View.swift#L386
+        let utf8Bytes = Array(value.utf8).span.bytes
+        #else
+        // Builds for watchOS 64 bit variants and all other platforms
         let utf8Bytes = value.utf8.span.bytes
+        #endif
         let utf8ByteCount = utf8Bytes.byteCount
         if byteCount <= utf8ByteCount {
             try span(utf8Bytes.extracting(first: byteCount))
@@ -757,7 +765,15 @@ public struct FrameSerializer: ~Copyable {
             return
         }
 
+        #if os(watchOS) && arch(arm64_32)
+        // Fix for Span not being available on 32-bit watchOS
+        // This surfaces when build with the arm64_32 toolchain
+        // https://github.com/swiftlang/swift/blob/51b0b4aa41f28eae7d96af6f98c1fbd2b4b63958/stdlib/public/core/StringUTF8View.swift#L386
+        let utf8Bytes = Array(value.utf8).span.bytes.extracting(first: byteCount)
+        #else
+        // Builds for watchOS 64 bit variants and all other platforms
         let utf8Bytes = value.utf8.span.bytes.extracting(first: byteCount)
+        #endif
         let extraBytes = byteCount - utf8Bytes.byteCount
 
         withOutputSpan(length: byteCount) { outputSpan in


### PR DESCRIPTION
SwiftNIO QUIC has a macOS Tests Swift 6.3 build variant that is failing due to `arm64_32` builds for the watchOS toolchain tripping up on `Span` in the `String.UTF8View` type.
```
/Users/runner/Library/Developer/Xcode/DerivedData/swift-nio-quic-aizjhmmkhpwybjavsacfgpunzsnd/SourcePackages/checkouts/swift-network-evolution/Sources/SwiftNetwork/Utilities/Serializer.swift:545:36: error: 'span' is unavailable in watchOS
        let utf8Bytes = value.utf8.span.bytes
                                   ^~~~
Swift.String.UTF8View.span:4:16: note: 'span' has been explicitly marked unavailable here
    public var span: Span<UTF8.CodeUnit> { get }  }
               ^
/Users/runner/Library/Developer/Xcode/DerivedData/swift-nio-quic-aizjhmmkhpwybjavsacfgpunzsnd/SourcePackages/checkouts/swift-network-evolution/Sources/SwiftNetwork/Utilities/Serializer.swift:760:36: error: 'span' is unavailable in watchOS
        let utf8Bytes = value.utf8.span.bytes.extracting(first: byteCount)
                                   ^~~~
Swift.String.UTF8View.span:4:16: note: 'span' has been explicitly marked unavailable here
    public var span: Span<UTF8.CodeUnit> { get }  }
```
This is in-fact not supported by the compiler, see here:
https://github.com/swiftlang/swift/blob/51b0b4aa41f28eae7d96af6f98c1fbd2b4b63958/stdlib/public/core/StringUTF8View.swift#L386

This change adds a compiler directive to check for `arm64_32` variants of watchOS and provide compatibility support there.  All other 64 bit variants and other platforms use `Span` in a normal fashion.


