### PR TITLE
Add reassembly support for fragmented IPv4 packets in Swift IP

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -121,7 +121,8 @@ let package = Package(
             name: "SignpostOutput",
             description: "Enables `OSSignposter` output from the QUIC implementation."
         ),
-        .default(enabledTraits: []),
+        //.default(enabledTraits: []),
+        .default(enabledTraits: ["DisableDebugLogging", "DisableErrorLogging"]),
     ],
     dependencies: packageDependencies,
     targets: [

--- a/Sources/SwiftNetwork/Protocols/FrameArray.swift
+++ b/Sources/SwiftNetwork/Protocols/FrameArray.swift
@@ -57,6 +57,19 @@ public struct FrameArray: ~Copyable {
         }
     }
 
+    public mutating func prepend(frame: consuming Frame) {
+        var newArray = FrameArray(capacity: self.count + 1)
+        newArray.add(frame: frame)
+        if !self.frames.isEmpty {
+            while !self.frames.isEmpty {
+                if let first = self.frames.popFirst() {
+                    newArray.add(frame: first)
+                }
+            }
+        }
+        self = newArray
+    }
+
     public var count: Int {
         frames.count
     }

--- a/Sources/SwiftNetwork/Protocols/FrameArray.swift
+++ b/Sources/SwiftNetwork/Protocols/FrameArray.swift
@@ -58,16 +58,7 @@ public struct FrameArray: ~Copyable {
     }
 
     public mutating func prepend(frame: consuming Frame) {
-        var newArray = FrameArray(capacity: self.count + 1)
-        newArray.add(frame: frame)
-        if !self.frames.isEmpty {
-            while !self.frames.isEmpty {
-                if let first = self.frames.popFirst() {
-                    newArray.add(frame: first)
-                }
-            }
-        }
-        self = newArray
+        self.frames.prepend(frame)
     }
 
     public var count: Int {

--- a/Sources/SwiftNetwork/Protocols/IPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/IPProtocol.swift
@@ -339,6 +339,10 @@ public struct IPProtocol: NetworkProtocol {
         var log = NetworkLoggerState()
         var eventManager = ProtocolEventManager()
 
+        static let IP_MF: UInt16 = 0x2000
+        static let IP_OFFMASK: UInt16 = 0x1FFF
+        static let IP_MAX_FRAGMENT_COUNT: Int = 32
+
         // Only called by newProtocolInstance()
         fileprivate static func registerNewIP(on context: NetworkContext) -> ProtocolInstanceReference {
             let ip = IPInstance(context: context)
@@ -352,7 +356,7 @@ public struct IPProtocol: NetworkProtocol {
 
         var passthroughEvents = true
 
-        struct IPCounters {
+        struct IPCounters: ~Copyable {
             var txPackets = 0
             var rxPackets = 0
             var rxECT0Packets = 0
@@ -367,9 +371,9 @@ public struct IPProtocol: NetworkProtocol {
             var dscpValue: UInt8?
         }
 
-        struct IPReassemblyState {
-            var reassemblyID: UInt32
-            //	TODO: inputReassemblyFrames, assignedInputFrameArray, assignedOutputFrameArray
+        struct IPReassemblyState: ~Copyable {
+            var reassemblyID: UInt16
+            var inputReassemblyFrames = FrameArray()
         }
 
         struct IPInstanceFlags: OptionSet {
@@ -431,7 +435,7 @@ public struct IPProtocol: NetworkProtocol {
             }
         }
 
-        struct IPv4Instance {
+        struct IPv4Instance: ~Copyable {
             var ipProtocolNumber: UInt8 = 0
             var localAddress = IPv4Address.any
             var remoteAddress = IPv4Address.any
@@ -457,20 +461,222 @@ public struct IPProtocol: NetworkProtocol {
                 return value + IPv4Instance.headerLength
             }
 
-            mutating func processInboundFrames(_ ip: borrowing IPInstance, _ inboundFrames: inout FrameArray) {
+            mutating func appendReassembledPackets(
+                _ log: borrowing NetworkLoggerState,
+                reassembled: inout FrameArray
+            ) {
+                guard let empty = reassemblyState?.inputReassemblyFrames.isEmpty, !empty else {
+                    return
+                }
+                guard let reassemblyID = reassemblyState?.reassemblyID else {
+                    return
+                }
+                var complete = false
+                var expectedOffset: UInt16 = 0
+                reassemblyState?.inputReassemblyFrames.iterateMutableFrames { frame in
+                    guard frame.bufferLength >= IPv4Instance.headerLength else {
+                        log.info("Reassembly frame is no longer valid")
+                        complete = false
+                        return false
+                    }
+                    var offset: UInt16 = 0
+                    var length: UInt16 = 0
+                    let result = Deserializer.deserialize(&frame, claim: false) { read throws(DeserializationError) in
+                        try read.skip(1)
+                        try read.skip(1)
+                        try read.uint16NetworkByteOrder(&length)
+                        try read.skip(2)
+                        try read.uint16NetworkByteOrder(&offset)
+                    }
+                    guard result.isValid else {
+                        complete = false
+                        return false
+                    }
+                    // Fragment offset is in 8 byte increments
+                    let fragmentByteOffset = (offset & IP_OFFMASK) * 8
+                    guard fragmentByteOffset == expectedOffset else {
+                        complete = false
+                        return false
+                    }
+                    let payloadLength = length - UInt16(IPv4Instance.headerLength)
+                    let (next, overflow) = expectedOffset.addingReportingOverflow(payloadLength)
+                    guard !overflow else {
+                        log.error("Fragment offset overflow for IP ID \(reassemblyID)")
+                        complete = false
+                        return false
+                    }
+                    // Found the next fragment
+                    expectedOffset = next
+                    if offset & IP_MF == 0 {
+                        // No more fragments, we're complete
+                        complete = true
+                        return false
+                    }
+                    return true
+                }
+                guard complete else {
+                    log.debug("Fragments for IP ID \(reassemblyID) incomplete")
+                    return
+                }
+                // Create a new frame with the complete length for reassembly
+                // Guard against the max value of UInt16
+                let rawLength = UInt32(IPv4Instance.headerLength) + UInt32(expectedOffset)
+                guard rawLength <= UInt16.max else {
+                    log.fault("Reassembled IP length overflows for IP ID \(reassemblyID)")
+                    return
+                }
+                let newIPFrameLength = UInt16(rawLength)
+                var newFrame = Frame(count: Int(newIPFrameLength))
+
+                // Fillout the IP header
+                let headerCopied = reassemblyState?.inputReassemblyFrames.peekFirstFrame { first in
+                    first.copyInto(&newFrame, length: IPv4Instance.headerLength)
+                }
+                guard headerCopied == IPv4Instance.headerLength else {
+                    log.fault("Failed to copy IP header from first fragment (IP ID \(reassemblyID))")
+                    newFrame.finalize(success: false)
+                    return
+                }
+                let result = Serializer.serialize(&newFrame, claim: false) { write throws(SerializationError) in
+                    try write.skip(2)
+                    try write.uint16NetworkByteOrder(newIPFrameLength)
+                    try write.skip(2)
+                    try write.uint16NetworkByteOrder(0)
+                }
+                guard result.isValid else {
+                    log.fault("Failed to write the updated IP header")
+                    newFrame.finalize(success: false)
+                    return
+                }
+                guard newFrame.claim(fromStart: IPv4Instance.headerLength) else {
+                    log.fault("Failed to claim the updated IP header")
+                    newFrame.finalize(success: false)
+                    return
+                }
+                // Copy each fragment's payload into the new frame sequentially.
+                var writeOffset = 0
+                var copyFailed = false
+                reassemblyState?.inputReassemblyFrames.iterateMutableFrames { fragment in
+                    guard fragment.bufferLength >= IPv4Instance.headerLength else {
+                        log.fault("Fragment became invalid during reassembly copy")
+                        copyFailed = true
+                        return false
+                    }
+                    var ipLength: UInt16 = 0
+                    let result = Deserializer.deserialize(&fragment, claim: false) {
+                        read throws(DeserializationError) in
+                        try read.skip(2)
+                        try read.uint16NetworkByteOrder(&ipLength)
+                    }
+                    guard result.isValid else {
+                        copyFailed = true
+                        return false
+                    }
+                    guard ipLength >= IPv4Instance.headerLength else {
+                        copyFailed = true
+                        return false
+                    }
+                    guard fragment.bufferLength >= Int(ipLength) else {
+                        log.fault(
+                            "Fragment buffer \(fragment.bufferLength) < ip_len \(ipLength) for IP ID \(reassemblyID)"
+                        )
+                        copyFailed = true
+                        return false
+                    }
+                    let totalIPLength = Int(ipLength)
+                    let payloadLength = totalIPLength - IPv4Instance.headerLength
+                    let payloadEnd = writeOffset + payloadLength
+                    guard payloadEnd <= Int(newIPFrameLength) - IPv4Instance.headerLength else {
+                        log.fault("Writing fragment payload overflows the new IP frame")
+                        copyFailed = true
+                        return false
+                    }
+                    let copied = fragment.copyInto(
+                        &newFrame,
+                        atOffset: writeOffset,
+                        fromOffset: IPv4Instance.headerLength,
+                        length: payloadLength
+                    )
+                    guard copied == payloadLength else {
+                        log.fault("Payload copy mismatch for IP ID \(reassemblyID): \(copied) != \(payloadLength)")
+                        copyFailed = true
+                        return false
+                    }
+                    writeOffset += payloadLength
+                    return true
+                }
+
+                guard !copyFailed else {
+                    newFrame.finalize(success: false)
+                    return
+                }
+
+                log.debug("Reassembly complete for IP ID \(reassemblyID), total length \(newIPFrameLength)")
+
+                newFrame.metadataComplete = true
+                reassembled.add(frame: newFrame)
+
+                // Finalize the original fragment frames
+                while var fragment = reassemblyState?.inputReassemblyFrames.popFirst() {
+                    fragment.finalize(success: true)
+                }
+            }
+
+            mutating func processReassembly(
+                _ log: borrowing NetworkLoggerState,
+                ipID: UInt16,
+                reassembled: inout FrameArray,
+                forceFlush: Bool
+            ) {
+                let hasAccumulatedFragments = reassemblyState?.inputReassemblyFrames.isEmpty == false
+                let isNewID = reassemblyState?.reassemblyID != ipID
+
+                if hasAccumulatedFragments && (isNewID || forceFlush) {
+                    appendReassembledPackets(log, reassembled: &reassembled)
+                    // Only discard buffered fragments when the IP ID changes
+                    if isNewID && !forceFlush {
+                        var dropped = 0
+                        while var fragment = reassemblyState?.inputReassemblyFrames.popFirst() {
+                            fragment.finalize(success: false)
+                            dropped += 1
+                        }
+                        if dropped > 0 {
+                            log.error(
+                                "Dropping \(dropped) incomplete fragments for IP ID \(reassemblyState?.reassemblyID ?? 0)"
+                            )
+                        }
+                    }
+                }
+                // Only update the stored reassembly ID when processing a real fragment and not on force flush
+                if !forceFlush {
+                    if reassemblyState == nil {
+                        reassemblyState = IPReassemblyState(reassemblyID: ipID)
+                    } else {
+                        reassemblyState?.reassemblyID = ipID
+                    }
+                }
+            }
+
+            mutating func processInboundFrames(_ log: borrowing NetworkLoggerState, _ inboundFrames: inout FrameArray) {
+                // Hoist loop-invariant values.
+                let localAddress: UInt32 = self.localAddress.addressValue
+                let remoteAddress: UInt32 = self.remoteAddress.addressValue
+                let mask = (0xF000_0000 as UInt32).bigEndian
+                let subnet = (0xE000_0000 as UInt32).bigEndian
+
+                // IP fragments are not common so preserve a fast-path that just loops inboundFrames in-place
+                var hadFragments = false
+                // If fragments are present, hadFragments will be set and metadataComplete will not be set on the frame.
                 inboundFrames.iterateMutableFrames { frame in
                     let originalFrameLength = frame.unclaimedLength
                     var versionAndHeaderLength: UInt8 = 0
                     var tos: UInt8 = 0
-
                     var totalLength: UInt16 = 0
                     var ttl: UInt8 = 0
                     var destinationAddressValue: UInt32 = 0
                     var checksum: UInt16 = 0
                     var identifier: UInt16 = 0
                     var offset: UInt16 = 0
-                    let localAddress: UInt32 = self.localAddress.addressValue
-                    let remoteAddress: UInt32 = self.remoteAddress.addressValue
 
                     let result = Deserializer.deserialize(&frame, claim: false) { read throws(DeserializationError) in
                         try read.uint8(&versionAndHeaderLength)
@@ -486,68 +692,70 @@ public struct IPProtocol: NetworkProtocol {
                     }
 
                     guard result.isValid else {
-                        ip.log.info("Failed to parse IPv4 header: \(result)")
-
-                        // Keep processing other frames even if some are invalid.
+                        log.info("Failed to parse IPv4 header: \(result)")
                         frame.finalize(success: false)
                         return .removeFrameAndContinue
                     }
-
                     guard originalFrameLength >= IPv4Instance.headerLength else {
-                        ip.log.error("Received IPv4 packet with incorrect length \(originalFrameLength)")
+                        log.error("Received IPv4 packet with incorrect length \(originalFrameLength)")
                         frame.finalize(success: false)
                         return .removeFrameAndContinue
                     }
 
-                    let version = UInt8(versionAndHeaderLength >> 4)  // Get the first four bits
+                    let version = UInt8(versionAndHeaderLength >> 4)
                     guard version == Version.v4.rawValue else {
-                        ip.log.error("Invalid IPv4 version: \(version)")
+                        log.error("Invalid IPv4 version: \(version)")
                         frame.finalize(success: false)
                         return .removeFrameAndContinue
                     }
 
-                    let headerLengthLastFour = UInt8(versionAndHeaderLength & 0x0F)  // Get the last four bits
+                    let headerLengthLastFour = UInt8(versionAndHeaderLength & 0x0F)
                     let headerLength = UInt32(headerLengthLastFour << 2)
-                    let mask = (0xF000_0000 as UInt32).bigEndian
-                    let subnet = (0xE000_0000 as UInt32).bigEndian
 
                     guard headerLength >= IPv4Instance.headerLength else {
-                        ip.log.error("Invalid header length: \(headerLength)")
+                        log.error("Invalid header length: \(headerLength)")
                         frame.finalize(success: false)
                         return .removeFrameAndContinue
                     }
                     guard headerLength <= originalFrameLength else {
-                        ip.log.error("Invalid header length: \(headerLength) > \(originalFrameLength)")
+                        log.error("Invalid header length: \(headerLength) > \(originalFrameLength)")
                         frame.finalize(success: false)
                         return .removeFrameAndContinue
                     }
                     guard
-                        // Allow receiving reclassified multicast
                         destinationAddressValue == localAddress || (destinationAddressValue & mask == subnet)
-                            || destinationAddressValue == IPv4Address.broadcast.addressValue  // and broadcast packets
+                            || destinationAddressValue == IPv4Address.broadcast.addressValue
                             || (self.broadcast.addressValue != 0
                                 && destinationAddressValue == self.broadcast.addressValue)
                             || ((self.broadcast.addressValue != 0 && self.netmask.addressValue != 0)
                                 && destinationAddressValue == (self.broadcast.addressValue & self.netmask.addressValue))
                     else {
-                        ip.log.error("Received local address \(destinationAddressValue) != \(localAddress)")
+                        log.error("Received local address \(destinationAddressValue) != \(localAddress)")
                         frame.finalize(success: false)
                         return .removeFrameAndContinue
                     }
                     guard totalLength == originalFrameLength else {
-                        ip.log.error(
+                        log.error(
                             "Received length mismatch with IP total length \(totalLength) != \(originalFrameLength)"
                         )
                         frame.finalize(success: false)
                         return .removeFrameAndContinue
                     }
                     guard headerLength <= totalLength else {
-                        ip.log.error("Invalid header length (greater than IP length): \(headerLength) > \(totalLength)")
+                        log.error("Invalid header length (greater than IP length): \(headerLength) > \(totalLength)")
                         frame.finalize(success: false)
                         return .removeFrameAndContinue
                     }
 
-                    // TODO: Handle reassembly / fragmentation
+                    // IP fragment detected, set hadFragments for future reassembly processing
+                    if offset & UInt16(IP_MF | IP_OFFMASK) != 0 {
+                        if frame.isSingleIPAggregate {
+                            log.fault("Received fragment on a super-packet with length: \(originalFrameLength)")
+                            return .removeFrameAndContinue
+                        }
+                        hadFragments = true
+                        return .continueIterating
+                    }
 
                     let ipECN = IPProtocol.ECN(tos)
                     frame.ecnFlag = ipECN
@@ -574,22 +782,113 @@ public struct IPProtocol: NetworkProtocol {
 
                     if frame.isChecksumIPChecked {
                         guard frame.isChecksumIPValid else {
-                            ip.log.error("Invalid checksum \(checksum)")
+                            log.error("Invalid checksum \(checksum)")
+                            frame.finalize(success: false)
                             return .removeFrameAndContinue
                         }
                     } else {
                         guard let frameChecksum = try? frame.ipChecksum(offset: 0, length: Int(headerLength)),
                             frameChecksum == 0
                         else {
-                            ip.log.error("Invalid checksum \(checksum)")
+                            log.error("Invalid checksum \(checksum)")
+                            frame.finalize(success: false)
                             return .removeFrameAndContinue
-
                         }
                     }
                     _ = frame.claim(fromStart: Int(headerLength), fromEnd: originalFrameLength - Int(totalLength))
                     self.counters.rxPackets += 1
                     return .continueIterating
                 }
+
+                // No fragments, just return here as normal
+                guard hadFragments || reassemblyState != nil else { return }
+
+                // Reassembly path, build out a processedFrames array to combine both the reassembled fragments and the inbound frames.
+                var processedFrames = FrameArray(capacity: inboundFrames.count)
+                var reassembledFragments = FrameArray()
+
+                while var frame = inboundFrames.popFirst() {
+                    // metadataComplete signals that the frame does not need to be processed
+                    guard !frame.metadataComplete else {
+                        processedFrames.add(frame: frame)
+                        continue
+                    }
+                    var identifier: UInt16 = 0
+                    var offset: UInt16 = 0
+                    let result = Deserializer.deserialize(&frame, claim: false) { read throws(DeserializationError) in
+                        try read.skip(4)
+                        try read.uint16NetworkByteOrder(&identifier)
+                        try read.uint16NetworkByteOrder(&offset)
+                        try read.skip(1)
+                        try read.uint8(expect: self.ipProtocolNumber)
+                        try read.skip(2)
+                        try read.uint32(expect: remoteAddress)
+                    }
+                    guard result.isValid else {
+                        frame.finalize(success: false)
+                        continue
+                    }
+
+                    processReassembly(log, ipID: identifier, reassembled: &reassembledFragments, forceFlush: false)
+                    if reassemblyState == nil {
+                        reassemblyState = IPReassemblyState(reassemblyID: identifier)
+                    }
+                    let currentFragmentCount = reassemblyState?.inputReassemblyFrames.count ?? 0
+                    guard currentFragmentCount < IP_MAX_FRAGMENT_COUNT else {
+                        frame.finalize(success: false)
+                        continue
+                    }
+
+                    let fragmentByteOffset = (offset & IP_OFFMASK) * 8
+                    if fragmentByteOffset == 0 {
+                        reassemblyState?.inputReassemblyFrames.prepend(frame: frame)
+                    } else if offset & IP_MF == 0 {
+                        reassemblyState?.inputReassemblyFrames.add(frame: frame)
+                    } else {
+                        var sorted = FrameArray()
+                        var frameOffsetFound = false
+                        while var existing = reassemblyState?.inputReassemblyFrames.popFirst() {
+                            if !frameOffsetFound, existing.bufferLength >= IPv4Instance.headerLength {
+                                var existingOffset: UInt16 = 0
+                                var existingLength: UInt16 = 0
+                                let result = Deserializer.deserialize(&existing, claim: false) {
+                                    read throws(DeserializationError) in
+                                    try read.skip(1)
+                                    try read.skip(1)
+                                    try read.uint16NetworkByteOrder(&existingLength)
+                                    try read.skip(2)
+                                    try read.uint16NetworkByteOrder(&existingOffset)
+                                }
+                                guard result.isValid else {
+                                    sorted.add(frame: existing)
+                                    continue
+                                }
+                                existingOffset = existingOffset & IP_OFFMASK
+                                let existingByteOffset = existingOffset * 8
+                                let predecessorEnd =
+                                    UInt32(existingByteOffset) + UInt32(existingLength)
+                                    - UInt32(IPv4Instance.headerLength)
+                                if UInt32(fragmentByteOffset) == predecessorEnd {
+                                    sorted.add(frame: existing)
+                                    frameOffsetFound = true
+                                    break
+                                }
+                            }
+                            sorted.add(frame: existing)
+                        }
+                        sorted.add(frame: frame)
+                        if frameOffsetFound {
+                            while let remaining = reassemblyState?.inputReassemblyFrames.popFirst() {
+                                sorted.add(frame: remaining)
+                            }
+                        }
+                        reassemblyState?.inputReassemblyFrames = sorted
+                    }
+                    self.counters.rxPackets += 1
+                }
+                processReassembly(log, ipID: 0, reassembled: &reassembledFragments, forceFlush: true)
+                processedFrames.add(frames: reassembledFragments)
+                inboundFrames = processedFrames
             }
 
             func prepareOutboundFrames(_ outboundFrames: inout FrameArray) {
@@ -692,7 +991,7 @@ public struct IPProtocol: NetworkProtocol {
             }
         }
 
-        struct IPv6Instance {
+        struct IPv6Instance: ~Copyable {
             var ipProtocolNumber: UInt8 = 0
             var localAddress = IPv6Address.any
             var remoteAddress = IPv6Address.any
@@ -720,7 +1019,7 @@ public struct IPProtocol: NetworkProtocol {
                 return value + IPv6Instance.headerLength
             }
 
-            mutating func processInboundFrames(_ ip: borrowing IPInstance, _ inboundFrames: inout FrameArray) {
+            mutating func processInboundFrames(_ log: borrowing NetworkLoggerState, _ inboundFrames: inout FrameArray) {
                 inboundFrames.iterateMutableFrames { frame in
                     let originalFrameLength = frame.unclaimedLength
                     var flow: UInt32 = 0
@@ -746,7 +1045,7 @@ public struct IPProtocol: NetworkProtocol {
                     }
 
                     guard result.isValid else {
-                        ip.log.info("Failed to parse IPv6 header: \(result)")
+                        log.info("Failed to parse IPv6 header: \(result)")
 
                         // Keep processing other frames even if some are invalid.
                         frame.finalize(success: false)
@@ -754,19 +1053,19 @@ public struct IPProtocol: NetworkProtocol {
                     }
 
                     guard originalFrameLength >= IPv6Instance.headerLength else {
-                        ip.log.error("Received IPv6 packet with incorrect length \(originalFrameLength)")
+                        log.error("Received IPv6 packet with incorrect length \(originalFrameLength)")
                         frame.finalize(success: false)
                         return .removeFrameAndContinue
                     }
                     let version = UInt8(flow >> 28)  // Get the first 4 high order bits for version
                     guard version == Version.v6.rawValue else {
-                        ip.log.error("Not an IPv6 packet")
+                        log.error("Not an IPv6 packet")
                         frame.finalize(success: false)
                         return .removeFrameAndContinue
                     }
                     let ipv6Length = (payloadLength + UInt16(IPv6Instance.headerLength))
                     guard ipv6Length == originalFrameLength else {
-                        ip.log.error(
+                        log.error(
                             "Received IPv6 packet with incorrect length, expected \(ipv6Length) received \(originalFrameLength)"
                         )
                         frame.finalize(success: false)
@@ -873,7 +1172,7 @@ public struct IPProtocol: NetworkProtocol {
             }
         }
 
-        enum IPInstanceType {
+        enum IPInstanceType: ~Copyable {
             case ipv4(IPv4Instance)
             case ipv6(IPv6Instance)
         }
@@ -983,17 +1282,13 @@ public struct IPProtocol: NetworkProtocol {
             }
         }
 
-        func receiveDatagrams(maximumDatagramCount: Int) throws(NetworkError) -> FrameArray? {
+        mutating func receiveDatagrams(maximumDatagramCount: Int) throws(NetworkError) -> FrameArray? {
             repeat {
                 let inboundFrames = try invokeReceiveDatagrams(maximumDatagramCount: maximumDatagramCount)
                 guard var inboundFrames, !inboundFrames.isEmpty else {
                     return nil
                 }
-
-                switch self.instanceType {
-                case .ipv4(var instance): instance.processInboundFrames(self, &inboundFrames)
-                case .ipv6(var instance): instance.processInboundFrames(self, &inboundFrames)
-                }
+                IPInstance.processInbound(&self.instanceType, log: self.log, frames: &inboundFrames)
                 guard !inboundFrames.isEmpty else {
                     log.error("Dropped inbound packets, checking for more")
                     continue
@@ -1026,12 +1321,37 @@ public struct IPProtocol: NetworkProtocol {
             }
         }
 
-        func sendDatagrams(_ datagrams: consuming FrameArray) throws(NetworkError) {
-            switch self.instanceType {
-            case .ipv4(var instance): instance.writeOutboundFrames(&datagrams)
-            case .ipv6(var instance): instance.writeOutboundFrames(&datagrams)
+        mutating func sendDatagrams(_ datagrams: consuming FrameArray) throws(NetworkError) {
+            IPInstance.processSend(&self.instanceType, datagrams: &datagrams)
+            try invokeSendDatagrams(datagrams)
+        }
+
+        @inline(__always)
+        private static func processInbound(
+            _ instanceType: inout IPInstanceType,
+            log: borrowing NetworkLoggerState,
+            frames: inout FrameArray
+        ) {
+            switch instanceType {
+            case .ipv4(var instance):
+                instance.processInboundFrames(log, &frames)
+                instanceType = .ipv4(instance)
+            case .ipv6(var instance):
+                instance.processInboundFrames(log, &frames)
+                instanceType = .ipv6(instance)
             }
-            return try invokeSendDatagrams(datagrams)
+        }
+
+        @inline(__always)
+        private static func processSend(_ instanceType: inout IPInstanceType, datagrams: inout FrameArray) {
+            switch instanceType {
+            case .ipv4(var instance):
+                instance.writeOutboundFrames(&datagrams)
+                instanceType = .ipv4(instance)
+            case .ipv6(var instance):
+                instance.writeOutboundFrames(&datagrams)
+                instanceType = .ipv6(instance)
+            }
         }
 
         #if !NETWORK_EMBEDDED

--- a/Sources/SwiftNetwork/Protocols/IPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/IPProtocol.swift
@@ -841,9 +841,6 @@ public struct IPProtocol: NetworkProtocol {
                     }
 
                     processReassembly(log, ipID: identifier, reassembled: &reassembledFragments, forceFlush: false)
-                    if reassemblyState == nil {
-                        reassemblyState = IPReassemblyState(reassemblyID: identifier)
-                    }
                     let currentFragmentCount = reassemblyState?.inputReassemblyFrames.count ?? 0
                     guard currentFragmentCount < IPMaxFragmentCount else {
                         frame.finalize(success: false)
@@ -1305,11 +1302,13 @@ public struct IPProtocol: NetworkProtocol {
                 while var fragment = instance.reassemblyState?.inputReassemblyFrames.popFirst() {
                     fragment.finalize(success: false)
                 }
+                instance.reassemblyState = nil
                 instanceType = .ipv4(instance)
             case .ipv6(var instance):
                 while var fragment = instance.reassemblyState?.inputReassemblyFrames.popFirst() {
                     fragment.finalize(success: false)
                 }
+                instance.reassemblyState = nil
                 instanceType = .ipv6(instance)
             }
         }

--- a/Sources/SwiftNetwork/Protocols/IPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/IPProtocol.swift
@@ -473,6 +473,8 @@ public struct IPProtocol: NetworkProtocol {
                 }
                 var complete = false
                 var expectedOffset: UInt16 = 0
+                var tos: UInt8 = 0
+                var ttl: UInt8 = 0
                 reassemblyState?.inputReassemblyFrames.iterateMutableFrames { frame in
                     guard frame.bufferLength >= IPv4Instance.headerLength else {
                         log.info("Reassembly frame is no longer valid")
@@ -483,10 +485,11 @@ public struct IPProtocol: NetworkProtocol {
                     var length: UInt16 = 0
                     let result = Deserializer.deserialize(&frame, claim: false) { read throws(DeserializationError) in
                         try read.skip(1)
-                        try read.skip(1)
+                        try read.uint8(&tos)
                         try read.uint16NetworkByteOrder(&length)
                         try read.skip(2)
                         try read.uint16NetworkByteOrder(&offset)
+                        try read.uint8(&ttl)
                     }
                     guard result.isValid else {
                         complete = false
@@ -613,7 +616,15 @@ public struct IPProtocol: NetworkProtocol {
 
                 log.debug("Reassembly complete for IP ID \(reassemblyID), total length \(newIPFrameLength)")
 
+                let dscpValue = tos >> 2  // IPTOS_DSCP_SHIFT
+                newFrame.dscpValue = dscpValue
+                if self.flags.receiveHopLimit {
+                    newFrame.hopLimit = ttl
+                }
                 newFrame.metadataComplete = true
+                if self.flags.calculateReceiveTime {
+                    newFrame.timestamp = Frame.FrameTimestamp.receiveTime(.now)
+                }
                 reassembled.add(frame: newFrame)
 
                 // Finalize the original fragment frames
@@ -1322,7 +1333,7 @@ public struct IPProtocol: NetworkProtocol {
         }
 
         mutating func sendDatagrams(_ datagrams: consuming FrameArray) throws(NetworkError) {
-            IPInstance.processSend(&self.instanceType, datagrams: &datagrams)
+            IPInstance.processOutbound(&self.instanceType, datagrams: &datagrams)
             try invokeSendDatagrams(datagrams)
         }
 
@@ -1343,7 +1354,7 @@ public struct IPProtocol: NetworkProtocol {
         }
 
         @inline(__always)
-        private static func processSend(_ instanceType: inout IPInstanceType, datagrams: inout FrameArray) {
+        private static func processOutbound(_ instanceType: inout IPInstanceType, datagrams: inout FrameArray) {
             switch instanceType {
             case .ipv4(var instance):
                 instance.writeOutboundFrames(&datagrams)

--- a/Sources/SwiftNetwork/Protocols/IPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/IPProtocol.swift
@@ -525,7 +525,7 @@ public struct IPProtocol: NetworkProtocol {
                 // Guard against the max value of UInt16
                 let rawLength = UInt32(IPv4Instance.headerLength) + UInt32(expectedOffset)
                 guard rawLength <= UInt16.max else {
-                    log.fault("Reassembled IP length overflows for IP ID \(reassemblyID)")
+                    log.error("Reassembled IP length overflows for IP ID \(reassemblyID)")
                     return
                 }
                 let newIPFrameLength = UInt16(rawLength)
@@ -536,7 +536,7 @@ public struct IPProtocol: NetworkProtocol {
                     first.copyInto(&newFrame, length: IPv4Instance.headerLength)
                 }
                 guard headerCopied == IPv4Instance.headerLength else {
-                    log.fault("Failed to copy IP header from first fragment (IP ID \(reassemblyID))")
+                    log.error("Failed to copy IP header from first fragment (IP ID \(reassemblyID))")
                     newFrame.finalize(success: false)
                     return
                 }
@@ -547,12 +547,12 @@ public struct IPProtocol: NetworkProtocol {
                     try write.uint16NetworkByteOrder(0)
                 }
                 guard result.isValid else {
-                    log.fault("Failed to write the updated IP header")
+                    log.error("Failed to write the updated IP header")
                     newFrame.finalize(success: false)
                     return
                 }
                 guard newFrame.claim(fromStart: IPv4Instance.headerLength) else {
-                    log.fault("Failed to claim the updated IP header")
+                    log.error("Failed to claim the updated IP header")
                     newFrame.finalize(success: false)
                     return
                 }
@@ -561,7 +561,7 @@ public struct IPProtocol: NetworkProtocol {
                 var copyFailed = false
                 reassemblyState?.inputReassemblyFrames.iterateMutableFrames { fragment in
                     guard fragment.bufferLength >= IPv4Instance.headerLength else {
-                        log.fault("Fragment became invalid during reassembly copy")
+                        log.error("Fragment became invalid during reassembly copy")
                         copyFailed = true
                         return false
                     }
@@ -580,7 +580,7 @@ public struct IPProtocol: NetworkProtocol {
                         return false
                     }
                     guard fragment.bufferLength >= Int(ipLength) else {
-                        log.fault(
+                        log.error(
                             "Fragment buffer \(fragment.bufferLength) < ip_len \(ipLength) for IP ID \(reassemblyID)"
                         )
                         copyFailed = true
@@ -590,7 +590,7 @@ public struct IPProtocol: NetworkProtocol {
                     let payloadLength = totalIPLength - IPv4Instance.headerLength
                     let payloadEnd = writeOffset + payloadLength
                     guard payloadEnd <= Int(newIPFrameLength) - IPv4Instance.headerLength else {
-                        log.fault("Writing fragment payload overflows the new IP frame")
+                        log.error("Writing fragment payload overflows the new IP frame")
                         copyFailed = true
                         return false
                     }
@@ -601,7 +601,7 @@ public struct IPProtocol: NetworkProtocol {
                         length: payloadLength
                     )
                     guard copied == payloadLength else {
-                        log.fault("Payload copy mismatch for IP ID \(reassemblyID): \(copied) != \(payloadLength)")
+                        log.error("Payload copy mismatch for IP ID \(reassemblyID): \(copied) != \(payloadLength)")
                         copyFailed = true
                         return false
                     }

--- a/Sources/SwiftNetwork/Protocols/IPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/IPProtocol.swift
@@ -748,7 +748,7 @@ public struct IPProtocol: NetworkProtocol {
                     }
 
                     // IP fragment detected, set hadFragments for future reassembly processing
-                    if offset & UInt16(IP_MF | IP_OFFMASK) != 0 {
+                    if offset & UInt16(IPMoreFragmentsFlag | IPFragmentOffsetMask) != 0 {
                         if frame.isSingleIPAggregate {
                             log.fault("Received fragment on a super-packet with length: \(originalFrameLength)")
                             return .removeFrameAndContinue

--- a/Sources/SwiftNetwork/Protocols/IPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/IPProtocol.swift
@@ -1293,6 +1293,27 @@ public struct IPProtocol: NetworkProtocol {
             }
         }
 
+        mutating func teardown() {
+            IPInstance.drainReassemblyQueue(&instanceType)
+        }
+
+        @inline(__always)
+        private static func drainReassemblyQueue(_ instanceType: inout IPInstanceType) {
+            // Make sure that there are no left over frames stranded in the reassembly queue
+            switch instanceType {
+            case .ipv4(var instance):
+                while var fragment = instance.reassemblyState?.inputReassemblyFrames.popFirst() {
+                    fragment.finalize(success: false)
+                }
+                instanceType = .ipv4(instance)
+            case .ipv6(var instance):
+                while var fragment = instance.reassemblyState?.inputReassemblyFrames.popFirst() {
+                    fragment.finalize(success: false)
+                }
+                instanceType = .ipv6(instance)
+            }
+        }
+
         mutating func receiveDatagrams(maximumDatagramCount: Int) throws(NetworkError) -> FrameArray? {
             repeat {
                 let inboundFrames = try invokeReceiveDatagrams(maximumDatagramCount: maximumDatagramCount)

--- a/Sources/SwiftNetwork/Protocols/IPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/IPProtocol.swift
@@ -339,9 +339,9 @@ public struct IPProtocol: NetworkProtocol {
         var log = NetworkLoggerState()
         var eventManager = ProtocolEventManager()
 
-        static let IP_MF: UInt16 = 0x2000
-        static let IP_OFFMASK: UInt16 = 0x1FFF
-        static let IP_MAX_FRAGMENT_COUNT: Int = 32
+        static let IPMoreFragmentsFlag: UInt16 = 0x2000
+        static let IPFragmentOffsetMask: UInt16 = 0x1FFF
+        static let IPMaxFragmentCount: Int = 32
 
         // Only called by newProtocolInstance()
         fileprivate static func registerNewIP(on context: NetworkContext) -> ProtocolInstanceReference {
@@ -493,7 +493,7 @@ public struct IPProtocol: NetworkProtocol {
                         return false
                     }
                     // Fragment offset is in 8 byte increments
-                    let fragmentByteOffset = (offset & IP_OFFMASK) * 8
+                    let fragmentByteOffset = (offset & IPFragmentOffsetMask) * 8
                     guard fragmentByteOffset == expectedOffset else {
                         complete = false
                         return false
@@ -507,7 +507,7 @@ public struct IPProtocol: NetworkProtocol {
                     }
                     // Found the next fragment
                     expectedOffset = next
-                    if offset & IP_MF == 0 {
+                    if offset & IPMoreFragmentsFlag == 0 {
                         // No more fragments, we're complete
                         complete = true
                         return false
@@ -834,15 +834,15 @@ public struct IPProtocol: NetworkProtocol {
                         reassemblyState = IPReassemblyState(reassemblyID: identifier)
                     }
                     let currentFragmentCount = reassemblyState?.inputReassemblyFrames.count ?? 0
-                    guard currentFragmentCount < IP_MAX_FRAGMENT_COUNT else {
+                    guard currentFragmentCount < IPMaxFragmentCount else {
                         frame.finalize(success: false)
                         continue
                     }
 
-                    let fragmentByteOffset = (offset & IP_OFFMASK) * 8
+                    let fragmentByteOffset = (offset & IPFragmentOffsetMask) * 8
                     if fragmentByteOffset == 0 {
                         reassemblyState?.inputReassemblyFrames.prepend(frame: frame)
-                    } else if offset & IP_MF == 0 {
+                    } else if offset & IPMoreFragmentsFlag == 0 {
                         reassemblyState?.inputReassemblyFrames.add(frame: frame)
                     } else {
                         var sorted = FrameArray()
@@ -863,7 +863,7 @@ public struct IPProtocol: NetworkProtocol {
                                     sorted.add(frame: existing)
                                     continue
                                 }
-                                existingOffset = existingOffset & IP_OFFMASK
+                                existingOffset = existingOffset & IPFragmentOffsetMask
                                 let existingByteOffset = existingOffset * 8
                                 let predecessorEnd =
                                     UInt32(existingByteOffset) + UInt32(existingLength)

--- a/Tests/SwiftNetworkTests/SwiftNetworkFrameArrayTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkFrameArrayTests.swift
@@ -655,4 +655,13 @@ final class SwiftNetworkFrameArrayTests: NetTestCase {
         drained.finalizeAllFramesAsFailed()
         array.finalizeAllFramesAsFailed()
     }
+
+    func testPrepend() {
+        var array = FrameArray(frame: Frame(copyBuffer: [1, 2, 3]))
+        array.prepend(frame: Frame(copyBuffer: [4, 5, 6]))
+        XCTAssertEqual(array.count, 2)
+        XCTAssertEqual(array.unclaimedLength, 6)
+        XCTAssertEqual(collectBytes(array), [4, 5, 6, 1, 2, 3])
+        array.finalizeAllFramesAsFailed()
+    }
 }

--- a/Tests/SwiftNetworkTests/SwiftNetworkIPTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkIPTests.swift
@@ -501,7 +501,7 @@ final class SwiftNetworkIPTests: NetTestCase {
             SwiftNetworkIPTests.threeFragmentInputPacket2,
             SwiftNetworkIPTests.threeFragmentInputPacket3,
         ])
-        XCTAssertNotNil(readBytes, "Failed to receive reassembled IPv4 packet from two fragments")
+        XCTAssertNotNil(readBytes, "Failed to receive reassembled IPv4 packet from three fragments")
         if let readBytes {
             XCTAssertEqual(
                 readBytes,

--- a/Tests/SwiftNetworkTests/SwiftNetworkIPTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkIPTests.swift
@@ -107,7 +107,7 @@ final class SwiftNetworkIPTests: NetTestCase {
     static let outputMessage: [UInt8] = [0xfc, 0xf7, 0x04, 0xd2, 0x00, 0x0d, 0xe8, 0x04, 0x68, 0x65, 0x6c, 0x6c, 0x6f]
     static let inputMessage: [UInt8] = [0x04, 0xd2, 0xfc, 0xf7, 0x00, 0x0d, 0xe8, 0x04, 0x68, 0x65, 0x6c, 0x6c, 0x6f]
 
-    // 169.254.225.163 -> 169.254.156.146, fragment 1 of 2: first 8 bytes of inputMessage, MF=1 (More fragments)
+    // 169.254.225.163 -> 169.254.156.146 (for simulation only), fragment 1 of 2: first 8 bytes of inputMessage, MF=1 (More fragments)
     // The first 8 bytes of inputMessage are the UDP header
     // reassemblyID = 0xABCD
     static let twoFragmentInputPacket1: [UInt8] = [
@@ -115,7 +115,7 @@ final class SwiftNetworkIPTests: NetTestCase {
         0xA9, 0xFE, 0xE1, 0xA3, 0xA9, 0xFE, 0x9C, 0x92,
         0x04, 0xD2, 0xFC, 0xF7, 0x00, 0x0D, 0xE8, 0x04,
     ]
-    // 169.254.225.163 -> 169.254.156.146, fragment 2 of 2: last 5 bytes of inputMessage, MF=0 (Last fragment)
+    // 169.254.225.163 -> 169.254.156.146 (for simulation only), fragment 2 of 2: last 5 bytes of inputMessage, MF=0 (Last fragment)
     // The next 5 bytes of inputMessage are the UDP payload (hello)
     // reassemblyID = 0xABCD
     static let twoFragmentInputPacket2: [UInt8] = [
@@ -124,7 +124,92 @@ final class SwiftNetworkIPTests: NetTestCase {
         0x68, 0x65, 0x6C, 0x6C, 0x6F,
     ]
 
-    // 169.254.225.163 -> 169.254.156.146, fragment 1 of 3: bytes 0–7, MF=1, offset=0 (More fragments)
+    // 169.254.225.163 -> 169.254.156.146 (for simulation only), fragment 1 of 2: bytes 0–7, MF=1 (More fragments)
+    // Fragment 2 uses offset=2 (byte offset 16), skipping offset=1 (byte offset 8).
+    // This creates a gap so appendReassembledPackets detects expectedOffset mismatch and drops the sequence.
+    // reassemblyID = 0xDEAD
+    static let gappedFragmentInputPacket1: [UInt8] = [
+        0x45, 0x00, 0x00, 0x1C, 0xDE, 0xAD, 0x20, 0x00, 0x40, 0x11, 0x00, 0x00,
+        0xA9, 0xFE, 0xE1, 0xA3, 0xA9, 0xFE, 0x9C, 0x92,
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    ]
+    // Fragment at offset=2 (byte offset=16), MF=0 (Last fragment). Skips offset=1 (byte offset=8) entirely.
+    // reassemblyID = 0xDEAD
+    static let gappedFragmentInputPacket2: [UInt8] = [
+        0x45, 0x00, 0x00, 0x1C, 0xDE, 0xAD, 0x00, 0x02, 0x40, 0x11, 0x00, 0x00,
+        0xA9, 0xFE, 0xE1, 0xA3, 0xA9, 0xFE, 0x9C, 0x92,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+    ]
+
+    // Two fragments, both with MF=1 set (More fragments)
+    // reassemblyID = 0xF00D
+    static let noTerminalFragmentPacket1: [UInt8] = [
+        0x45, 0x00, 0x00, 0x1C, 0xF0, 0x0D, 0x20, 0x00, 0x40, 0x11, 0x00, 0x00,
+        0xA9, 0xFE, 0xE1, 0xA3, 0xA9, 0xFE, 0x9C, 0x92,
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    ]
+    // Fragment at offset=1 (byte 8), also MF=1 (More fragments)
+    // reassemblyID = 0xF00D
+    static let noTerminalFragmentPacket2: [UInt8] = [
+        0x45, 0x00, 0x00, 0x1C, 0xF0, 0x0D, 0x20, 0x01, 0x40, 0x11, 0x00, 0x00,
+        0xA9, 0xFE, 0xE1, 0xA3, 0xA9, 0xFE, 0x9C, 0x92,
+        0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+    ]
+
+    // Two fragments whose combined payload totals 65516 bytes, making rawLength (20 + 65516 = 65536) exceed UInt16.max.
+    // reassemblyID = 0xCAFE
+    static let overflowFragmentPacket1: [UInt8] = {
+        var packet = [UInt8](repeating: 0, count: 32772)
+        packet[0] = 0x45
+        packet[1] = 0x00
+        packet[2] = 0x80
+        packet[3] = 0x04
+        packet[4] = 0xCA
+        packet[5] = 0xFE
+        packet[6] = 0x20
+        packet[7] = 0x00
+        packet[8] = 0x40
+        packet[9] = 0x11
+        packet[10] = 0x00
+        packet[11] = 0x00
+        packet[12] = 0xA9
+        packet[13] = 0xFE
+        packet[14] = 0xE1
+        packet[15] = 0xA3
+        packet[16] = 0xA9
+        packet[17] = 0xFE
+        packet[18] = 0x9C
+        packet[19] = 0x92
+        return packet
+    }()
+
+    // reassemblyID = 0xCAFE
+    static let overflowFragmentPacket2: [UInt8] = {
+        var packet = [UInt8](repeating: 0, count: 32784)
+        packet[0] = 0x45
+        packet[1] = 0x00
+        packet[2] = 0x80
+        packet[3] = 0x10
+        packet[4] = 0xCA
+        packet[5] = 0xFE
+        packet[6] = 0x0F
+        packet[7] = 0xFE
+        packet[8] = 0x40
+        packet[9] = 0x11
+        packet[10] = 0x00
+        packet[11] = 0x00
+        packet[12] = 0xA9
+        packet[13] = 0xFE
+        packet[14] = 0xE1
+        packet[15] = 0xA3
+        packet[16] = 0xA9
+        packet[17] = 0xFE
+        packet[18] = 0x9C
+        packet[19] = 0x92
+        return packet
+    }()
+
+    // 169.254.225.163 -> 169.254.156.146 (for simulation only), fragment 1 of 3: bytes 0–7, MF=1, offset=0 (More fragments)
     // reassemblyID = 0xBEEF
     static let threeFragmentInputPacket1: [UInt8] = [
         0x45, 0x00, 0x00, 0x1C, 0xBE, 0xEF, 0x20, 0x00, 0x40, 0x11, 0x00, 0x00,
@@ -410,86 +495,77 @@ final class SwiftNetworkIPTests: NetTestCase {
         )
     }
 
-    func testTwoIPv4FragmentsToReassemble() {
-        let parameters = Parameters()
-        let expectation = XCTestExpectation(description: "Two reassembled packets expectation")
-        let context = parameters.context
-        context.async {
-            defer { expectation.fulfill() }
-            let path = PathProperties(parameters: parameters)
-            let ipInstance = IPProtocol.instance(context: parameters.context)
-            let ipOptions = IPProtocol.options()
-            ipOptions.setLogID(prefix: "C", parent: "1", protocolLogIDNumber: 2)
-            ipOptions.setProtocolInstance(ipInstance)
-            parameters.defaultStack.internet = .ip(ipOptions)
-
-            let udpOptions = UDPProtocol.options()
-            udpOptions.noMetadata = true
-            udpOptions.setLogID(prefix: "C", parent: "1", protocolLogIDNumber: 1)
-            parameters.defaultStack.transport = .udp(udpOptions)
-
-            let localEndpoint = Endpoint(address: IPv4Address(SwiftNetworkIPTests.localIPv4Address)!, port: 0)
-            let remoteEndpoint = Endpoint(address: IPv4Address(SwiftNetworkIPTests.remoteIPv4Address)!, port: 0)
-
-            let ipLinkage = OutboundDatagramLinkage(reference: ipInstance)
-            let upperHarness = DatagramUpperHarness(
-                identifier: "Client",
-                local: localEndpoint,
-                remote: remoteEndpoint,
-                parameters: parameters,
-                path: path,
-                context: parameters.context,
-                lowerProtocol: ipLinkage
+    func testThreeAIPv4FragmentsToReassemble() {
+        let readBytes = processIPv4Fragment(packets: [
+            SwiftNetworkIPTests.threeFragmentInputPacket1,
+            SwiftNetworkIPTests.threeFragmentInputPacket2,
+            SwiftNetworkIPTests.threeFragmentInputPacket3,
+        ])
+        XCTAssertNotNil(readBytes, "Failed to receive reassembled IPv4 packet from two fragments")
+        if let readBytes {
+            XCTAssertEqual(
+                readBytes,
+                SwiftNetworkIPTests.threeFragmentPayload,
+                "Reassembled payload did not match expected"
             )
-            XCTAssertNotNil(upperHarness, "Failed to attach IP to upper harness")
-            guard let upperHarness else { return }
-
-            let lowerHarness = DatagramLowerHarness(identifier: "Client", context: parameters.context)
-            do {
-                try ipInstance.attachLowerDatagramProtocol(
-                    lowerHarness.reference,
-                    remote: remoteEndpoint,
-                    local: localEndpoint,
-                    parameters: parameters,
-                    path: path
-                )
-            } catch {
-                XCTAssertTrue(false, "Failed to attach IP to lower harness")
-            }
-
-            upperHarness.start { connected in
-                XCTAssertTrue(connected, "IP failed to become connected")
-            }
-            // Deliver both fragments in a single batch.
-            lowerHarness.setNextInboundPacket(SwiftNetworkIPTests.twoFragmentInputPacket1, sendAvailableEvent: false)
-            lowerHarness.setNextInboundPacket(SwiftNetworkIPTests.twoFragmentInputPacket2)
-
-            let readBytes = upperHarness.read()
-            XCTAssertNotNil(readBytes, "Failed to receive reassembled IPv4 packet from two fragments")
-            if let readBytes {
-                XCTAssertEqual(
-                    readBytes,
-                    SwiftNetworkIPTests.inputMessage,
-                    "Reassembled payload did not match expected"
-                )
-            }
-            upperHarness.stop()
-            upperHarness.teardown()
         }
-        wait(for: [expectation], timeout: 5.0)
     }
 
-    func testThreeIPv4FragmentsToReassemble() {
-        // This test will also test the sorted fragment logic
+    func testTwoIPv4FragmentsToReassemble() {
+        let readBytes = processIPv4Fragment(packets: [
+            SwiftNetworkIPTests.twoFragmentInputPacket1,
+            SwiftNetworkIPTests.twoFragmentInputPacket2,
+        ])
+        XCTAssertNotNil(readBytes, "Failed to receive reassembled IPv4 packet from two fragments")
+        if let readBytes {
+            XCTAssertEqual(readBytes, SwiftNetworkIPTests.inputMessage, "Reassembled payload did not match expected")
+        }
+    }
+
+    // Verifies that appendReassembledPackets discards a fragment when it detects an offset gap.
+    // fragment 1 has byte offset 0, fragment 2 jumps to byte offset 16, skipping 8.
+    func testGappedIPv4FragmentsProduceNoReassembledFrame() {
+        let readBytes = processIPv4Fragment(packets: [
+            SwiftNetworkIPTests.gappedFragmentInputPacket1,
+            SwiftNetworkIPTests.gappedFragmentInputPacket2,
+        ])
+        XCTAssertNil(readBytes, "Unexpectedly received a packet from a gapped fragment sequence")
+    }
+
+    // Verifies that appendReassembledPackets does not create a reassembled fragment without a terminal MF=0 flag.
+    func testAllMFSetFragmentsProduceNoReassembledFrame() {
+        let readBytes = processIPv4Fragment(packets: [
+            SwiftNetworkIPTests.noTerminalFragmentPacket1,
+            SwiftNetworkIPTests.noTerminalFragmentPacket2,
+        ])
+        XCTAssertNil(readBytes, "Unexpectedly received a packet when no terminal fragment was present")
+    }
+
+    // Verifies that appendReassembledPackets rejects a complete fragment sequence whose combined
+    // payload would cause rawLength (headerLength + totalPayload) exceeds UInt16.max.
+    func testReassembledLengthOverflowProducesNoFrame() {
+        let readBytes = processIPv4Fragment(packets: [
+            SwiftNetworkIPTests.overflowFragmentPacket1,
+            SwiftNetworkIPTests.overflowFragmentPacket2,
+        ])
+        XCTAssertNil(readBytes, "Unexpectedly received a packet when reassembled length overflows UInt16")
+    }
+
+    // Sets up a minimal IPv4 harness to test different fragment and reassembly conditions.
+    private func processIPv4Fragment(
+        packets: [[UInt8]],
+        logIDNumber: Int = 2
+    ) -> [UInt8]? {
         let parameters = Parameters()
-        let expectation = XCTestExpectation(description: "Three reassembled packets expectation")
+        var result: [UInt8]? = nil
+        let expectation = XCTestExpectation()
         let context = parameters.context
         context.async {
             defer { expectation.fulfill() }
             let path = PathProperties(parameters: parameters)
             let ipInstance = IPProtocol.instance(context: parameters.context)
             let ipOptions = IPProtocol.options()
-            ipOptions.setLogID(prefix: "C", parent: "1", protocolLogIDNumber: 2)
+            ipOptions.setLogID(prefix: "C", parent: "1", protocolLogIDNumber: logIDNumber)
             ipOptions.setProtocolInstance(ipInstance)
             parameters.defaultStack.internet = .ip(ipOptions)
 
@@ -502,17 +578,20 @@ final class SwiftNetworkIPTests: NetTestCase {
             let remoteEndpoint = Endpoint(address: IPv4Address(SwiftNetworkIPTests.remoteIPv4Address)!, port: 0)
 
             let ipLinkage = OutboundDatagramLinkage(reference: ipInstance)
-            let upperHarness = DatagramUpperHarness(
-                identifier: "Client",
-                local: localEndpoint,
-                remote: remoteEndpoint,
-                parameters: parameters,
-                path: path,
-                context: parameters.context,
-                lowerProtocol: ipLinkage
-            )
-            XCTAssertNotNil(upperHarness, "Failed to attach IP to upper harness")
-            guard let upperHarness else { return }
+            guard
+                let upperHarness = DatagramUpperHarness(
+                    identifier: "Client",
+                    local: localEndpoint,
+                    remote: remoteEndpoint,
+                    parameters: parameters,
+                    path: path,
+                    context: parameters.context,
+                    lowerProtocol: ipLinkage
+                )
+            else {
+                XCTFail("Failed to attach IP to upper harness")
+                return
+            }
 
             let lowerHarness = DatagramLowerHarness(identifier: "Client", context: parameters.context)
             do {
@@ -524,31 +603,25 @@ final class SwiftNetworkIPTests: NetTestCase {
                     path: path
                 )
             } catch {
-                XCTAssertTrue(false, "Failed to attach IP to lower harness")
+                XCTFail("Failed to attach IP to lower harness")
+                return
             }
 
             upperHarness.start { connected in
-                XCTAssertTrue(connected, "IP failed to become connected")
-            }
-            // Deliver all three fragments in a single batch.
-            lowerHarness.setNextInboundPacket(SwiftNetworkIPTests.threeFragmentInputPacket1, sendAvailableEvent: false)
-            lowerHarness.setNextInboundPacket(SwiftNetworkIPTests.threeFragmentInputPacket2, sendAvailableEvent: false)
-            lowerHarness.setNextInboundPacket(SwiftNetworkIPTests.threeFragmentInputPacket3)
-
-            let readBytes = upperHarness.read()
-            XCTAssertNotNil(readBytes, "Failed to receive reassembled IPv4 packet from three fragments")
-            if let readBytes {
-                XCTAssertEqual(
-                    readBytes,
-                    SwiftNetworkIPTests.threeFragmentPayload,
-                    "Reassembled payload did not match expected"
-                )
+                XCTAssertTrue(connected)
             }
 
+            for (index, packet) in packets.enumerated() {
+                let isLast = index == packets.count - 1
+                lowerHarness.setNextInboundPacket(packet, sendAvailableEvent: isLast)
+            }
+
+            result = upperHarness.read()
             upperHarness.stop()
             upperHarness.teardown()
         }
         wait(for: [expectation], timeout: 5.0)
+        return result
     }
 
     func ipEcho(clientEndpoint: Endpoint, serverEndpoint: Endpoint, messages: [[UInt8]]) {

--- a/Tests/SwiftNetworkTests/SwiftNetworkIPTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkIPTests.swift
@@ -107,6 +107,52 @@ final class SwiftNetworkIPTests: NetTestCase {
     static let outputMessage: [UInt8] = [0xfc, 0xf7, 0x04, 0xd2, 0x00, 0x0d, 0xe8, 0x04, 0x68, 0x65, 0x6c, 0x6c, 0x6f]
     static let inputMessage: [UInt8] = [0x04, 0xd2, 0xfc, 0xf7, 0x00, 0x0d, 0xe8, 0x04, 0x68, 0x65, 0x6c, 0x6c, 0x6f]
 
+    // 169.254.225.163 -> 169.254.156.146, fragment 1 of 2: first 8 bytes of inputMessage, MF=1 (More fragments)
+    // The first 8 bytes of inputMessage are the UDP header
+    // reassemblyID = 0xABCD
+    static let twoFragmentInputPacket1: [UInt8] = [
+        0x45, 0x00, 0x00, 0x1C, 0xAB, 0xCD, 0x20, 0x00, 0x40, 0x11, 0x00, 0x00,
+        0xA9, 0xFE, 0xE1, 0xA3, 0xA9, 0xFE, 0x9C, 0x92,
+        0x04, 0xD2, 0xFC, 0xF7, 0x00, 0x0D, 0xE8, 0x04,
+    ]
+    // 169.254.225.163 -> 169.254.156.146, fragment 2 of 2: last 5 bytes of inputMessage, MF=0 (Last fragment)
+    // The next 5 bytes of inputMessage are the UDP payload (hello)
+    // reassemblyID = 0xABCD
+    static let twoFragmentInputPacket2: [UInt8] = [
+        0x45, 0x00, 0x00, 0x19, 0xAB, 0xCD, 0x00, 0x01, 0x40, 0x11, 0x00, 0x00,
+        0xA9, 0xFE, 0xE1, 0xA3, 0xA9, 0xFE, 0x9C, 0x92,
+        0x68, 0x65, 0x6C, 0x6C, 0x6F,
+    ]
+
+    // 169.254.225.163 -> 169.254.156.146, fragment 1 of 3: bytes 0–7, MF=1, offset=0 (More fragments)
+    // reassemblyID = 0xBEEF
+    static let threeFragmentInputPacket1: [UInt8] = [
+        0x45, 0x00, 0x00, 0x1C, 0xBE, 0xEF, 0x20, 0x00, 0x40, 0x11, 0x00, 0x00,
+        0xA9, 0xFE, 0xE1, 0xA3, 0xA9, 0xFE, 0x9C, 0x92,
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    ]
+    // fragment 2 of 3: bytes 8–15, MF=1, offset=1 (offsets are in byte increments) (More fragments)
+    // reassemblyID = 0xBEEF
+    static let threeFragmentInputPacket2: [UInt8] = [
+        0x45, 0x00, 0x00, 0x1C, 0xBE, 0xEF, 0x20, 0x01, 0x40, 0x11, 0x00, 0x00,
+        0xA9, 0xFE, 0xE1, 0xA3, 0xA9, 0xFE, 0x9C, 0x92,
+        0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+    ]
+    // fragment 3 of 3: bytes 16–23, MF=0, offset=2 (offsets are in byte increments) (Last fragment)
+    // reassemblyID = 0xBEEF
+    static let threeFragmentInputPacket3: [UInt8] = [
+        0x45, 0x00, 0x00, 0x1C, 0xBE, 0xEF, 0x00, 0x02, 0x40, 0x11, 0x00, 0x00,
+        0xA9, 0xFE, 0xE1, 0xA3, 0xA9, 0xFE, 0x9C, 0x92,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+    ]
+    // Expected reassembled payload for all of the three fragments above
+    // This payload does not represent anything, just that the 3 packets above can be reassembled correctly.
+    static let threeFragmentPayload: [UInt8] = [
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+    ]
+
     func internalTestIP(
         localEndpoint: Endpoint,
         remoteEndpoint: Endpoint,
@@ -362,6 +408,147 @@ final class SwiftNetworkIPTests: NetTestCase {
             inputPacket: SwiftNetworkIPTests.inputIPv6Packet,
             hopLimit: 32
         )
+    }
+
+    func testTwoIPv4FragmentsToReassemble() {
+        let parameters = Parameters()
+        let expectation = XCTestExpectation(description: "Two reassembled packets expectation")
+        let context = parameters.context
+        context.async {
+            defer { expectation.fulfill() }
+            let path = PathProperties(parameters: parameters)
+            let ipInstance = IPProtocol.instance(context: parameters.context)
+            let ipOptions = IPProtocol.options()
+            ipOptions.setLogID(prefix: "C", parent: "1", protocolLogIDNumber: 2)
+            ipOptions.setProtocolInstance(ipInstance)
+            parameters.defaultStack.internet = .ip(ipOptions)
+
+            let udpOptions = UDPProtocol.options()
+            udpOptions.noMetadata = true
+            udpOptions.setLogID(prefix: "C", parent: "1", protocolLogIDNumber: 1)
+            parameters.defaultStack.transport = .udp(udpOptions)
+
+            let localEndpoint = Endpoint(address: IPv4Address(SwiftNetworkIPTests.localIPv4Address)!, port: 0)
+            let remoteEndpoint = Endpoint(address: IPv4Address(SwiftNetworkIPTests.remoteIPv4Address)!, port: 0)
+
+            let ipLinkage = OutboundDatagramLinkage(reference: ipInstance)
+            let upperHarness = DatagramUpperHarness(
+                identifier: "Client",
+                local: localEndpoint,
+                remote: remoteEndpoint,
+                parameters: parameters,
+                path: path,
+                context: parameters.context,
+                lowerProtocol: ipLinkage
+            )
+            XCTAssertNotNil(upperHarness, "Failed to attach IP to upper harness")
+            guard let upperHarness else { return }
+
+            let lowerHarness = DatagramLowerHarness(identifier: "Client", context: parameters.context)
+            do {
+                try ipInstance.attachLowerDatagramProtocol(
+                    lowerHarness.reference,
+                    remote: remoteEndpoint,
+                    local: localEndpoint,
+                    parameters: parameters,
+                    path: path
+                )
+            } catch {
+                XCTAssertTrue(false, "Failed to attach IP to lower harness")
+            }
+
+            upperHarness.start { connected in
+                XCTAssertTrue(connected, "IP failed to become connected")
+            }
+            // Deliver both fragments in a single batch.
+            lowerHarness.setNextInboundPacket(SwiftNetworkIPTests.twoFragmentInputPacket1, sendAvailableEvent: false)
+            lowerHarness.setNextInboundPacket(SwiftNetworkIPTests.twoFragmentInputPacket2)
+
+            let readBytes = upperHarness.read()
+            XCTAssertNotNil(readBytes, "Failed to receive reassembled IPv4 packet from two fragments")
+            if let readBytes {
+                XCTAssertEqual(
+                    readBytes,
+                    SwiftNetworkIPTests.inputMessage,
+                    "Reassembled payload did not match expected"
+                )
+            }
+            upperHarness.stop()
+            upperHarness.teardown()
+        }
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func testThreeIPv4FragmentsToReassemble() {
+        // This test will also test the sorted fragment logic
+        let parameters = Parameters()
+        let expectation = XCTestExpectation(description: "Three reassembled packets expectation")
+        let context = parameters.context
+        context.async {
+            defer { expectation.fulfill() }
+            let path = PathProperties(parameters: parameters)
+            let ipInstance = IPProtocol.instance(context: parameters.context)
+            let ipOptions = IPProtocol.options()
+            ipOptions.setLogID(prefix: "C", parent: "1", protocolLogIDNumber: 2)
+            ipOptions.setProtocolInstance(ipInstance)
+            parameters.defaultStack.internet = .ip(ipOptions)
+
+            let udpOptions = UDPProtocol.options()
+            udpOptions.noMetadata = true
+            udpOptions.setLogID(prefix: "C", parent: "1", protocolLogIDNumber: 1)
+            parameters.defaultStack.transport = .udp(udpOptions)
+
+            let localEndpoint = Endpoint(address: IPv4Address(SwiftNetworkIPTests.localIPv4Address)!, port: 0)
+            let remoteEndpoint = Endpoint(address: IPv4Address(SwiftNetworkIPTests.remoteIPv4Address)!, port: 0)
+
+            let ipLinkage = OutboundDatagramLinkage(reference: ipInstance)
+            let upperHarness = DatagramUpperHarness(
+                identifier: "Client",
+                local: localEndpoint,
+                remote: remoteEndpoint,
+                parameters: parameters,
+                path: path,
+                context: parameters.context,
+                lowerProtocol: ipLinkage
+            )
+            XCTAssertNotNil(upperHarness, "Failed to attach IP to upper harness")
+            guard let upperHarness else { return }
+
+            let lowerHarness = DatagramLowerHarness(identifier: "Client", context: parameters.context)
+            do {
+                try ipInstance.attachLowerDatagramProtocol(
+                    lowerHarness.reference,
+                    remote: remoteEndpoint,
+                    local: localEndpoint,
+                    parameters: parameters,
+                    path: path
+                )
+            } catch {
+                XCTAssertTrue(false, "Failed to attach IP to lower harness")
+            }
+
+            upperHarness.start { connected in
+                XCTAssertTrue(connected, "IP failed to become connected")
+            }
+            // Deliver all three fragments in a single batch.
+            lowerHarness.setNextInboundPacket(SwiftNetworkIPTests.threeFragmentInputPacket1, sendAvailableEvent: false)
+            lowerHarness.setNextInboundPacket(SwiftNetworkIPTests.threeFragmentInputPacket2, sendAvailableEvent: false)
+            lowerHarness.setNextInboundPacket(SwiftNetworkIPTests.threeFragmentInputPacket3)
+
+            let readBytes = upperHarness.read()
+            XCTAssertNotNil(readBytes, "Failed to receive reassembled IPv4 packet from three fragments")
+            if let readBytes {
+                XCTAssertEqual(
+                    readBytes,
+                    SwiftNetworkIPTests.threeFragmentPayload,
+                    "Reassembled payload did not match expected"
+                )
+            }
+
+            upperHarness.stop()
+            upperHarness.teardown()
+        }
+        wait(for: [expectation], timeout: 5.0)
     }
 
     func ipEcho(clientEndpoint: Endpoint, serverEndpoint: Endpoint, messages: [[UInt8]]) {


### PR DESCRIPTION
The goal here is to add reassembly support for fragmented IPv4 packets in Swift IP without impacting performance and on standard path.
Since IP fragmentation is not very common there needs to be fall-back behavior for reassembly when IP fragments are detected in `processInboundFrames` to ensure performance.

This change includes such fall-back behavior for reassembly and I verified the performance with QUICTransfer:
```
Top of tree:
213.05 M  47.9%	-	 IPProtocol.IPInstance.IPv4Instance.processInboundFrames(_:_:)

With this change
226.35 M  46.7%	-	 IPProtocol.IPInstance.IPv4Instance.processInboundFrames(_:_:)
```

Adds support for reassembly IPv4 fragments only. IPv6 support will come in a future change.