### PR TITLE
QUIC: Cap the number of tracked ACK blocks

### DIFF
--- a/Sources/SwiftNetwork/QUIC/Ack.swift
+++ b/Sources/SwiftNetwork/QUIC/Ack.swift
@@ -298,6 +298,10 @@ struct AckSpace: ~Copyable, PrefixedLoggable {
         if let frame {
             setAckFrame(packetNumberSpace, frame, (blockCount > Ack.pingThreshold))
         }
+        if blockCount > Ack.maxAckBlocks {
+            blocks.removeFirst()
+            generationCount += 1
+        }
 
         return len
     }
@@ -416,8 +420,28 @@ struct AckBlockSequence: Sequence {
 final class Ack: PrefixedLoggable, TimerUser {
     var log: LogPrefixer
 
-    static let pingThreshold = 5  // Threshold to add a PING frame.
-    static let immediateAcks = 8  // Number of immediate ACKs when we need to ACK immediately
+    // When an outgoing ACK reports more than this many blocks (i.e. this many gaps
+    // in the packet numbers we've received), we piggyback a PING frame. An ACK
+    // frame is not ack-eliciting on its own, so the peer is not obliged to
+    // acknowledge it; the PING makes the packet ack-eliciting, forcing the peer to
+    // ACK it. That ack-of-ack lets us confirm the peer saw our gap report and prune
+    // the corresponding ACK blocks, keeping the list from growing.
+    static let pingThreshold = 5
+
+    // Upper bound on the number of ACK blocks (ranges) we track per packet number
+    // space. A peer that sends highly fragmented or persistently reordered traffic
+    // would otherwise grow this list without bound, inflating both memory use and
+    // the size of the ACK frames we emit. When the count exceeds this limit we drop
+    // the oldest (lowest-PN) block as each ACK is built, trimming the list back
+    // toward the cap.
+    static let maxAckBlocks = 256
+
+    // Number of consecutive packets to ACK immediately (bypassing the ACK delay
+    // timer) after entering aggressive-ACK mode via ackAgressively(). The
+    // counter is seeded with this value and decremented on each ACK sent; while it
+    // is non-zero we send ACKs without waiting, which speeds up loss recovery and
+    // RTT sampling during sensitive phases.
+    static let immediateAcks = 8
 
     static let defaultPacketThreshold = 128
     static let defaultDelayExponent = 3 /* 2 ** 3 */

--- a/Tests/QUICTests/AckTests.swift
+++ b/Tests/QUICTests/AckTests.swift
@@ -1009,6 +1009,50 @@ final class AckTests: XCTestCase {
         XCTAssertEqual(emittedBlocks, 0)
     }
 
+    // Appending more than Ack.maxAckBlocks (256) separate blocks must cause the
+    // oldest (lowest-PN) block to be dropped when the ACK is sized/assembled, and
+    // the block count must converge to 256.
+    func testAckMaxBlocksCap() {
+        // PNs spaced by 2 leave a one-packet gap between each, so no two blocks
+        // coalesce: 257 appends -> 257 separate blocks.
+        for i in 0...256 {
+            ack.append(packetNumberSpace: .applicationData, packetNumber: PacketNumber(Int64(i * 2)))
+        }
+        XCTAssertEqual(ack.blocksForPacketNumberSpace(packetNumberSpace: .applicationData), 257)
+
+        // Sizing the ACK drives AckSpace.build(), which trims one block because the
+        // count (257) exceeds Ack.maxAckBlocks.
+        XCTAssertGreaterThan(ack.size(for: .applicationData), 0)
+        XCTAssertEqual(ack.blocksForPacketNumberSpace(packetNumberSpace: .applicationData), 256)
+
+        // The dropped block must be the oldest one (the block covering PN 0).
+        // Re-appending PN 0 proves it: if PN 0 is no longer covered the append
+        // creates a fresh block (count -> 257); had any other block been dropped,
+        // PN 0 would still be covered and the append would be a no-op duplicate.
+        ack.append(packetNumberSpace: .applicationData, packetNumber: 0)
+        XCTAssertEqual(ack.blocksForPacketNumberSpace(packetNumberSpace: .applicationData), 257)
+        // Clean up that probe block so the cap-stability check below starts at 256.
+        ack.acknowledged(packetNumberSpace: .applicationData, between: 0, and: 0)
+        XCTAssertEqual(ack.blocksForPacketNumberSpace(packetNumberSpace: .applicationData), 256)
+
+        // The cap is stable: 256 is not > Ack.maxAckBlocks, so a second sizing
+        // removes nothing.
+        XCTAssertGreaterThan(ack.size(for: .applicationData), 0)
+        XCTAssertEqual(ack.blocksForPacketNumberSpace(packetNumberSpace: .applicationData), 256)
+    }
+
+    // Exactly Ack.maxAckBlocks (256) blocks must not trigger trimming: the guard
+    // is "> 256", not ">= 256".
+    func testAckMaxBlocksBoundary() {
+        for i in 0..<256 {
+            ack.append(packetNumberSpace: .applicationData, packetNumber: PacketNumber(Int64(i * 2)))
+        }
+        XCTAssertEqual(ack.blocksForPacketNumberSpace(packetNumberSpace: .applicationData), 256)
+
+        XCTAssertGreaterThan(ack.size(for: .applicationData), 0)
+        XCTAssertEqual(ack.blocksForPacketNumberSpace(packetNumberSpace: .applicationData), 256)
+    }
+
 }
 
 #endif


### PR DESCRIPTION
- Add `maxAckBlocks` limit (256) to bound per-space ACK block growth
- Drop the oldest block while building ACKs once the cap is exceeded,
  preventing unbounded memory and ACK frame size from fragmented or
  reordered traffic
- Document the rationale behind `pingThreshold`, `maxAckBlocks`, and
  `immediateAcks`
- Add tests covering the cap, boundary, and stability behavior