### PR TITLE
QUIC: Gate `QUICSignpost` real implementation on `canImport(os)`

### DIFF
--- a/Sources/SwiftNetwork/QUIC/Signpost.swift
+++ b/Sources/SwiftNetwork/QUIC/Signpost.swift
@@ -14,14 +14,9 @@
 
 #if !NETWORK_NO_SWIFT_QUIC
 
-#if SignpostOutput
+#if SignpostOutput && canImport(os)
 
-#if canImport(Glibc)
-import Glibc
-internal import Logging
-#elseif canImport(os)
 internal import os
-#endif
 
 @available(Network 0.1.0, *)
 struct QUICSignpost {
@@ -114,7 +109,8 @@ struct QUICSignpost {
     }
 }
 #else
-// Signposts are not enabled unless the `SignpostOutput` package trait is enabled.
+// Signposts are not enabled unless the `SignpostOutput` package trait is
+// enabled and the target platform supports Apple's OS signposting APIs.
 @available(Network 0.1.0, *)
 struct QUICSignpost {
     typealias IntervalState = Int


### PR DESCRIPTION
* Add `canImport(os)` to the `#if SignpostOutput` condition so the `OSSignposter`-backed `QUICSignpost` only compiles on platforms that ship Apple's OS signposting APIs.
* Drop the dead `#if canImport(Glibc) ... #elseif canImport(os)` import block; the `Glibc`/`Logging` arm imported swift-log symbols that the struct never used.
* On non-Apple platforms with the trait enabled, `QUICSignpost` now falls through to the existing `#else` no-op stub instead of failing to compile with "cannot find type 'OSSignpostIntervalState'".