### PR TITLE
Disable Netlink to unblock swift-nio-quic builds

### DIFF
--- a/Sources/SwiftNetwork/Endpoint/NetlinkAddress.swift
+++ b/Sources/SwiftNetwork/Endpoint/NetlinkAddress.swift
@@ -35,7 +35,7 @@ struct NetlinkAddress: IPAddress, Hashable, CustomDebugStringConvertible {
     /// Creates a Netlink address from raw bytes.
     init?(_ bytes: [UInt8]) {
         if bytes.count >= NetlinkAddress.layoutSize {
-            #if os(Linux)
+            #if os(Linux) && NETLINK_ENABLED
             let nl = bytes.withUnsafeBytes { $0.load(as: sockaddr_nl.self) }
             self.init(nl)
             #else
@@ -47,12 +47,12 @@ struct NetlinkAddress: IPAddress, Hashable, CustomDebugStringConvertible {
         }
     }
 
-    #if os(Linux)
+    #if os(Linux) && NETLINK_ENABLED
     // Linux has a specific type: sockaddr_nl
     init(_ sockaddr_nl: sockaddr_nl) {
         self.address = sockaddr_nl
     }
-    #elseif canImport(Darwin)
+    #else
     // rtsock on Darwin uses sockaddr
     // struct sockaddr route_dst = { .sa_len = 2, .sa_family = PF_ROUTE, .sa_data = { 0, } };
     init(_ sockaddr: sockaddr) {
@@ -68,14 +68,14 @@ struct NetlinkAddress: IPAddress, Hashable, CustomDebugStringConvertible {
         "NetlinkAddress"
     }
 
-    #if os(Linux)
+    #if os(Linux) && NETLINK_ENABLED
     var address: sockaddr_nl
     var nl_pid: pid_t = 0
     #else
     var address: sockaddr
     #endif
 
-    #if os(Linux)
+    #if os(Linux) && NETLINK_ENABLED
     private static let layoutSize = MemoryLayout<sockaddr_nl>.size
     #else
     private static let layoutSize = MemoryLayout<sockaddr>.size

--- a/Sources/SwiftNetwork/System/Linux/LinuxRoute.swift
+++ b/Sources/SwiftNetwork/System/Linux/LinuxRoute.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux) && NETLINK_ENABLED
+#if os(Linux) && canImport(Glibc) && NETLINK_ENABLED
 import Glibc
 internal import Logging
 internal import SwiftNetworkLinuxShim

--- a/Sources/SwiftNetwork/System/Linux/LinuxRoute.swift
+++ b/Sources/SwiftNetwork/System/Linux/LinuxRoute.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux)
+#if os(Linux) && NETLINK_ENABLED
 import Glibc
 internal import Logging
 internal import SwiftNetworkLinuxShim
@@ -534,6 +534,12 @@ internal enum SystemRoute {
             }
             return ifIndex
         }
+    }
+}
+#elseif os(Linux)
+internal enum SystemRoute {
+    static func routeGetInterfaceIndex(dst: any IPAddress, scopedIndex: UInt32 = 0) throws -> UInt32 {
+        0
     }
 }
 #endif

--- a/Sources/SwiftNetworkLinuxShim/include/SwiftNetworkLinuxShim.h
+++ b/Sources/SwiftNetworkLinuxShim/include/SwiftNetworkLinuxShim.h
@@ -18,8 +18,10 @@
 #ifdef __linux__
 
 #include <stdio.h>
-#include <linux/netlink.h>
-#include <linux/rtnetlink.h>
+#ifdef NETLINK_ENABLED
+    #include <linux/netlink.h>
+    #include <linux/rtnetlink.h>
+#endif
 #include <arpa/inet.h>
 
 // Not exposed in Glibc.swiftmodule

--- a/Tests/SwiftNetworkTests/SwiftNetworkInterfaceTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkInterfaceTests.swift
@@ -120,7 +120,10 @@ final class SwiftNetworkInterfaceTests: NetTestCase {
         )
     }
 
-    func testRouteGetInterfaceIndex() {
+    func testRouteGetInterfaceIndex() throws {
+        #if os(Linux) && !NETLINK_ENABLED
+        try XCTSkipIf(true)
+        #else
         // Very basic localhost test
         let v4Bytes: [UInt8] = [0x7F, 0x00, 0x00, 0x01]
 
@@ -154,5 +157,6 @@ final class SwiftNetworkInterfaceTests: NetTestCase {
         // Use a v6 loopback address with a scoped interface index
         let routeIndex4 = try! System.routeGetInterfaceIndex(dst: IPv6Address.loopback, scopedIndex: 1)
         XCTAssertEqual(routeIndex4, 1)
+        #endif
     }
 }


### PR DESCRIPTION
This PR disables the Netlink functionality until we devise a strategy to support this functionality long term on all Linux variants.  This will unblock the swift-nio-quic builds and hopefully address this issue: https://github.com/apple/swift-network-evolution/issues/19