### PR TITLE
SwiftQUIC: Guard underflows in Congestion Control

### DIFF
--- a/Sources/SwiftNetwork/QUIC/CongestionControl.swift
+++ b/Sources/SwiftNetwork/QUIC/CongestionControl.swift
@@ -413,7 +413,13 @@ extension CongestionControlProtocol {
     }
 
     mutating func decrementBytesInFlight(_ bytes: UInt64) {
-        bytesInFlight -= bytes
+        let result = bytesInFlight.subtractingReportingOverflow(bytes)
+        if result.overflow {
+            log.fault("undeflow, \(bytes) decremented from \(bytesInFlight)")
+            bytesInFlight = 0
+        } else {
+            bytesInFlight = result.partialValue
+        }
         log.datapath("bytes in flight updated to \(bytesInFlight)")
         QUICSignpost.bytesInFlight(bytesInFlight: Int(bytesInFlight))
     }


### PR DESCRIPTION
Adds a check in CongestionControl to guard against the possibility of an underflow.  This logic adds a fault logic so the situation can be properly investigated instead of crashing the process.