### PR TITLE
Add support for Musl

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.9
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:
       swift_flags: "-Xswiftc -warnings-as-errors"
       swift_nightly_flags: "--build-system native -Xswiftc -warnings-as-errors"  # workaround nightly-main issue
@@ -19,7 +19,7 @@ jobs:
       enable_windows_checks: false
       enable_android_sdk_build: false
       enable_embedded_wasm_sdk_build: false
-      enable_linux_static_sdk_build: false
+      enable_linux_static_sdk_build: true
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main

--- a/Sources/SwiftNetwork/Connection/Connection.swift
+++ b/Sources/SwiftNetwork/Connection/Connection.swift
@@ -20,6 +20,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Context/NetworkContext.swift
+++ b/Sources/SwiftNetwork/Context/NetworkContext.swift
@@ -19,6 +19,9 @@ import Dispatch
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Endpoint/AddressEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/AddressEndpoint.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Endpoint/NetlinkAddress.swift
+++ b/Sources/SwiftNetwork/Endpoint/NetlinkAddress.swift
@@ -16,6 +16,10 @@
 import Glibc
 internal import Logging
 internal import SwiftNetworkLinuxShim
+#elseif canImport(Musl)
+import Musl
+internal import Logging
+internal import SwiftNetworkLinuxShim
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/EndpointFlow/EndpointFlow.swift
+++ b/Sources/SwiftNetwork/EndpointFlow/EndpointFlow.swift
@@ -20,6 +20,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/EndpointFlow/EndpointFlowExtension.swift
+++ b/Sources/SwiftNetwork/EndpointFlow/EndpointFlowExtension.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/EndpointFlow/EndpointFlowProtocols.swift
+++ b/Sources/SwiftNetwork/EndpointFlow/EndpointFlowProtocols.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/EndpointFlow/WriteRequest.swift
+++ b/Sources/SwiftNetwork/EndpointFlow/WriteRequest.swift
@@ -19,6 +19,9 @@ internal import SwiftSystem
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Parameters/Parameters.swift
+++ b/Sources/SwiftNetwork/Parameters/Parameters.swift
@@ -20,6 +20,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Parameters/PathParameters.swift
+++ b/Sources/SwiftNetwork/Parameters/PathParameters.swift
@@ -20,6 +20,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Path/Interface.swift
+++ b/Sources/SwiftNetwork/Path/Interface.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Path/PathProperties.swift
+++ b/Sources/SwiftNetwork/Path/PathProperties.swift
@@ -20,6 +20,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/BottomProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/BottomProtocol.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/BridgeProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/BridgeProtocol.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/Checksum.swift
+++ b/Sources/SwiftNetwork/Protocols/Checksum.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/CustomIPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/CustomIPProtocol.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/Frame.swift
+++ b/Sources/SwiftNetwork/Protocols/Frame.swift
@@ -20,6 +20,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/HarnessProtocols.swift
+++ b/Sources/SwiftNetwork/Protocols/HarnessProtocols.swift
@@ -20,6 +20,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/IPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/IPProtocol.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/OneToOneProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/OneToOneProtocol.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/ProtocolEventManager.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolEventManager.swift
@@ -20,6 +20,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/ProtocolInstance.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolInstance.swift
@@ -20,6 +20,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/ProtocolStack.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolStack.swift
@@ -20,6 +20,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/ProtocolStreamHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolStreamHandlers.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/QUICConnectionProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/QUICConnectionProtocol.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/QUICStreamProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/QUICStreamProtocol.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/SocketProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/SocketProtocol.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/SwiftTLSProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/SwiftTLSProtocol.swift
@@ -27,6 +27,9 @@ import Foundation
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/TCPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/TCPProtocol.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/TopProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/TopProtocol.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Protocols/UDPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/UDPProtocol.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/Ack.swift
+++ b/Sources/SwiftNetwork/QUIC/Ack.swift
@@ -22,6 +22,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/CongestionControl.swift
+++ b/Sources/SwiftNetwork/QUIC/CongestionControl.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/Crypto.swift
+++ b/Sources/SwiftNetwork/QUIC/Crypto.swift
@@ -22,6 +22,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/Cubic.swift
+++ b/Sources/SwiftNetwork/QUIC/Cubic.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/ECN.swift
+++ b/Sources/SwiftNetwork/QUIC/ECN.swift
@@ -22,6 +22,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/FlowControl.swift
+++ b/Sources/SwiftNetwork/QUIC/FlowControl.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/Ledbat.swift
+++ b/Sources/SwiftNetwork/QUIC/Ledbat.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/Logger+QUIC.swift
+++ b/Sources/SwiftNetwork/QUIC/Logger+QUIC.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/PMTUD.swift
+++ b/Sources/SwiftNetwork/QUIC/PMTUD.swift
@@ -22,6 +22,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/Pacer.swift
+++ b/Sources/SwiftNetwork/QUIC/Pacer.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/Packet.swift
+++ b/Sources/SwiftNetwork/QUIC/Packet.swift
@@ -22,6 +22,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/PacketBuilder.swift
+++ b/Sources/SwiftNetwork/QUIC/PacketBuilder.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/PacketFormats.swift
+++ b/Sources/SwiftNetwork/QUIC/PacketFormats.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/PacketNumberSpace.swift
+++ b/Sources/SwiftNetwork/QUIC/PacketNumberSpace.swift
@@ -22,6 +22,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/PacketParser.swift
+++ b/Sources/SwiftNetwork/QUIC/PacketParser.swift
@@ -22,6 +22,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/Prague.swift
+++ b/Sources/SwiftNetwork/QUIC/Prague.swift
@@ -23,6 +23,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/Protector.swift
+++ b/Sources/SwiftNetwork/QUIC/Protector.swift
@@ -18,6 +18,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/QLog.swift
+++ b/Sources/SwiftNetwork/QUIC/QLog.swift
@@ -23,6 +23,9 @@ import class Foundation.JSONSerialization
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -22,6 +22,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/QUICConnectionID.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnectionID.swift
@@ -22,6 +22,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/QUICDatagramFlow.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICDatagramFlow.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/QUICError.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICError.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/QUICFrame.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICFrame.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/QUICPath.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICPath.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/QUICStream.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICStream.swift
@@ -22,6 +22,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/QUICStreamID.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICStreamID.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/QUICStreamState.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICStreamState.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/QUICStreamZombies.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICStreamZombies.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/QUICUtilities.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICUtilities.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/RTT.swift
+++ b/Sources/SwiftNetwork/QUIC/RTT.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/ReassemblyQueue.swift
+++ b/Sources/SwiftNetwork/QUIC/ReassemblyQueue.swift
@@ -22,6 +22,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/Recovery.swift
+++ b/Sources/SwiftNetwork/QUIC/Recovery.swift
@@ -22,6 +22,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/SendItems.swift
+++ b/Sources/SwiftNetwork/QUIC/SendItems.swift
@@ -22,6 +22,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/Shorthand.swift
+++ b/Sources/SwiftNetwork/QUIC/Shorthand.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/StatelessResetToken.swift
+++ b/Sources/SwiftNetwork/QUIC/StatelessResetToken.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/Statistics.swift
+++ b/Sources/SwiftNetwork/QUIC/Statistics.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/StreamSendBuffer.swift
+++ b/Sources/SwiftNetwork/QUIC/StreamSendBuffer.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/Timer.swift
+++ b/Sources/SwiftNetwork/QUIC/Timer.swift
@@ -22,6 +22,9 @@ internal import DequeModule
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/QUIC/TransportParameters.swift
+++ b/Sources/SwiftNetwork/QUIC/TransportParameters.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/System/Linux/LinuxInterface.swift
+++ b/Sources/SwiftNetwork/System/Linux/LinuxInterface.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 #if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 internal import Logging
 internal import SwiftNetworkLinuxShim
 

--- a/Sources/SwiftNetwork/System/Linux/LinuxResources.swift
+++ b/Sources/SwiftNetwork/System/Linux/LinuxResources.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 #if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 internal import SwiftNetworkLinuxShim
 
 /// A set of Linux system APIs for interacting with the system resources.

--- a/Sources/SwiftNetwork/System/Linux/LinuxRoute.swift
+++ b/Sources/SwiftNetwork/System/Linux/LinuxRoute.swift
@@ -12,8 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux) && canImport(Glibc) && NETLINK_ENABLED
+#if os(Linux) && NETLINK_ENABLED
+
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
 internal import Logging
 internal import SwiftNetworkLinuxShim
 

--- a/Sources/SwiftNetwork/System/NetworkError.swift
+++ b/Sources/SwiftNetwork/System/NetworkError.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/System/System.swift
+++ b/Sources/SwiftNetwork/System/System.swift
@@ -19,6 +19,9 @@ import Dispatch
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/System/SystemAddressFamily.swift
+++ b/Sources/SwiftNetwork/System/SystemAddressFamily.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 #if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 #elseif !NETWORK_STANDALONE
 import Darwin
 #endif

--- a/Sources/SwiftNetwork/System/SystemAddressFamily.swift
+++ b/Sources/SwiftNetwork/System/SystemAddressFamily.swift
@@ -12,12 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux)
 #if canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#endif
 #elseif !NETWORK_STANDALONE
 import Darwin
 #endif

--- a/Sources/SwiftNetwork/System/SystemCalls.swift
+++ b/Sources/SwiftNetwork/System/SystemCalls.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 #if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 internal import SwiftNetworkLinuxShim
 #elseif !NETWORK_STANDALONE
 import Darwin

--- a/Sources/SwiftNetwork/System/SystemInterface.swift
+++ b/Sources/SwiftNetwork/System/SystemInterface.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 #if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 #elseif !NETWORK_STANDALONE
 import Darwin
 #endif

--- a/Sources/SwiftNetwork/System/SystemSocket.swift
+++ b/Sources/SwiftNetwork/System/SystemSocket.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif
@@ -28,19 +31,19 @@ enum SocketType: CUnsignedInt, Sendable {
     var socketType: Int32 {
         switch self {
         case .stream:
-            #if os(Linux)
+            #if os(Linux) && canImport(Glibc)
             return CInt(SOCK_STREAM.rawValue)
             #else
             return SOCK_STREAM
             #endif
         case .datagram:
-            #if os(Linux)
+            #if os(Linux) && canImport(Glibc)
             return CInt(SOCK_DGRAM.rawValue)
             #else
             return SOCK_DGRAM
             #endif
         case .raw:
-            #if os(Linux)
+            #if os(Linux) && canImport(Glibc)
             return CInt(SOCK_RAW.rawValue)
             #else
             return SOCK_RAW
@@ -275,8 +278,10 @@ extension IPAddress {
                 }
             } else if addressFamily == .ipv6, let v6Address = self as? IPv6Address {
                 var sockaddr6 = sockaddr_in6()
-                #if os(Linux)
+                #if canImport(Glibc)
                 sockaddr6.sin6_addr.__in6_u.__u6_addr32 = v6Address.address
+                #elseif canImport(Musl)
+                sockaddr6.sin6_addr.__in6_union.__s6_addr32 = v6Address.address
                 #elseif canImport(Darwin)
                 sockaddr6.sin6_len = UInt8(MemoryLayout<sockaddr_in6>.size)
                 sockaddr6.sin6_addr.__u6_addr.__u6_addr32 = v6Address.address

--- a/Sources/SwiftNetwork/System/SystemUUID.swift
+++ b/Sources/SwiftNetwork/System/SystemUUID.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Utilities/Logging.swift
+++ b/Sources/SwiftNetwork/Utilities/Logging.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetwork/Utilities/UInt64+VLE.swift
+++ b/Sources/SwiftNetwork/Utilities/UInt64+VLE.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetworkBenchmarks/BenchmarkUtility.swift
+++ b/Sources/SwiftNetworkBenchmarks/BenchmarkUtility.swift
@@ -24,6 +24,9 @@ internal import Crypto
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetworkBenchmarks/DatagramPerfTestHandler.swift
+++ b/Sources/SwiftNetworkBenchmarks/DatagramPerfTestHandler.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetworkBenchmarks/NewFlowPerfTestHandler.swift
+++ b/Sources/SwiftNetworkBenchmarks/NewFlowPerfTestHandler.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetworkBenchmarks/StreamPerfTestHandler.swift
+++ b/Sources/SwiftNetworkBenchmarks/StreamPerfTestHandler.swift
@@ -17,6 +17,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/SwiftNetworkLinuxShim/include/SwiftNetworkLinuxShim.h
+++ b/Sources/SwiftNetworkLinuxShim/include/SwiftNetworkLinuxShim.h
@@ -18,7 +18,9 @@
 #ifdef __linux__
 
 #include <stdio.h>
-#ifdef NETLINK_ENABLED
+// We cannot just use "ifdef NETLINK_ENABLED" because
+// flags from Package.swift don't get propagated here.
+#if __has_include(<linux/netlink.h>)
     #include <linux/netlink.h>
     #include <linux/rtnetlink.h>
 #endif

--- a/Sources/Tools/IPUDPTransfer/main.swift
+++ b/Sources/Tools/IPUDPTransfer/main.swift
@@ -19,6 +19,9 @@ import Dispatch
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/Tools/QUICHandshake/main.swift
+++ b/Sources/Tools/QUICHandshake/main.swift
@@ -19,6 +19,9 @@ import Dispatch
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/Tools/QUICStreamLoad/main.swift
+++ b/Sources/Tools/QUICStreamLoad/main.swift
@@ -19,6 +19,9 @@ import Dispatch
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/Tools/QUICTransfer/main.swift
+++ b/Sources/Tools/QUICTransfer/main.swift
@@ -19,6 +19,9 @@ import Dispatch
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Sources/Tools/SocketTransfer/main.swift
+++ b/Sources/Tools/SocketTransfer/main.swift
@@ -18,6 +18,9 @@ import Dispatch
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/QUICTestHarness.swift
+++ b/Tests/SwiftNetworkTests/QUICTestHarness.swift
@@ -39,6 +39,9 @@ import Crypto
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkInterfaceTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkInterfaceTests.swift
@@ -18,6 +18,9 @@ import XCTest
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICECNTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICECNTests.swift
@@ -39,6 +39,9 @@ import Crypto
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICEarlyDataTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICEarlyDataTests.swift
@@ -39,6 +39,9 @@ import Crypto
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICHarnessTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICHarnessTests.swift
@@ -39,6 +39,9 @@ import Crypto
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICKeepaliveTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICKeepaliveTests.swift
@@ -39,6 +39,9 @@ import Crypto
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICPacer.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICPacer.swift
@@ -39,6 +39,9 @@ import Crypto
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICQlogTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICQlogTests.swift
@@ -32,7 +32,6 @@ import XCTest
 
 #if os(Linux)
 import Crypto
-import Glibc
 #else
 import CryptoKit
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICQlogTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICQlogTests.swift
@@ -40,6 +40,9 @@ import CryptoKit
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICRetryTokenTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICRetryTokenTests.swift
@@ -39,6 +39,9 @@ import Crypto
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICShortLHPacketTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICShortLHPacketTests.swift
@@ -39,6 +39,9 @@ import Crypto
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICSpinBitTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICSpinBitTests.swift
@@ -39,6 +39,9 @@ import Crypto
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICStackTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICStackTests.swift
@@ -39,6 +39,9 @@ import Crypto
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICStatisticsTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICStatisticsTests.swift
@@ -39,6 +39,9 @@ import Crypto
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICUngracefulCloseTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICUngracefulCloseTests.swift
@@ -43,6 +43,9 @@ import Dispatch
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICVersionNegotiation.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICVersionNegotiation.swift
@@ -39,6 +39,9 @@ import Crypto
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkUUIDTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkUUIDTests.swift
@@ -24,8 +24,11 @@ import XCTest
 import Foundation
 #endif
 
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
+internal import SwiftNetworkLinuxShim
+#elseif canImport(Musl)
+import Musl
 internal import SwiftNetworkLinuxShim
 #endif
 

--- a/Tests/SwiftNetworkTests/TestLogger.swift
+++ b/Tests/SwiftNetworkTests/TestLogger.swift
@@ -15,6 +15,9 @@
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif

--- a/Tests/SwiftNetworkTests/TestMultiplexingProtocol.swift
+++ b/Tests/SwiftNetworkTests/TestMultiplexingProtocol.swift
@@ -23,6 +23,9 @@ import XCTest
 #if canImport(Glibc)
 import Glibc
 internal import Logging
+#elseif canImport(Musl)
+import Musl
+internal import Logging
 #elseif canImport(os)
 internal import os
 #endif


### PR DESCRIPTION
Static SDK builds on Linux use Musl instead of Glibc. This adds import guards to switch to Musl when available. Two other changes are necessary to adopt to differences between the two (check `SystemSocket.swift`):

* `SOCK_{STREAM,DGRAM,RAW}` do not have a `raw_value` member in Musl
* `sin6_addr` members have different names

Building with the netlink flag revealed a problem with the imports there. Adjusting the guard around importing the headers resolves that.