### PR TITLE
CI improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      swiftlang-actions:
+        patterns:
+          - "swiftlang/github-workflows/*"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.9
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:
       swift_flags: "-Xswiftc -warnings-as-errors"
       swift_nightly_flags: "--build-system native -Xswiftc -warnings-as-errors"  # workaround nightly-main issue

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,6 +13,25 @@ jobs:
       swift_nightly_flags: "--build-system native -Xswiftc -warnings-as-errors"  # workaround nightly-main issue
       enable_macos_checks: true
       macos_exclude_xcode_versions: "[{\"xcode_version\": \"16.4\"}, {\"xcode_version\": \"26.3\"}]"
+      macos_build_command: >-
+        bash -c '
+        rc=0;
+        echo "=== xcodebuild macOS ===";
+        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=macos,variant=macos" build || rc=1;
+        echo "=== xcodebuild Mac Catalyst ===";
+        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=macos,variant=Mac Catalyst" build || rc=1;
+        echo "=== xcodebuild iOS ===";
+        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=ios" build || rc=1;
+        echo "=== xcodebuild watchOS ===";
+        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=watchos" build || rc=1;
+        echo "=== xcodebuild tvOS ===";
+        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=tvos" build || rc=1;
+        echo "=== xcodebuild visionOS ===";
+        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=visionos" build || rc=1;
+        echo "=== xcrun swift test ===";
+        xcrun swift test "$@" || rc=1;
+        exit $rc
+        ' bash
       enable_linux_checks: true
       linux_swift_versions: '["nightly-main", "nightly-6.3", "6.3"]'
       linux_build_command: "swift test -c release"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,7 +35,7 @@ jobs:
         /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=visionos" build && visionos=PASSED || { rc=1; visionos=FAILED; };
         echo "=== visionOS build: $visionos ===";
         echo "=== xcrun swift test ===";
-        xcrun swift test "$@" && tests=PASSED || { rc=1; tests=FAILED; };
+        xcrun swift test --quiet "$@" && tests=PASSED || { rc=1; tests=FAILED; };
         echo "=== swift test: $tests ===";
         echo "=== Summary ===";
         printf "%-20s %s\n" "macOS build:" "$macos";
@@ -53,15 +53,21 @@ jobs:
         bash -c '
         set -e;
         echo "=== Build (default traits) ===";
-        swift build --build-tests "$@";
+        swift build --build-tests --quiet "$@";
+        echo "=== Build (default traits): PASSED ===";
         echo "=== Build (additive traits on) ===";
-        swift build --build-tests --traits DatapathLogging,QlogOutput,SignpostOutput "$@";
+        swift build --build-tests --quiet --traits DatapathLogging,QlogOutput,SignpostOutput "$@";
+        echo "=== Build (additive traits on): PASSED ===";
         echo "=== Build (reductive traits on) ===";
-        swift build --build-tests --traits DisableDebugLogging,DisableErrorLogging "$@";
+        swift build --build-tests --quiet --traits DisableDebugLogging,DisableErrorLogging "$@";
+        echo "=== Build (reductive traits on): PASSED ===";
         echo "=== Test (debug) ===";
-        swift test "$@";
+        swift test --quiet "$@";
+        echo "=== Test (debug): PASSED ===";
         echo "=== Test (release) ===";
-        swift test -c release "$@"
+        swift test --quiet -c release "$@";
+        echo "=== Test (release): PASSED ===";
+        echo "=== Summary: all builds and tests passed ==="
         ' bash
       enable_windows_checks: false
       enable_android_sdk_build: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,7 +34,20 @@ jobs:
         ' bash
       enable_linux_checks: true
       linux_swift_versions: '["nightly-main", "nightly-6.3", "6.3"]'
-      linux_build_command: "swift test -c release"
+      linux_build_command: >-
+        bash -c '
+        set -e;
+        echo "=== Build (default traits) ===";
+        swift build --build-tests "$@";
+        echo "=== Build (additive traits on) ===";
+        swift build --build-tests --traits DatapathLogging,QlogOutput,SignpostOutput "$@";
+        echo "=== Build (reductive traits on) ===";
+        swift build --build-tests --traits DisableDebugLogging,DisableErrorLogging "$@";
+        echo "=== Test (debug) ===";
+        swift test "$@";
+        echo "=== Test (release) ===";
+        swift test -c release "$@"
+        ' bash
       enable_windows_checks: false
       enable_android_sdk_build: false
       enable_embedded_wasm_sdk_build: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,7 +38,7 @@ jobs:
       enable_windows_checks: false
       enable_android_sdk_build: false
       enable_embedded_wasm_sdk_build: false
-      enable_linux_static_sdk_build: false
+      enable_linux_static_sdk_build: true
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,19 +17,34 @@ jobs:
         bash -c '
         rc=0;
         echo "=== xcodebuild macOS ===";
-        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=macos,variant=macos" build || rc=1;
+        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=macos,variant=macos" build && macos=PASSED || { rc=1; macos=FAILED; };
+        echo "=== macOS build: $macos ===";
         echo "=== xcodebuild Mac Catalyst ===";
-        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=macos,variant=Mac Catalyst" build || rc=1;
+        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=macos,variant=Mac Catalyst" build && catalyst=PASSED || { rc=1; catalyst=FAILED; };
+        echo "=== Mac Catalyst build: $catalyst ===";
         echo "=== xcodebuild iOS ===";
-        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=ios" build || rc=1;
+        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=ios" build && ios=PASSED || { rc=1; ios=FAILED; };
+        echo "=== iOS build: $ios ===";
         echo "=== xcodebuild watchOS ===";
-        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=watchos" build || rc=1;
+        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=watchos" build && watchos=PASSED || { rc=1; watchos=FAILED; };
+        echo "=== watchOS build: $watchos ===";
         echo "=== xcodebuild tvOS ===";
-        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=tvos" build || rc=1;
+        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=tvos" build && tvos=PASSED || { rc=1; tvos=FAILED; };
+        echo "=== tvOS build: $tvos ===";
         echo "=== xcodebuild visionOS ===";
-        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=visionos" build || rc=1;
+        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=visionos" build && visionos=PASSED || { rc=1; visionos=FAILED; };
+        echo "=== visionOS build: $visionos ===";
         echo "=== xcrun swift test ===";
-        xcrun swift test "$@" || rc=1;
+        xcrun swift test "$@" && tests=PASSED || { rc=1; tests=FAILED; };
+        echo "=== swift test: $tests ===";
+        echo "=== Summary ===";
+        printf "%-20s %s\n" "macOS build:" "$macos";
+        printf "%-20s %s\n" "Mac Catalyst build:" "$catalyst";
+        printf "%-20s %s\n" "iOS build:" "$ios";
+        printf "%-20s %s\n" "watchOS build:" "$watchos";
+        printf "%-20s %s\n" "tvOS build:" "$tvos";
+        printf "%-20s %s\n" "visionOS build:" "$visionos";
+        printf "%-20s %s\n" "swift test:" "$tests";
         exit $rc
         ' bash
       enable_linux_checks: true


### PR DESCRIPTION
- Cover every Darwin platform via xcodebuild (macOS, Mac Catalyst, iOS, watchOS, tvOS, visionOS) alongside the existing `xcrun swift test`. Every step runs regardless of earlier failures and a final summary table reports per-platform `PASSED`/`FAILED`.
- On Linux, build the package with three trait combinations before running the test suite: 
  - default
  - all additive traits on (`DatapathLogging` / `QlogOutput` / `SignpostOutput`)
  - all reductive traits on (`DisableDebugLogging` / `DisableErrorLogging`).
- Tests run in both debug and release.
- Enable the Static Linux Swift SDK build job.
- Bump the `swiftlang/github-workflows` pin from `0.0.9` to `0.0.11` to pick up updated static-SDK defaults (the `0.0.9` default matrix installs Swift 6.2 toolchains, which can't satisfy our 6.3 `swift-tools-version`).
- Add a Dependabot config that groups `swiftlang/github-workflows/*` bumps so future pin updates arrive as a single PR rather than one per workflow file.
- Clarify workflow results.
  - Pass `--quiet` to every `swift build` / `swift test` and to `xcrun swift test`
  - emit `=== <step>: PASSED ===` markers per step (plus a column-aligned summary on macOS and an "all builds and tests passed" footer on Linux)