### PR TITLE
Track pending wakeup state in Timer

### DIFF
--- a/Sources/SwiftNetwork/QUIC/Timer.swift
+++ b/Sources/SwiftNetwork/QUIC/Timer.swift
@@ -86,9 +86,9 @@ final class Timer: PrefixedLoggable {
             return .zero
         }
     }
-    private var wakeup: KernelWakeup = .idle
+    private var wakeup: WakeupState = .idle
 
-    private enum KernelWakeup {
+    private enum WakeupState {
         case idle
         case armed(NetworkClock.Instant)
     }

--- a/Sources/SwiftNetwork/QUIC/Timer.swift
+++ b/Sources/SwiftNetwork/QUIC/Timer.swift
@@ -78,7 +78,20 @@ final class Timer: PrefixedLoggable {
     #else
     private let extraDebugging = false
     #endif
-    private(set) var nextDeadline: NetworkClock.Instant = .zero
+    var nextDeadline: NetworkClock.Instant {
+        switch wakeup {
+        case .armed(let instant):
+            return instant
+        case .idle:
+            return .zero
+        }
+    }
+    private var wakeup: KernelWakeup = .idle
+
+    private enum KernelWakeup {
+        case idle
+        case armed(NetworkClock.Instant)
+    }
 
     static let timerThreshold = NetworkDuration.milliseconds(1)
 
@@ -126,6 +139,7 @@ final class Timer: PrefixedLoggable {
         if !timerCancelled {
             log.debug("Stopping timer")
             timerCancelled = true
+            wakeup = .idle
             reference?.unscheduleWakeup()
         }
         if final {
@@ -180,8 +194,10 @@ final class Timer: PrefixedLoggable {
         }
 
         // If the timer is over one millisecond in the future,
-        // check if it is redundant with the existing deadline (nextDeadline)
-        if nextDeadline != .zero, delta > Timer.timerThreshold {
+        // check if it is redundant with the existing deadline (nextDeadline).
+        // This optimisation is only valid if there's a pending wakeup, otherwise
+        // the timer may never fire.
+        if case .armed(let nextDeadline) = wakeup, delta > Timer.timerThreshold {
             let deadlineDifference = earliestDeadline.duration(to: nextDeadline)
             if deadlineDifference < Timer.timerThreshold && deadlineDifference > (Timer.timerThreshold * -1) {
                 // Timer is already set to within a millisecond of where it needs to be, don't schedule it
@@ -192,7 +208,7 @@ final class Timer: PrefixedLoggable {
 
         timerCancelled = false
         let oldDeadline = nextDeadline
-        nextDeadline = now + delta
+        wakeup = .armed(now + delta)
         log.datapath(
             "arming timer for the next \(delta) (now \(now)), new deadline \(nextDeadline) old deadline \(oldDeadline)"
         )
@@ -234,6 +250,9 @@ final class Timer: PrefixedLoggable {
     }
 
     public func timerFired(timeNow: NetworkClock.Instant = .now) {
+        // Timer fired means the kernel woke us up.
+        wakeup = .idle
+
         if _slowPath(timerCancelled) {
             log.fault("Timer fired after it was cancelled")
             return

--- a/Tests/QUICTests/TimerTests.swift
+++ b/Tests/QUICTests/TimerTests.swift
@@ -179,6 +179,82 @@ final class TimerTests: XCTestCase {
     func testAbsoluteNow() {
         XCTAssertGreaterThan(System.Time.nowAbsoluteNanoseconds(), 0)
     }
+
+    func testSpuriousFireRearmsRemainingTimer() {
+        let timer = QUICTimer(logPrefixer: timerTestsLogPrefixer)
+        let semaphore = DispatchSemaphore(value: 0)
+
+        // A, in 2s
+        let idA = timer.insert(description: "A", fromNow: .seconds(2), timerNow: .zero) {
+            XCTFail("A was disabled and must not fire")
+        }
+        XCTAssertEqual(timer.nextDeadline, .init(.seconds(2)))
+
+        // B, 999us after A (crucially, just before the 1ms coalescing threshold)
+        let idB = timer.insert(
+            description: "B",
+            fromNow: .seconds(2) + .microseconds(999),
+            timerNow: .zero
+        ) {
+            semaphore.signal()
+        }
+        // A was earlier, deadline is unchanged
+        XCTAssertEqual(timer.nextDeadline, .init(.seconds(2)))
+
+        // Disable A. B is now the earliest *enabled* entry but the scheduled
+        // time should remain at 2s (as B was within the threshold of A).
+        timer.reschedule(identifier: idA, fromNow: .zero, timerNow: .zero)
+        XCTAssertEqual(timer.nextDeadline, .init(.seconds(2)))
+
+        // Simulate a wakeup which is 0.5ms early. With the 1ms leeway,
+        // post-leeway 'now' = 2s + 500us, which is still before B's
+        // deadline (2s + 999us), so B doesn't fire and the spurious path runs.
+        timer.timerFired(timeNow: .init(.seconds(2) - .microseconds(500)))
+
+        // timerFired needs to rearm the wakeup.
+        XCTAssertEqual(timer.nextDeadline, .init(.seconds(2) + .microseconds(999)))
+
+        // Make sure B fires.
+        timer.timerFired(timeNow: .init(.seconds(2) + .microseconds(999)))
+        XCTAssertEqual(
+            semaphore.wait(timeout: DispatchTime.now() + .seconds(1)),
+            DispatchTimeoutResult.success
+        )
+
+        timer.remove(idA)
+        timer.remove(idB)
+    }
+
+    func testCancellationFollowedByCloseInsertRearmsTimer() {
+        let timer = QUICTimer(logPrefixer: timerTestsLogPrefixer)
+        let semaphore = DispatchSemaphore(value: 0)
+
+        let idA = timer.insert(description: "A", fromNow: .seconds(2), timerNow: .zero) {
+            XCTFail("A was cancelled and must not fire")
+        }
+        XCTAssertEqual(timer.nextDeadline, .init(.seconds(2)))
+
+        // Cancel A; disarm the wakeup.
+        timer.reschedule(identifier: idA, fromNow: .zero, timerNow: .zero)
+
+        // Schedule a new timer.
+        let idB = timer.insert(
+            description: "B",
+            fromNow: .seconds(2) + .microseconds(500),
+            timerNow: .zero
+        ) {
+            semaphore.signal()
+        }
+        XCTAssertEqual(timer.nextDeadline, .init(.seconds(2) + .microseconds(500)))
+        timer.timerFired(timeNow: .init(.seconds(2) + .microseconds(500)))
+        XCTAssertEqual(
+            semaphore.wait(timeout: DispatchTime.now() + .seconds(1)),
+            DispatchTimeoutResult.success
+        )
+
+        timer.remove(idA)
+        timer.remove(idB)
+    }
 }
 
 #endif


### PR DESCRIPTION
Timer's optimisation in 'recalculate' for an already scheduled wakeup applies even if there's no wakeup pending. This can happen when the wakeup is early as an event which would've fallen within the threshold no longer does, so it can remain unscheduled.

Store the kernel wakeup state as an enum: it's either armed for a given time or idle.