### PR TITLE
Mark Sendable for NetworkContext's external async calls

### DIFF
--- a/Sources/SwiftNetwork/Connection/Connection.swift
+++ b/Sources/SwiftNetwork/Connection/Connection.swift
@@ -969,7 +969,7 @@ public struct TCP: StreamProtocol {
 #if !NETWORK_EMBEDDED
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-public struct DatagramBridge: DatagramProtocol {
+public struct DatagramBridge: DatagramProtocol, Sendable {
     public typealias ContentType = Void
 
     public let belowProtocol: Void
@@ -990,7 +990,7 @@ public struct DatagramBridge: DatagramProtocol {
 #if !NETWORK_EMBEDDED
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-public struct StreamBridge: StreamProtocol {
+public struct StreamBridge: StreamProtocol, Sendable {
     public typealias ContentType = Void
 
     public let belowProtocol: Void
@@ -1010,8 +1010,8 @@ public struct StreamBridge: StreamProtocol {
 
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-public struct NoTransport: StreamProtocol {
-    public enum BelowProtocol {
+public struct NoTransport: StreamProtocol, Sendable {
+    public enum BelowProtocol: Sendable {
         case void
         #if !NETWORK_EMBEDDED
         case bridge(StreamBridge)
@@ -1331,7 +1331,7 @@ public struct QUIC: MultiplexProtocol {
 /// > Note: This type is not intended to be inserted into the protocol stack manually; it is vended by connections that use QUIC.
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-public struct QUICStream: StreamProtocol {
+public struct QUICStream: StreamProtocol, Sendable {
     public let belowProtocol: Void
 
     public enum Directionality: Equatable {
@@ -1353,7 +1353,7 @@ public struct QUICStream: StreamProtocol {
 /// UDP supports sending and receiving datagrams.
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-public struct UDP: DatagramProtocol {
+public struct UDP: DatagramProtocol, Sendable {
     public typealias ContentType = [UInt8]
 
     private var preferNoChecksum: Bool?
@@ -1397,8 +1397,8 @@ public struct UDP: DatagramProtocol {
 /// protocol stack when configuring IP options.
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-public struct IP: NetworkProtocolOptions {
-    public enum BelowProtocol {
+public struct IP: NetworkProtocolOptions, Sendable {
+    public enum BelowProtocol: Sendable {
         case void
         #if !NETWORK_EMBEDDED
         case bridge(DatagramBridge)
@@ -2085,7 +2085,7 @@ extension NetworkChannel where ApplicationProtocol: MessageProtocol {
 
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-extension NetworkChannel where ApplicationProtocol: StreamProtocol {
+extension NetworkChannel where ApplicationProtocol: StreamProtocol & Sendable {
     public struct StreamMessage {
         public static func message(content: [UInt8]? = nil, isComplete: Bool = false) -> StreamMessage {
             StreamMessage(content: content, isComplete: isComplete)
@@ -2097,10 +2097,12 @@ extension NetworkChannel where ApplicationProtocol: StreamProtocol {
 
     public func send(_ message: StreamMessage, completion: (@Sendable (Result<Void, NetworkError>) -> Void)? = nil) {
         let endpointFlow = self.endpointFlow
+        let content = message.content
+        let isComplete = message.isComplete
         endpointFlow.async {
             let writeRequest = WriteRequest(
-                content: message.content,
-                isComplete: message.isComplete,
+                content: content,
+                isComplete: isComplete,
                 completion: completion
             )
             endpointFlow.addWriteRequestOnContext(writeRequest)
@@ -2114,10 +2116,12 @@ extension NetworkChannel where ApplicationProtocol: StreamProtocol {
         completion: (@Sendable (Result<Void, NetworkError>) -> Void)? = nil
     ) {
         let endpointFlow = self.endpointFlow
+        nonisolated(unsafe) let unsafeBuffer = buffer
+        nonisolated(unsafe) let unsafeOwner = owner
         endpointFlow.async {
             let writeRequest = WriteRequest(
-                buffer: buffer,
-                owner: owner,
+                buffer: unsafeBuffer,
+                owner: unsafeOwner,
                 isComplete: isComplete,
                 completion: completion
             )
@@ -2144,7 +2148,7 @@ extension NetworkChannel where ApplicationProtocol: StreamProtocol {
 
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-extension NetworkChannel where ApplicationProtocol: DatagramProtocol {
+extension NetworkChannel where ApplicationProtocol: DatagramProtocol & Sendable {
     public struct DatagramMessage {
         public static func message(content: [UInt8]? = nil) -> DatagramMessage {
             DatagramMessage(content: content)
@@ -2155,8 +2159,9 @@ extension NetworkChannel where ApplicationProtocol: DatagramProtocol {
 
     public func send(_ message: DatagramMessage, completion: (@Sendable (Result<Void, NetworkError>) -> Void)? = nil) {
         let endpointFlow = self.endpointFlow
+        let content = message.content
         endpointFlow.async {
-            let writeRequest = WriteRequest(content: message.content, isComplete: true, completion: completion)
+            let writeRequest = WriteRequest(content: content, isComplete: true, completion: completion)
             endpointFlow.addWriteRequestOnContext(writeRequest)
         }
     }
@@ -2168,10 +2173,12 @@ extension NetworkChannel where ApplicationProtocol: DatagramProtocol {
         completion: (@Sendable (Result<Void, NetworkError>) -> Void)? = nil
     ) {
         let endpointFlow = self.endpointFlow
+        nonisolated(unsafe) let unsafeBuffer = buffer
+        nonisolated(unsafe) let unsafeOwner = owner
         endpointFlow.async {
             let writeRequest = WriteRequest(
-                buffer: buffer,
-                owner: owner,
+                buffer: unsafeBuffer,
+                owner: unsafeOwner,
                 isComplete: isComplete,
                 completion: completion
             )

--- a/Sources/SwiftNetwork/Context/NetworkContext.swift
+++ b/Sources/SwiftNetwork/Context/NetworkContext.swift
@@ -46,8 +46,9 @@ public protocol NetworkContextProtocol: AnyObject, Hashable {
     init(identifier: String)
     var identifier: String { get }
     func activate()
-    func async(_ block: @escaping () -> Void)
-    func barrierAsync(_ block: @escaping () -> Void)
+    func async(_ block: @Sendable @escaping () -> Void)
+    func isolatedAsync(_ block: @escaping () -> Void)
+    func barrierAsync(_ block: @Sendable @escaping () -> Void)
 }
 
 @_spi(Essentials)
@@ -65,12 +66,17 @@ public final class NetworkContext: NetworkContextProtocol, @unchecked Sendable {
     }
 
     public protocol Scheduler: AnyObject {
+        /// Runs an immediate task, scheduled from the scheduler's context (so the completion is non-sendable).
+        /// No assumptions are made about how the task is run.
+        func runImmediateIsolated(_ task: @escaping () -> Void)
+
         /// Runs an immediate task. No assumptions are made about how the task is run.
-        func runImmediate(_ task: @escaping (() -> Void))
+        func runImmediate(_ task: @Sendable @escaping () -> Void)
+
         /// Schedules a task to run after a delay, using a reference.
         ///
         /// The `milliseconds` parameter specifies the delay before the task runs.
-        func schedule(_ task: @escaping (() -> Void), milliseconds: Int64, reference: TimerReference)
+        func schedule(_ task: @escaping () -> Void, milliseconds: Int64, reference: TimerReference)
         /// Unschedules a task with a reference.
         func unschedule(reference: TimerReference)
         /// A Boolean value that indicates whether the current code is running in the scheduler.
@@ -301,7 +307,7 @@ extension NetworkContext {
                 entries.removeFirst(where: { $0.reference == reference })
             }
 
-            func insert(targetTime: DispatchTime, reference: TimerReference, task: @escaping (() -> Void)) {
+            func insert(targetTime: DispatchTime, reference: TimerReference, task: @escaping () -> Void) {
                 // First, remove an existing entry for this reference
                 remove(by: reference)
                 // Check to see if the targetTime is before the first entry before it's added
@@ -348,14 +354,19 @@ extension NetworkContext {
         init(globals: Globals) {
             self.globals = globals
         }
+        /// Runs an immediate task, scheduled from the scheduler's context (so the completion is non-sendable).
+        /// No assumptions are made about how the task is run.
+        func runImmediateIsolated(_ task: @escaping () -> Void) {
+            globals.queue.async(execute: DispatchWorkItem(block: task))
+        }
         /// Runs an immediate task. No assumptions are made about how the task is run.
-        func runImmediate(_ task: @escaping (() -> Void)) {
+        func runImmediate(_ task: @Sendable @escaping () -> Void) {
             globals.queue.async(execute: DispatchWorkItem(block: task))
         }
         /// Schedules a task to run after a delay, using a reference.
         ///
         /// The `milliseconds` parameter specifies the delay before the task runs.
-        func schedule(_ task: @escaping (() -> Void), milliseconds: Int64, reference: TimerReference) {
+        func schedule(_ task: @escaping () -> Void, milliseconds: Int64, reference: TimerReference) {
             let targetTime = DispatchTime.now() + DispatchTimeInterval.milliseconds(Int(milliseconds))
             globals.timerList.insert(targetTime: targetTime, reference: reference, task: task)
         }
@@ -380,11 +391,18 @@ extension NetworkContext {
         globals.queue
     }
 
-    public func async(_ block: @escaping () -> Void) {
+    public func async(_ block: @Sendable @escaping () -> Void) {
         scheduler.runImmediate(block)
     }
 
-    public func barrierAsync(_ block: @escaping () -> Void) {
+    public func isolatedAsync(_ block: @escaping () -> Void) {
+        #if DEBUG
+        assert()
+        #endif
+        scheduler.runImmediateIsolated(block)
+    }
+
+    public func barrierAsync(_ block: @Sendable @escaping () -> Void) {
         scheduler.runImmediate(block)
     }
 

--- a/Sources/SwiftNetwork/EndpointFlow/EndpointFlow.swift
+++ b/Sources/SwiftNetwork/EndpointFlow/EndpointFlow.swift
@@ -32,7 +32,7 @@ internal import Synchronization
 #endif
 
 @available(Network 0.1.0, *)
-final class EndpointFlow: CustomDebugStringConvertible {
+final class EndpointFlow: CustomDebugStringConvertible, @unchecked Sendable {
 
     /// State used to emit logs on the data path.
     public var log = NetworkLoggerState()
@@ -269,7 +269,7 @@ final class EndpointFlow: CustomDebugStringConvertible {
         }
     }
 
-    func async(_ block: @escaping () -> Void) {
+    func async(_ block: @Sendable @escaping () -> Void) {
         self.parameters.context.async(block)
     }
 

--- a/Sources/SwiftNetwork/EndpointFlow/ReadRequest.swift
+++ b/Sources/SwiftNetwork/EndpointFlow/ReadRequest.swift
@@ -13,11 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 @available(Network 0.1.0, *)
-struct ReadRequest {
+struct ReadRequest: Sendable {
     let minimumBytes: Int
     let maximumBytes: Int
     let maximumFrames: Int
-    let completion: ([UInt8]?, Bool, Bool, NetworkError?) -> Void
+    let completion: @Sendable ([UInt8]?, Bool, Bool, NetworkError?) -> Void
 
     func complete(content: [UInt8]?, isComplete: Bool, isFinal: Bool, error: NetworkError? = nil) {
         completion(content, isComplete, isFinal, error)

--- a/Sources/SwiftNetwork/Protocols/IPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/IPProtocol.swift
@@ -55,7 +55,7 @@ public struct IPProtocol: NetworkProtocol {
         // Destination Address: UInt128
     }
 
-    public enum Version: UInt8 {
+    public enum Version: UInt8, Sendable {
         /// Allows any IP version.
         case any = 0
         /// Uses only IP version 4 (IPv4).
@@ -64,7 +64,7 @@ public struct IPProtocol: NetworkProtocol {
         case v6 = 6
     }
 
-    public enum AddressPreference: UInt8 {
+    public enum AddressPreference: UInt8, Sendable {
         case any = 0
         case temporary = 1
         case stable = 2

--- a/Sources/SwiftNetwork/Protocols/ProtocolEventManager.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolEventManager.swift
@@ -520,7 +520,7 @@ extension NetworkContext {
 
     fileprivate func async(index: NetworkStateIndex, _ block: @escaping () -> Void) {
         self.softAssert()
-        self.async {
+        self.isolatedAsync {
             self.protocolEventStates[index].startAsyncCall()
             defer {
                 self.protocolEventStates[index].finishAsyncCall()

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -4023,7 +4023,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             else {
                 return
             }
-            context.async {
+            self.async {
                 var flowType: QLogFlowType = .client
                 var applicationType = "client"
                 if self.isServer {
@@ -5253,7 +5253,7 @@ extension QUICConnection {
         }
         asyncSendRunning = true
         log.datapath("async: scheduling restart after packet burst")
-        self.context.async {
+        self.async {
             self.resumeSendingAfterBurstLimit()
         }
     }

--- a/Sources/SwiftNetworkBenchmarks/BenchmarkUtility.swift
+++ b/Sources/SwiftNetworkBenchmarks/BenchmarkUtility.swift
@@ -72,7 +72,7 @@ public struct QUICLoopbackState {
 
 @_spi(ProtocolProvider)
 @available(Network 0.1.0, *)
-public struct QUICClientEndpointResult {
+public struct QUICClientEndpointResult: @unchecked Sendable {
     public var instance: QUICConnection
     public var parameters: Parameters
     public var upperHandler: StreamUpperHarness
@@ -82,7 +82,7 @@ public struct QUICClientEndpointResult {
 
 @_spi(ProtocolProvider)
 @available(Network 0.1.0, *)
-public struct QUICServerEndpointResult {
+public struct QUICServerEndpointResult: @unchecked Sendable {
     public var instance: QUICConnection
     public var parameters: Parameters
     public var upperHandler: NewStreamFlowHarness
@@ -96,12 +96,12 @@ public enum BenchmarkError: Error {
 
 @_spi(ProtocolProvider)
 @available(Network 0.1.0, *)
-public final class QUICBenchmarkUtility {
+public final class QUICBenchmarkUtility: Sendable {
 
     // 127.0.0.1 (Just point both at loopback)
     public static let localIPv4Address: [UInt8] = [0x7f, 0x00, 0x00, 0x01]
     public static let remoteIPv4Address: [UInt8] = [0x7f, 0x00, 0x00, 0x01]
-    var serverSigningKey = P256.Signing.PrivateKey()
+    let serverSigningKey = P256.Signing.PrivateKey()
 
     public func createQUICTestOptions(
         server: Bool = false,
@@ -265,7 +265,7 @@ public final class QUICBenchmarkUtility {
 #if !(os(Linux) || NETWORK_EMBEDDED)
 @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 #endif
-public struct LoggingHandle: CustomStringConvertible {
+public struct LoggingHandle: CustomStringConvertible, Sendable {
     #if os(Linux) || NETWORK_EMBEDDED
     let logger = Logger(label: "com.apple.network.benchmarks")
     #else
@@ -273,12 +273,12 @@ public struct LoggingHandle: CustomStringConvertible {
     let logger = Logger(subsystem: "com.apple.network.benchmarks", category: "perf")
     #endif
     #endif
-    public enum LoggingType: Int {
+    public enum LoggingType: Int, Sendable {
         case none = 0
         case print = 1
         case log = 2
     }
-    public var loggingType: LoggingType = .none
+    public let loggingType: LoggingType
 
     public init(loggingType: LoggingType) {
         self.loggingType = loggingType
@@ -322,7 +322,7 @@ public struct LoggingHandle: CustomStringConvertible {
 
 @_spi(ProtocolProvider)
 @available(Network 0.1.0, *)
-public final class DataBenchmarkUtility {
+public final class DataBenchmarkUtility: Sendable {
     @discardableResult
     public func loopOutputHandlerPackets(
         sender: DatagramLowerHarness,

--- a/Sources/Tools/IPUDPTransfer/main.swift
+++ b/Sources/Tools/IPUDPTransfer/main.swift
@@ -27,7 +27,7 @@ internal import os
 #endif
 
 @available(Network 0.1.0, *)
-final class IPUDPTransfer {
+final class IPUDPTransfer: @unchecked Sendable {
 
     // 169.254.156.146
     let localIPv4Address: [UInt8] = [0xa9, 0xfe, 0x9c, 0x92]
@@ -37,14 +37,14 @@ final class IPUDPTransfer {
     let dataBenchmarkUtility = DataBenchmarkUtility()
     let NSEC_PER_MSEC = UInt64(Duration.milliseconds(1) / Duration.nanoseconds(1))
 
+    var iterationIndex = 0
+
     func run(iterations: Int, packets: Int, loggingHandle: LoggingHandle, group: DispatchGroup, sendSize: Int) -> Double
     {
-        let ipv4Client = Endpoint(address: IPv4Address(localIPv4Address)!, port: 0)
-        let ipv4Server = Endpoint(address: IPv4Address(remoteIPv4Address)!, port: 0)
         // Create a random payload to send back and forth
-        var payload = [UInt8](repeating: 0, count: sendSize)
-        payload = (0..<sendSize).map { _ in UInt8.random(in: 0...255) }
-        var iterationIndex = 0
+        var mutablePayload = [UInt8](repeating: 0, count: sendSize)
+        mutablePayload = (0..<sendSize).map { _ in UInt8.random(in: 0...255) }
+        let payload = mutablePayload
         print(
             "Running IP/UDP transfer, transferring \(iterations) iteration\(iterations > 1 ? "s" : "") of \(packets) packet\(packets > 1 ? "s" : "")"
         )
@@ -53,11 +53,15 @@ final class IPUDPTransfer {
         // NOTE: Today this benchmark relies on DispatchGroups due to Sendability issues on some of the project types.
         // In the future we should try to adopt Swift Concurrency.
         group.enter()
-        var clientParameters = Parameters()
         let context = NetworkContext(identifier: "IPUDPTransfer")
-        clientParameters.context = context
         context.activate()
         context.async {
+            let ipv4Client = Endpoint(address: IPv4Address(self.localIPv4Address)!, port: 0)
+            let ipv4Server = Endpoint(address: IPv4Address(self.remoteIPv4Address)!, port: 0)
+
+            var clientParameters = Parameters()
+            clientParameters.context = context
+
             for _ in 0..<iterations {
                 // Client
                 let path = PathProperties(parameters: clientParameters)
@@ -185,7 +189,7 @@ final class IPUDPTransfer {
                 serverInput.stop()
                 serverInput.teardown()
 
-                iterationIndex += 1
+                self.iterationIndex += 1
             }
             group.leave()
         }

--- a/Sources/Tools/QUICHandshake/main.swift
+++ b/Sources/Tools/QUICHandshake/main.swift
@@ -29,7 +29,7 @@ internal import os
 #if IMPORT_SWIFTTLS && canImport(SwiftTLS)
 
 @available(Network 0.1.0, *)
-final class QUICHandshake {
+final class QUICHandshake: @unchecked Sendable {
 
     let quicBenchmarkUtility = QUICBenchmarkUtility()
     let dataBenchmarkUtility = DataBenchmarkUtility()
@@ -137,7 +137,7 @@ final class QUICHandshake {
                     }
                 }
                 // Wait until both instances are connected to signal handshake complete
-                func pollForConnectedInstances() {
+                @Sendable func pollForConnectedInstances() {
                     // Wait for the client connection state to go into connected
                     if client.instance.state == .connected {
                         loggingHandle.log("Client connection handshake finished")

--- a/Sources/Tools/QUICStreamLoad/main.swift
+++ b/Sources/Tools/QUICStreamLoad/main.swift
@@ -35,7 +35,7 @@ import Crypto
 #if IMPORT_SWIFTTLS && canImport(SwiftTLS)
 
 @available(Network 0.1.0, *)
-final class QUICStreamLoad {
+final class QUICStreamLoad: @unchecked Sendable {
 
     // 169.254.156.146
     let localIPv4Address: [UInt8] = [0xa9, 0xfe, 0x9c, 0x92]
@@ -55,8 +55,8 @@ final class QUICStreamLoad {
         downloadSize: Int,
         linkDelay: NetworkDuration
     ) -> NetworkDuration {
-        let ipv4Client = Endpoint(address: IPv4Address(localIPv4Address)!, port: 1234)
-        let ipv4Server = Endpoint(address: IPv4Address(remoteIPv4Address)!, port: 2345)
+        nonisolated(unsafe) let ipv4Client = Endpoint(address: IPv4Address(localIPv4Address)!, port: 1234)
+        nonisolated(unsafe) let ipv4Server = Endpoint(address: IPv4Address(remoteIPv4Address)!, port: 2345)
 
         var uploadPayload = [UInt8](repeating: 0, count: uploadSize)
         uploadPayload = (0..<uploadSize).map { _ in UInt8.random(in: 0...255) }
@@ -68,23 +68,23 @@ final class QUICStreamLoad {
         )
         let startTime = NetworkClock.Instant.now
 
-        var handshakeDuration = NetworkDuration.zero
+        nonisolated(unsafe) var handshakeDuration = NetworkDuration.zero
         var streamRoundTripDurations = [NetworkDuration]()
 
-        var clientInput: NewStreamFlowHarness? = nil
-        var clientListenerLinkage: StreamListenerLinkage? = nil
-        var serverInput: NewStreamFlowHarness? = nil
+        nonisolated(unsafe) var clientInput: NewStreamFlowHarness? = nil
+        nonisolated(unsafe) var clientListenerLinkage: StreamListenerLinkage? = nil
+        nonisolated(unsafe) var serverInput: NewStreamFlowHarness? = nil
 
         group.enter()
-        var clientParameters = Parameters()
+        nonisolated(unsafe) var clientParameters = Parameters()
         let context = NetworkContext(identifier: "QUICStreamLoad")
         clientParameters.context = context
-        let path = PathProperties(parameters: clientParameters)
+        nonisolated(unsafe) let path = PathProperties(parameters: clientParameters)
 
-        var serverParameters = Parameters()
+        nonisolated(unsafe) var serverParameters = Parameters()
         serverParameters.isServer = true
         serverParameters.context = context
-        let serverPath = PathProperties(parameters: serverParameters)
+        nonisolated(unsafe) let serverPath = PathProperties(parameters: serverParameters)
 
         context.activate()
         context.async {
@@ -257,13 +257,15 @@ final class QUICStreamLoad {
         guard let serverInput, let clientInput, let clientListenerLinkage else {
             return .zero
         }
+        nonisolated(unsafe) let unsafeServerInput = serverInput
+        nonisolated(unsafe) let unsafeClientListenerLinkage = clientListenerLinkage
 
         var index = 0
         for _ in 0..<streamCount {
             group.enter()
         }
 
-        var testStreamBlock: (() -> Void)? = nil
+        nonisolated(unsafe) var testStreamBlock: (() -> Void)? = nil
 
         testStreamBlock = {
             guard index < streamCount else { return }
@@ -280,7 +282,7 @@ final class QUICStreamLoad {
                 parameters: clientParameters,
                 path: path,
                 context: context,
-                listenerProtocol: clientListenerLinkage
+                listenerProtocol: unsafeClientListenerLinkage
             )
             guard let clientStream else {
                 group.leave()
@@ -292,8 +294,8 @@ final class QUICStreamLoad {
             var serverStreamToTeardown: StreamUpperHarness? = nil
 
             // Get new server stream
-            serverInput.waitForNewFlow {
-                guard let serverStream = serverInput.upperHarnesses.last else {
+            unsafeServerInput.waitForNewFlow {
+                guard let serverStream = unsafeServerInput.upperHarnesses.last else {
                     group.leave()
                     return
                 }
@@ -375,9 +377,10 @@ final class QUICStreamLoad {
 
         // Kick off first round of streams. Each stream will in turn kick another.
         if let testStreamBlock {
+            nonisolated(unsafe) let unsafeTestStreamBlock = testStreamBlock
             context.async {
                 for _ in 0..<concurrentStreams {
-                    testStreamBlock()
+                    unsafeTestStreamBlock()
                 }
             }
         }
@@ -389,11 +392,13 @@ final class QUICStreamLoad {
         print("Completed \(index) / \(streamCount) streams")
 
         group.enter()
+        nonisolated(unsafe) let unsafeClientInputTeardown = clientInput
+        nonisolated(unsafe) let unsafeServerInputTeardown = serverInput
         context.async {
-            clientInput.stop()
-            clientInput.teardown()
-            serverInput.stop()
-            serverInput.teardown()
+            unsafeClientInputTeardown.stop()
+            unsafeClientInputTeardown.teardown()
+            unsafeServerInputTeardown.stop()
+            unsafeServerInputTeardown.teardown()
             group.leave()
         }
         group.wait()

--- a/Sources/Tools/QUICTransfer/main.swift
+++ b/Sources/Tools/QUICTransfer/main.swift
@@ -35,7 +35,7 @@ import Crypto
 #if IMPORT_SWIFTTLS && canImport(SwiftTLS)
 
 @available(Network 0.1.0, *)
-final class QUICTransfer {
+final class QUICTransfer: @unchecked Sendable {
 
     // 169.254.156.146
     let localIPv4Address: [UInt8] = [0xa9, 0xfe, 0x9c, 0x92]
@@ -45,7 +45,12 @@ final class QUICTransfer {
     let dataBenchmarkUtility = DataBenchmarkUtility()
     let quicBenchmakrUtility = QUICBenchmarkUtility()
     let NSEC_PER_MSEC = UInt64(Duration.milliseconds(1) / Duration.nanoseconds(1))
-    var serverSigningKey = P256.Signing.PrivateKey()
+    let serverSigningKey = P256.Signing.PrivateKey()
+
+    var clientStream: StreamUpperHarness? = nil
+    var clientInput: NewStreamFlowHarness? = nil
+    var serverInput: NewStreamFlowHarness? = nil
+    var serverStream: StreamUpperHarness? = nil
 
     func run(
         iterations: Int,
@@ -54,30 +59,30 @@ final class QUICTransfer {
         sendSize: Int,
         linkDelay: NetworkDuration = .zero
     ) -> Double {
-        let ipv4Client = Endpoint(address: IPv4Address(localIPv4Address)!, port: 1234)
-        let ipv4Server = Endpoint(address: IPv4Address(remoteIPv4Address)!, port: 2345)
-        var clientStream: StreamUpperHarness? = nil
-        var clientInput: NewStreamFlowHarness? = nil
-        var serverInput: NewStreamFlowHarness? = nil
         // Create a random payload to send back and forth
-        var payload = [UInt8](repeating: 0, count: sendSize)
-        payload = (0..<sendSize).map { _ in UInt8.random(in: 0...255) }
-        var index = 0
+        var mutablePayload = [UInt8](repeating: 0, count: sendSize)
+        mutablePayload = (0..<sendSize).map { _ in UInt8.random(in: 0...255) }
+        let payload = mutablePayload
+        nonisolated(unsafe) var index = 0
         print("Running QUIC transfer, transferring \(iterations) packet\(iterations > 1 ? "s" : "")")
         let timestart = DispatchTime.now().uptimeNanoseconds
 
         group.enter()
-        var clientParameters = Parameters()
         let context = NetworkContext(identifier: "QUICTransfer")
-        clientParameters.context = context
-        let path = PathProperties(parameters: clientParameters)
-
-        var serverParameters = Parameters()
-        serverParameters.isServer = true
-        serverParameters.context = context
 
         context.activate()
         context.async {
+            let ipv4Client = Endpoint(address: IPv4Address(self.localIPv4Address)!, port: 1234)
+            let ipv4Server = Endpoint(address: IPv4Address(self.remoteIPv4Address)!, port: 2345)
+
+            var clientParameters = Parameters()
+            clientParameters.context = context
+            let path = PathProperties(parameters: clientParameters)
+
+            var serverParameters = Parameters()
+            serverParameters.isServer = true
+            serverParameters.context = context
+
             // Client
             let clientIP = IPProtocol.instance(context: clientParameters.context)
             let clientIPOptions = IPProtocol.options()
@@ -112,7 +117,7 @@ final class QUICTransfer {
             clientParameters.defaultStack.link = .custom(bridgeOptions)
 
             let clientListenerLinkage = StreamListenerLinkage(reference: clientQUIC)
-            clientInput = NewStreamFlowHarness(
+            self.clientInput = NewStreamFlowHarness(
                 identifier: "Client",
                 local: ipv4Client,
                 remote: ipv4Server,
@@ -122,7 +127,7 @@ final class QUICTransfer {
                 listenerProtocol: clientListenerLinkage
             )
 
-            clientStream = StreamUpperHarness(
+            self.clientStream = StreamUpperHarness(
                 identifier: "C1",
                 local: ipv4Client,
                 remote: ipv4Server,
@@ -131,7 +136,7 @@ final class QUICTransfer {
                 context: context,
                 listenerProtocol: clientListenerLinkage
             )
-            guard let clientInput else {
+            guard self.clientInput != nil else {
                 group.leave()
                 return
             }
@@ -196,7 +201,7 @@ final class QUICTransfer {
             serverParameters.defaultStack.link = .custom(serverBridgeOptions)
 
             let serverListenerLinkage = StreamListenerLinkage(reference: serverQUIC)
-            serverInput = NewStreamFlowHarness(
+            self.serverInput = NewStreamFlowHarness(
                 identifier: "Server",
                 local: ipv4Server,
                 remote: ipv4Client,
@@ -206,7 +211,7 @@ final class QUICTransfer {
                 listenerProtocol: serverListenerLinkage
             )
 
-            guard let serverInput else {
+            guard self.serverInput != nil else {
                 group.leave()
                 return
             }
@@ -238,33 +243,33 @@ final class QUICTransfer {
                 group.leave()
                 return
             }
-            serverInput.start { connected in
+            self.serverInput!.start { connected in
                 // Server connected event
                 group.leave()
             }
-            clientInput.start()
-            clientStream?.start()
+            self.clientInput!.start()
+            self.clientStream?.start()
         }
         group.wait()
-        guard let serverInput, let clientInput, let clientStream else {
+        guard self.serverInput != nil, self.clientInput != nil, self.clientStream != nil else {
             return 0
         }
-        var serverStream: StreamUpperHarness?
 
-        var totalReadSize = 0
+        nonisolated(unsafe) var totalReadSize = 0
         while index < iterations {
+            let indexToLog = index
             group.enter()
             context.async {
-                guard clientStream.write(payload) else {
-                    loggingHandle.log("Client failed to write at iteration: \(index)")
+                guard self.clientStream!.write(payload) else {
+                    loggingHandle.log("Client failed to write at iteration: \(indexToLog)")
                     group.leave()
                     return
                 }
-                if serverStream == nil {
+                if self.serverStream == nil {
                     group.enter()
-                    serverInput.waitForNewFlow {
+                    self.serverInput!.waitForNewFlow {
                         loggingHandle.log("Server got new inbound flow")
-                        serverStream = serverInput.upperHarnesses.last
+                        self.serverStream = self.serverInput!.upperHarnesses.last
                         group.leave()
                     }
                 }
@@ -272,7 +277,7 @@ final class QUICTransfer {
             }
             group.wait()
 
-            guard let serverStream else {
+            guard self.serverStream != nil else {
                 return 0
             }
 
@@ -281,7 +286,7 @@ final class QUICTransfer {
                 var serverReadDataSizeForIteration = 0
                 var serverReadCompletion: ((Bool) -> Void)? = nil
                 serverReadCompletion = { _ in
-                    let readBytes = serverStream.readAndDrop()
+                    let readBytes = self.serverStream!.readAndDrop()
                     if readBytes > 0 {
                         serverReadDataSizeForIteration += readBytes
                         totalReadSize += readBytes
@@ -291,21 +296,21 @@ final class QUICTransfer {
                         index += 1
                         group.leave()
                     } else {
-                        serverStream.waitForInboundDataAvailable(completion: serverReadCompletion!)
+                        self.serverStream!.waitForInboundDataAvailable(completion: serverReadCompletion!)
                     }
                 }
-                serverStream.waitForInboundDataAvailable(completion: serverReadCompletion!)
+                self.serverStream!.waitForInboundDataAvailable(completion: serverReadCompletion!)
             }
             group.wait()
         }
 
         group.enter()
         context.async {
-            clientStream.stop()
-            clientInput.stop()
-            clientInput.teardown()
-            serverInput.stop()
-            serverInput.teardown()
+            self.clientStream!.stop()
+            self.clientInput!.stop()
+            self.clientInput!.teardown()
+            self.serverInput!.stop()
+            self.serverInput!.teardown()
             group.leave()
         }
         group.wait()

--- a/Tests/QUICTests/QLogTests.swift
+++ b/Tests/QUICTests/QLogTests.swift
@@ -23,8 +23,11 @@ import XCTest
 #endif
 
 #if QlogOutput
+
+@available(Network 0.1.0, *)
 let qlogTestsLogPrefixer = LogPrefixer("[QLogTests]")
 
+@available(Network 0.1.0, *)
 final class QLogTests: XCTestCase {
     var qlog: QLog = QLog()
 

--- a/Tests/QUICTests/QUICConnectionTests.swift
+++ b/Tests/QUICTests/QUICConnectionTests.swift
@@ -23,7 +23,7 @@ import XCTest
 #endif
 
 @available(Network 0.1.0, *)
-final class QUICConnectionTests: XCTestCase {
+final class QUICConnectionTests: XCTestCase, @unchecked Sendable {
     var connection: QUICConnection!
     override func setUp() {
         connection = QUICConnection(context: NetworkContext.implicitContext)

--- a/Tests/QUICTests/QUICStreamZombiesTests.swift
+++ b/Tests/QUICTests/QUICStreamZombiesTests.swift
@@ -23,7 +23,7 @@ import XCTest
 #endif
 
 @available(Network 0.1.0, *)
-final class QUICStreamZombieListTests: XCTestCase {
+final class QUICStreamZombieListTests: XCTestCase, @unchecked Sendable {
     var zombieList = QUICStreamZombieList()
 
     func testAppend() {

--- a/Tests/QUICTests/RecoveryTests.swift
+++ b/Tests/QUICTests/RecoveryTests.swift
@@ -31,7 +31,7 @@ internal import DequeModule
 let recoveryTestsLogPrefixer: LogPrefixer = LogPrefixer("[RecoveryTests]")
 
 @available(Network 0.1.0, *)
-final class RecoveryTests: XCTestCase {
+final class RecoveryTests: XCTestCase, @unchecked Sendable {
     var connection = QUICConnection(context: .implicitContext)
     var path: QUICPath! = nil
 
@@ -571,7 +571,7 @@ final class RecoveryTests: XCTestCase {
         packet.transmittedItems.ping = true
         let sentPath = connection.currentPath?.identifier ?? .none
         packet.sentPath = sentPath
-        var timeNow = NetworkClock.Instant.now
+        nonisolated(unsafe) var timeNow = NetworkClock.Instant.now
         sentPacket(packet, connection: connection)
         XCTAssertEqual(
             connection.recovery.getLargestSentPN(packetNumberSpace: .initial),
@@ -591,7 +591,7 @@ final class RecoveryTests: XCTestCase {
         XCTAssertGreaterThan(connection.recovery.computedTimeout, .milliseconds(900))
 
         var expectation = XCTestExpectation()
-        self.connection.context.async {
+        self.connection.context.async { [expectation] in
             timeNow = timeNow.advanced(by: .seconds(1))
             self.connection.recovery.timerFired(timeNow: timeNow)
             expectation.fulfill()
@@ -612,7 +612,7 @@ final class RecoveryTests: XCTestCase {
         XCTAssertGreaterThan(connection.recovery.computedTimeout, .milliseconds(1900))
 
         expectation = XCTestExpectation()
-        self.connection.context.async {
+        self.connection.context.async { [expectation] in
             timeNow = timeNow.advanced(by: .seconds(2))
             self.connection.recovery.timerFired(timeNow: timeNow)
             expectation.fulfill()
@@ -633,7 +633,7 @@ final class RecoveryTests: XCTestCase {
         XCTAssertGreaterThan(connection.recovery.computedTimeout, .milliseconds(3900))
 
         expectation = XCTestExpectation()
-        self.connection.context.async {
+        self.connection.context.async { [expectation] in
             timeNow = timeNow.advanced(by: .seconds(4))
             self.connection.recovery.timerFired(timeNow: timeNow)
             expectation.fulfill()

--- a/Tests/SwiftNetworkTests/QUICTestHarness.swift
+++ b/Tests/SwiftNetworkTests/QUICTestHarness.swift
@@ -50,7 +50,7 @@ internal import os
 #if canImport(SwiftTLS)
 
 @available(Network 0.1.0, *)
-final class QUICTestHarness {
+final class QUICTestHarness: @unchecked Sendable {
     // 127.0.0.1
     static let clientIPv4Address: [UInt8] = [0x7f, 0x00, 0x00, 0x01]
     static let serverIPv4Address: [UInt8] = [0x7f, 0x00, 0x00, 0x01]
@@ -140,12 +140,16 @@ final class QUICTestHarness {
         clientOptions: ProtocolOptions<QUICProtocol> = QUICProtocol.options(),
         serverOptions: ProtocolOptions<QUICProtocol> = QUICProtocol.options()
     ) throws(NetworkError) {
-        var clientConnected = false
-        var serverConnected = false
+        nonisolated(unsafe) let clientOptions = clientOptions
+        nonisolated(unsafe) let serverOptions = serverOptions
+        nonisolated(unsafe) let clientDrops = clientDrops
+        nonisolated(unsafe) let serverDrops = serverDrops
+        nonisolated(unsafe) var clientConnected = false
+        nonisolated(unsafe) var serverConnected = false
         let handshakeExpectation = XCTestExpectation(description: "Wait for QUIC connection to be established")
 
-        var matchedError = false
-        var receivedError: NetworkError? = nil
+        nonisolated(unsafe) var matchedError = false
+        nonisolated(unsafe) var receivedError: NetworkError? = nil
 
         // Async onto the context to attach the protocol stack and start the handshake
         context.async {
@@ -370,25 +374,26 @@ final class QUICTestHarness {
             XCTFail("No instance found")
             return nil
         }
-        var upperHarnessConnected = false
-        var parameters = Parameters()
-        parameters.context = context
+        nonisolated(unsafe) let unsafeInstance = instance
+        nonisolated(unsafe) var upperHarnessConnected = false
 
-        var upperHarness: StreamUpperHarness?
+        nonisolated(unsafe) var upperHarness: StreamUpperHarness?
         let newStreamExpectation = XCTestExpectation(description: "Wait for new QUIC stream to be ready")
-        let options = quicOptions.deepCopy()
+        nonisolated(unsafe) let options = quicOptions.deepCopy()
         context.async {
+            var parameters = Parameters()
+            parameters.context = self.context
             options.setLogID(
                 prefix: identifier,
                 parent: "",
                 protocolLogIDNumber: 1
             )
-            options.setProtocolInstance(instance.reference)
+            options.setProtocolInstance(unsafeInstance.reference)
             parameters.defaultStack.transport = .custom(options)
             var path = PathProperties(parameters: parameters)
             path.effectiveMTU = 1500
 
-            let listenerLinkage = StreamListenerLinkage(reference: instance.reference)
+            let listenerLinkage = StreamListenerLinkage(reference: unsafeInstance.reference)
             let streamUpperHarness = StreamUpperHarness(
                 identifier: identifier,
                 local: self.clientEndpoint,
@@ -409,8 +414,9 @@ final class QUICTestHarness {
                 newStreamExpectation.fulfill()
                 return
             }
+            nonisolated(unsafe) let unsafeUpperHarness = upperHarness
 
-            upperHarness.start { connected in
+            unsafeUpperHarness.start { connected in
                 if connected {
                     upperHarnessConnected = true
                     newStreamExpectation.fulfill()
@@ -444,25 +450,26 @@ final class QUICTestHarness {
             XCTFail("No instance found")
             return nil
         }
-        var upperHarnessConnected = false
-        var parameters = Parameters()
-        parameters.context = context
+        nonisolated(unsafe) let unsafeInstance = instance
+        nonisolated(unsafe) var upperHarnessConnected = false
 
-        var upperHarness: DatagramUpperHarness?
+        nonisolated(unsafe) var upperHarness: DatagramUpperHarness?
         let newFlowExpectation = XCTestExpectation(description: "Wait for new QUIC datagram flow to be ready")
-        let options = quicOptions.deepCopy()
+        nonisolated(unsafe) let options = quicOptions.deepCopy()
         context.async {
+            var parameters = Parameters()
+            parameters.context = self.context
             options.setLogID(
                 prefix: identifier,
                 parent: "",
                 protocolLogIDNumber: 1
             )
-            options.setProtocolInstance(instance.reference)
+            options.setProtocolInstance(unsafeInstance.reference)
             parameters.defaultStack.transport = .custom(options)
             var path = PathProperties(parameters: parameters)
             path.effectiveMTU = 1500
 
-            let listenerLinkage = DatagramListenerLinkage(reference: instance.reference)
+            let listenerLinkage = DatagramListenerLinkage(reference: unsafeInstance.reference)
             let datagramUpperHarness = DatagramUpperHarness(
                 identifier: identifier,
                 local: self.clientEndpoint,
@@ -483,8 +490,9 @@ final class QUICTestHarness {
                 newFlowExpectation.fulfill()
                 return
             }
+            nonisolated(unsafe) let unsafeUpperHarness = upperHarness
 
-            upperHarness.start { connected in
+            unsafeUpperHarness.start { connected in
                 if connected {
                     upperHarnessConnected = true
                     newFlowExpectation.fulfill()
@@ -511,12 +519,13 @@ final class QUICTestHarness {
             XCTFail("State must be non-nil")
             return
         }
+        nonisolated(unsafe) let unsafeState = state
         let idleCompleteExpectation = XCTestExpectation(description: "Wait for marking idle")
         context.async {
-            for upperHarness in state.clientHarness.upperHarnesses {
+            for upperHarness in unsafeState.clientHarness.upperHarnesses {
                 upperHarness.invokeConnectionIdleEvent()
             }
-            for upperHarness in state.serverHarness.upperHarnesses {
+            for upperHarness in unsafeState.serverHarness.upperHarnesses {
                 upperHarness.invokeConnectionIdleEvent()
             }
             idleCompleteExpectation.fulfill()
@@ -529,14 +538,15 @@ final class QUICTestHarness {
             XCTFail("State must be non-nil")
             return
         }
+        nonisolated(unsafe) let unsafeState = state
         let stopCompleteExpectation = XCTestExpectation(description: "Wait for stop/teardown to complete")
         context.async {
-            state.clientHarness.stop()
-            state.serverHarness.stop()
-            state.serverDatagramHarness?.stop()
-            state.clientHarness.teardown()
-            state.serverHarness.teardown()
-            state.serverDatagramHarness?.teardown()
+            unsafeState.clientHarness.stop()
+            unsafeState.serverHarness.stop()
+            unsafeState.serverDatagramHarness?.stop()
+            unsafeState.clientHarness.teardown()
+            unsafeState.serverHarness.teardown()
+            unsafeState.serverDatagramHarness?.teardown()
             stopCompleteExpectation.fulfill()
             self.state = nil
         }
@@ -563,14 +573,15 @@ final class QUICTestHarness {
         let clientReadExpectation = XCTestExpectation(description: "Wait for client to read response")
 
         let serverStreamExpectation = XCTestExpectation(description: "Wait for server to receive stream")
-        let clientStreamHarness = state.clientHarness.upperHarnesses[streamIndex]
+        nonisolated(unsafe) let clientStreamHarness = state.clientHarness.upperHarnesses[streamIndex]
+        nonisolated(unsafe) let unsafeState = state
 
-        var serverStreamHarness: StreamUpperHarness? = nil
+        nonisolated(unsafe) var serverStreamHarness: StreamUpperHarness? = nil
 
         // Set up waiting for a server stream
         context.async {
-            state.serverHarness.waitForNewFlow {
-                guard let serverStream = state.serverHarness.upperHarnesses.last else {
+            unsafeState.serverHarness.waitForNewFlow {
+                guard let serverStream = unsafeState.serverHarness.upperHarnesses.last else {
                     serverStreamExpectation.fulfill()
                     return
                 }
@@ -598,10 +609,11 @@ final class QUICTestHarness {
         wait(for: [serverStreamExpectation], timeout: timeout)
         XCTAssertNotNil(serverStreamHarness)
         guard let serverStreamHarness else { return }
+        nonisolated(unsafe) let unsafeServerStreamHarness = serverStreamHarness
 
         // Block for reading on the client
-        var clientReadBytes = 0
-        var clientReadHandler: ((Bool) -> Void)? = nil
+        nonisolated(unsafe) var clientReadBytes = 0
+        nonisolated(unsafe) var clientReadHandler: ((Bool) -> Void)? = nil
         // The read handlers capture themselves: each re-registers via
         // `waitForInboundDataAvailable`, which stores the closure on the
         // harness's completions. Break the retain cycle.
@@ -638,20 +650,20 @@ final class QUICTestHarness {
         }
 
         // Block for reading on the server
-        var serverReadBytes = 0
-        var serverReadHandler: ((Bool) -> Void)? = nil
+        nonisolated(unsafe) var serverReadBytes = 0
+        nonisolated(unsafe) var serverReadHandler: ((Bool) -> Void)? = nil
         defer { serverReadHandler = nil }
         serverReadHandler = { hasData in
             defer {
                 if hasData {
                     // Schedule a follow-on read
-                    serverStreamHarness.waitForInboundDataAvailable { success in
+                    unsafeServerStreamHarness.waitForInboundDataAvailable { success in
                         serverReadHandler?(success)
                     }
                 }
             }
 
-            while let response = serverStreamHarness.read() {
+            while let response = unsafeServerStreamHarness.read() {
                 do {
                     try dataGenerator.validate(at: serverReadBytes, data: response)
                 } catch {
@@ -661,18 +673,18 @@ final class QUICTestHarness {
                 }
                 serverReadBytes += response.count
 
-                let receivedFIN = serverStreamHarness.receivedFIN
-                let writeResult = serverStreamHarness.write(response, sendFIN: receivedFIN)
+                let receivedFIN = unsafeServerStreamHarness.receivedFIN
+                let writeResult = unsafeServerStreamHarness.write(response, sendFIN: receivedFIN)
                 XCTAssertTrue(writeResult, "Server failed send response")
             }
 
             if serverReadBytes >= dataGenerator.totalSize {
                 if dataGenerator.sendFIN {
-                    let receivedFIN = serverStreamHarness.receivedFIN
+                    let receivedFIN = unsafeServerStreamHarness.receivedFIN
                     XCTAssertTrue(receivedFIN, "Server failed to receive FIN from client")
                 }
-                if serverStreamHarness.receivedFIN {
-                    serverStreamHarness.stop()
+                if unsafeServerStreamHarness.receivedFIN {
+                    unsafeServerStreamHarness.stop()
                 }
                 serverReadExpectation.fulfill()
                 return
@@ -695,7 +707,7 @@ final class QUICTestHarness {
                 clientStreamHarness.waitForDisconnected {
                     clientDisconnectedExpectation.fulfill()
                 }
-                serverStreamHarness.waitForDisconnected {
+                unsafeServerStreamHarness.waitForDisconnected {
                     serverDisconnectedExpectation.fulfill()
                 }
             }
@@ -718,19 +730,20 @@ final class QUICTestHarness {
             XCTFail("Server datagram harness must be non-nil")
             return
         }
+        nonisolated(unsafe) let unsafeServerDatagramHarness = serverDatagramHarness
 
         let serverReadExpectation = XCTestExpectation(description: "Wait for server to read request")
         let clientReadExpectation = XCTestExpectation(description: "Wait for client to read response")
 
         let serverDatagramFlowExpectation = XCTestExpectation(description: "Wait for server to receive stream")
-        let clientDatagramFlow = datagramFlow
+        nonisolated(unsafe) let clientDatagramFlow = datagramFlow
 
-        var serverDatagramFlow: DatagramUpperHarness? = nil
+        nonisolated(unsafe) var serverDatagramFlow: DatagramUpperHarness? = nil
 
         // Set up waiting for a server flow
         context.async {
-            serverDatagramHarness.waitForNewFlow {
-                guard let serverFlow = serverDatagramHarness.upperHarnesses.last else {
+            unsafeServerDatagramHarness.waitForNewFlow {
+                guard let serverFlow = unsafeServerDatagramHarness.upperHarnesses.last else {
                     serverDatagramFlowExpectation.fulfill()
                     return
                 }
@@ -753,10 +766,11 @@ final class QUICTestHarness {
         wait(for: [serverDatagramFlowExpectation], timeout: timeout)
         XCTAssertNotNil(serverDatagramFlow)
         guard let serverDatagramFlow else { return }
+        nonisolated(unsafe) let unsafeServerDatagramFlow = serverDatagramFlow
 
         // Block for reading on the client
-        var clientReadBytes = 0
-        var clientReadHandler: ((Bool) -> Void)? = nil
+        nonisolated(unsafe) var clientReadBytes = 0
+        nonisolated(unsafe) var clientReadHandler: ((Bool) -> Void)? = nil
         // The read handlers capture themselves: each re-registers via
         // `waitForInboundDataAvailable`, which stores the closure on the
         // harness's completions. Break the retain cycle.
@@ -789,20 +803,20 @@ final class QUICTestHarness {
         }
 
         // Block for reading on the server
-        var serverReadBytes = 0
-        var serverReadHandler: ((Bool) -> Void)? = nil
+        nonisolated(unsafe) var serverReadBytes = 0
+        nonisolated(unsafe) var serverReadHandler: ((Bool) -> Void)? = nil
         defer { serverReadHandler = nil }
         serverReadHandler = { hasData in
             defer {
                 if hasData {
                     // Schedule a follow-on read
-                    serverDatagramFlow.waitForInboundDataAvailable { success in
+                    unsafeServerDatagramFlow.waitForInboundDataAvailable { success in
                         serverReadHandler?(success)
                     }
                 }
             }
 
-            while let response = serverDatagramFlow.read() {
+            while let response = unsafeServerDatagramFlow.read() {
                 do {
                     try dataGenerator.validate(at: serverReadBytes, data: response)
                 } catch {
@@ -812,7 +826,7 @@ final class QUICTestHarness {
                 }
                 serverReadBytes += response.count
 
-                let writeResult = serverDatagramFlow.write(response)
+                let writeResult = unsafeServerDatagramFlow.write(response)
                 XCTAssertTrue(writeResult, "Server failed send response")
             }
 
@@ -973,7 +987,7 @@ final class QUICTestHarness {
 
         if !datagram {
             // Transfer stream data
-            var streamCount = streamCount
+            nonisolated(unsafe) var streamCount = streamCount
             if streamCount == 0 && (dataBlock != nil || blockCount > 0) {
                 // If there is some data to transfer, make sure there is at least one stream
                 streamCount = 1
@@ -1103,12 +1117,14 @@ final class QUICTestHarness {
 
         if validateMetrics {
             if let serverHarness = state?.serverHarness, let clientHarness = state?.clientHarness {
-                var clientReports: NetworkMetrics?
-                var serverReports: NetworkMetrics?
+                nonisolated(unsafe) let unsafeClientHarness = clientHarness
+                nonisolated(unsafe) let unsafeServerHarness = serverHarness
+                nonisolated(unsafe) var clientReports: NetworkMetrics?
+                nonisolated(unsafe) var serverReports: NetworkMetrics?
                 let snapshotExpectation = XCTestExpectation(description: "Wait for QUIC connection to receive metrics")
                 context.async {
-                    clientReports = clientHarness.getMetrics(requestedNetworkMetric: .dataTransferSnapshot)
-                    serverReports = serverHarness.getMetrics(requestedNetworkMetric: .dataTransferSnapshot)
+                    clientReports = unsafeClientHarness.getMetrics(requestedNetworkMetric: .dataTransferSnapshot)
+                    serverReports = unsafeServerHarness.getMetrics(requestedNetworkMetric: .dataTransferSnapshot)
                     XCTAssertNotNil(clientReports)
                     XCTAssertNotNil(serverReports)
                     snapshotExpectation.fulfill()
@@ -1121,8 +1137,12 @@ final class QUICTestHarness {
                     description: "Wait for QUIC connection to receive metrics"
                 )
                 context.async {
-                    clientReports = clientHarness.getMetrics(requestedNetworkMetric: .protocolEstablishmentReports)
-                    serverReports = serverHarness.getMetrics(requestedNetworkMetric: .protocolEstablishmentReports)
+                    clientReports = unsafeClientHarness.getMetrics(
+                        requestedNetworkMetric: .protocolEstablishmentReports
+                    )
+                    serverReports = unsafeServerHarness.getMetrics(
+                        requestedNetworkMetric: .protocolEstablishmentReports
+                    )
                     XCTAssertNotNil(clientReports)
                     XCTAssertNotNil(serverReports)
                     protocolEstablishmentReportExpectation.fulfill()
@@ -1136,8 +1156,9 @@ final class QUICTestHarness {
         // If applicationError is present, act upon that here
         if let applicationError, let applicationErrorReason {
             if let serverHarness = state?.serverHarness, let clientHarness = state?.clientHarness {
+                nonisolated(unsafe) let unsafeClientHarness = clientHarness
                 let errorExpectation = XCTestExpectation(description: "Wait for QUIC connection to receive error")
-                var networkError: NetworkError?
+                nonisolated(unsafe) var networkError: NetworkError?
                 serverHarness.waitForError { code in
                     guard let code else {
                         XCTAssertNotNil(code, "Error must be invoked with a valid error code")
@@ -1149,12 +1170,12 @@ final class QUICTestHarness {
                 }
                 context.async {
                     if sendApplicationCloseError {
-                        clientHarness.stop(
+                        unsafeClientHarness.stop(
                             error: .init(quicApplicationError: applicationError, reason: applicationErrorReason)
                         )
                     } else {
                         if let transportError = QUICTransportError(applicationError, applicationErrorReason) {
-                            clientHarness.stop(error: .init(quicTransportError: transportError))
+                            unsafeClientHarness.stop(error: .init(quicTransportError: transportError))
                         }
                     }
                 }
@@ -1205,9 +1226,11 @@ final class QUICTestHarness {
             if let serverUpperHarness = state?.serverHarness.upperHarnesses.first,
                 let clientUpperHarness = state?.clientHarness.upperHarnesses.first
             {
+                nonisolated(unsafe) let unsafeServerUpperHarness = serverUpperHarness
+                nonisolated(unsafe) let unsafeClientUpperHarness = clientUpperHarness
                 // Sends error code with STOP_SENDING / RESET_STREAM
                 let errorExpectation = XCTestExpectation(description: "Wait for ECONNRESET error")
-                var networkError: NetworkError?
+                nonisolated(unsafe) var networkError: NetworkError?
                 // Set up error handler before triggering the error
                 let errorBlock: ((NetworkError?) -> Void) = { code in
                     guard let code,
@@ -1224,7 +1247,7 @@ final class QUICTestHarness {
                         "Application error codes do not match"
                     )
 
-                    if let metadata: ProtocolMetadata<QUICProtocol> = serverUpperHarness.getMetadata(),
+                    if let metadata: ProtocolMetadata<QUICProtocol> = unsafeServerUpperHarness.getMetadata(),
                         let errorCode = metadata.applicationError
                     {
                         // Match the sent error in the metadata
@@ -1234,16 +1257,16 @@ final class QUICTestHarness {
                     }
                     errorExpectation.fulfill()
                 }
-                serverUpperHarness.waitForInboundAborted(completion: errorBlock)
-                serverUpperHarness.waitForOutboundAborted(completion: errorBlock)
+                unsafeServerUpperHarness.waitForInboundAborted(completion: errorBlock)
+                unsafeServerUpperHarness.waitForOutboundAborted(completion: errorBlock)
 
                 context.async {
                     if sendStreamResetError {
-                        clientUpperHarness.abortOutbound(
+                        unsafeClientUpperHarness.abortOutbound(
                             error: .init(quicApplicationError: applicationError, reason: applicationErrorReason)
                         )
                     } else if sendStreamStopSendingError {
-                        clientUpperHarness.abortInbound(
+                        unsafeClientUpperHarness.abortInbound(
                             error: .init(quicApplicationError: applicationError, reason: applicationErrorReason)
                         )
                     }
@@ -1253,7 +1276,7 @@ final class QUICTestHarness {
 
                 if verifyResetStreamHalfClosure {
                     XCTAssertFalse(
-                        serverUpperHarness.receivedDisconnected,
+                        unsafeServerUpperHarness.receivedDisconnected,
                         "Server stream must not be disconnected — only the read side was reset"
                     )
 
@@ -1262,8 +1285,8 @@ final class QUICTestHarness {
                     )
                     let halfClosurePayload = Array("half-closure-test".utf8)
                     context.async {
-                        clientUpperHarness.waitForInboundDataAvailable { _ in
-                            let data = clientUpperHarness.read()
+                        unsafeClientUpperHarness.waitForInboundDataAvailable { _ in
+                            let data = unsafeClientUpperHarness.read()
                             XCTAssertEqual(
                                 data,
                                 halfClosurePayload,
@@ -1271,7 +1294,7 @@ final class QUICTestHarness {
                             )
                             halfClosureExpectation.fulfill()
                         }
-                        let writeResult = serverUpperHarness.write(halfClosurePayload)
+                        let writeResult = unsafeServerUpperHarness.write(halfClosurePayload)
                         XCTAssertTrue(writeResult, "Server should be able to write after peer's RESET_STREAM")
                     }
                     wait(for: [halfClosureExpectation], timeout: 4.0)
@@ -1319,10 +1342,11 @@ final class QUICTestHarness {
             XCTFail("Failed to create client stream")
             return
         }
+        nonisolated(unsafe) let unsafeClientStream = clientStream
 
         let serverFlowExpectation = XCTestExpectation(description: "Server sees new flow")
         let serverAbortExpectation = XCTestExpectation(description: "Server sees abort event")
-        var serverStream: StreamUpperHarness?
+        nonisolated(unsafe) var serverStream: StreamUpperHarness?
 
         context.async {
             self.state?.serverHarness.waitForNewFlow {
@@ -1361,12 +1385,12 @@ final class QUICTestHarness {
         // (creating the flow) and the abort frame (targeting that flow) in
         // one pass.
         context.async {
-            _ = clientStream.write(Array("hello".utf8))
+            _ = unsafeClientStream.write(Array("hello".utf8))
             switch abortKind {
             case .reset:
-                clientStream.abortOutbound(error: .init(quicApplicationError: applicationError))
+                unsafeClientStream.abortOutbound(error: .init(quicApplicationError: applicationError))
             case .stopSending:
-                clientStream.abortInbound(error: .init(quicApplicationError: applicationError))
+                unsafeClientStream.abortInbound(error: .init(quicApplicationError: applicationError))
             }
         }
 
@@ -1396,10 +1420,11 @@ final class QUICTestHarness {
             XCTFail("Failed to create client stream")
             return
         }
+        nonisolated(unsafe) let unsafeClientStream = clientStream
 
         let serverFlowExpectation = XCTestExpectation(description: "Server sees new flow")
         let serverAbortExpectation = XCTestExpectation(description: "Server sees inbound abort event")
-        var serverStream: StreamUpperHarness?
+        nonisolated(unsafe) var serverStream: StreamUpperHarness?
 
         context.async {
             self.state?.serverHarness.waitForNewFlow {
@@ -1426,7 +1451,7 @@ final class QUICTestHarness {
         // this stream id is RESET_STREAM. There is no STREAM frame to
         // stride-create the flow ahead of the reset.
         context.async {
-            clientStream.abortOutbound(error: .init(quicApplicationError: applicationError))
+            unsafeClientStream.abortOutbound(error: .init(quicApplicationError: applicationError))
         }
 
         wait(for: [serverFlowExpectation], timeout: timeout)
@@ -1553,11 +1578,12 @@ final class QUICTestHarness {
                 quicOptions: clientOptions
             )
             XCTAssertNotNil(clientStream)
+            nonisolated(unsafe) let unsafeClientStream = clientStream
             let generator = TestDataGenerator(singleDataBlock: dataBlock)
             let clientWriteExpectation = XCTestExpectation(description: "Wait for client write \(index) to complete")
             context.async {
                 Logger.test.debug("Client writing data: \(dataBlock)")
-                let writeResult = clientStream?.write(generator.block)
+                let writeResult = unsafeClientStream?.write(generator.block)
                 XCTAssertNotNil(writeResult, "writeResult should not be nil")
                 XCTAssertTrue(writeResult!, "Client write failed for stream \(index)")
                 clientWriteExpectation.fulfill()
@@ -1566,7 +1592,7 @@ final class QUICTestHarness {
 
             // Wait for the server side stream to pass through handleNewFlow and become connected
             let serverHandlerExpectation = XCTestExpectation(description: "Wait for server input handler \(index)")
-            func checkForServerHandler() {
+            @Sendable func checkForServerHandler() {
                 if state?.serverHarness.upperHarnesses.count ?? 0 > index {
                     let serverHandler = state?.serverHarness.upperHarnesses[index]
                     if let serverHandler, serverHandler.receivedConnected {
@@ -1587,7 +1613,7 @@ final class QUICTestHarness {
             let serverReadExpectation = XCTestExpectation(description: "Wait for server read \(index) to complete")
             let serverHandlerIndex = index
             context.async {
-                func attemptServerRead() {
+                @Sendable func attemptServerRead() {
                     guard serverHandlerIndex < self.state?.serverHarness.upperHarnesses.count ?? 0 else {
                         self.context.async {
                             attemptServerRead()
@@ -1618,7 +1644,7 @@ final class QUICTestHarness {
             context.async {
                 if streamIDsToValidate.count > 0 {
                     let streamIDAtIndex = streamIDsToValidate[index]
-                    let metadata: ProtocolMetadata<QUICProtocol>? = clientStream?.getMetadata()
+                    let metadata: ProtocolMetadata<QUICProtocol>? = unsafeClientStream?.getMetadata()
                     XCTAssertNotNil(metadata)
                     if let metadata {
                         let streamID = metadata.streamID
@@ -1707,13 +1733,15 @@ final class QUICTestHarness {
             XCTFail("Failure to unwrap clientHarness")
             return
         }
+        nonisolated(unsafe) let unsafeClientHarness = clientHarness
 
         for (index, serverHarness) in state!.serverHarness.upperHarnesses.enumerated() {
+            nonisolated(unsafe) let unsafeServerHarness = serverHarness
             let generator = TestDataGenerator(singleDataBlock: dataBlock)
             let serverWriteExpectation = XCTestExpectation(description: "Wait for server write \(index) to complete")
             context.async {
                 Logger.test.debug("Client writing data: \(dataBlock)")
-                let writeResult = serverHarness.write(generator.block)
+                let writeResult = unsafeServerHarness.write(generator.block)
                 XCTAssertTrue(writeResult, "Server write failed for stream \(index)")
                 serverWriteExpectation.fulfill()
             }
@@ -1721,9 +1749,9 @@ final class QUICTestHarness {
 
             // Wait for the client side stream to pass through handleNewFlow and become connected
             let clientHandlerExpectation = XCTestExpectation(description: "Wait for client input handler \(index)")
-            func checkForClientHandler() {
-                if clientHarness.upperHarnesses.count > index {
-                    let clientHandler = clientHarness.upperHarnesses[index]
+            @Sendable func checkForClientHandler() {
+                if unsafeClientHarness.upperHarnesses.count > index {
+                    let clientHandler = unsafeClientHarness.upperHarnesses[index]
 
                     if clientHandler.receivedConnected {
                         clientHandlerExpectation.fulfill()
@@ -1743,14 +1771,14 @@ final class QUICTestHarness {
             let clientReadExpectation = XCTestExpectation(description: "Wait for client read \(index) to complete")
             let clientHandlerIndex = index
             context.async {
-                func attemptClientRead() {
-                    guard clientHandlerIndex < clientHarness.upperHarnesses.count else {
+                @Sendable func attemptClientRead() {
+                    guard clientHandlerIndex < unsafeClientHarness.upperHarnesses.count else {
                         self.context.async {
                             attemptClientRead()
                         }
                         return
                     }
-                    let clientUpperHarness = clientHarness.upperHarnesses[clientHandlerIndex]
+                    let clientUpperHarness = unsafeClientHarness.upperHarnesses[clientHandlerIndex]
                     if let response = clientUpperHarness.read() {
                         Logger.test.debug("Client read data: \(response)")
                         do {
@@ -1774,7 +1802,7 @@ final class QUICTestHarness {
             context.async {
                 if streamIDsToValidate.count > 0 {
                     let streamIDAtIndex = streamIDsToValidate[index]
-                    let metadata: ProtocolMetadata<QUICProtocol>? = serverHarness.getMetadata()
+                    let metadata: ProtocolMetadata<QUICProtocol>? = unsafeServerHarness.getMetadata()
                     XCTAssertNotNil(metadata)
                     if let metadata {
                         let streamID = metadata.streamID
@@ -1793,9 +1821,9 @@ final class QUICTestHarness {
             wait(for: [metadataCheckExpectation], timeout: timeout)
         }
         XCTAssertEqual(
-            clientHarness.upperHarnesses.count,
+            unsafeClientHarness.upperHarnesses.count,
             streamCount,
-            "Expected \(streamCount) client input handlers, but got \(clientHarness.upperHarnesses.count)"
+            "Expected \(streamCount) client input handlers, but got \(unsafeClientHarness.upperHarnesses.count)"
         )
 
         Logger.test.debug("Test phase: Termination")
@@ -1827,10 +1855,11 @@ final class QUICTestHarness {
             quicOptions: clientOptions,
             serverInitiated: true
         )
+        nonisolated(unsafe) let unsafeAddedStreamHandler = addedStreamHandler
         let clientWriteExpectation = XCTestExpectation(description: "Wait for client write to complete")
         context.async {
             Logger.test.debug("Client writing data: \(dataBlock)")
-            let writeResult = addedStreamHandler?.write(dataBlock)
+            let writeResult = unsafeAddedStreamHandler?.write(dataBlock)
             XCTAssertNotNil(writeResult, "writeResult should not be nil")
             XCTAssertTrue(writeResult!, "Client write failed to write on the unidirectional stream")
             clientWriteExpectation.fulfill()

--- a/Tests/SwiftNetworkTests/SwiftNetworkIPTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkIPTests.swift
@@ -118,12 +118,15 @@ final class SwiftNetworkIPTests: NetTestCase {
         corrumptChecksum: Bool = false,
         hopLimit: UInt8? = nil
     ) {
-        let parameters = Parameters()
+        nonisolated(unsafe) let localEndpoint = localEndpoint
+        nonisolated(unsafe) let remoteEndpoint = remoteEndpoint
 
         let expectation = XCTestExpectation()
-        let context = parameters.context
+        let context = NetworkContext.implicitContext
         context.async {
             defer { expectation.fulfill() }
+            var parameters = Parameters()
+            parameters.context = context
             let path = PathProperties(parameters: parameters)
 
             let reference = IPProtocol.instance(context: parameters.context)
@@ -365,11 +368,14 @@ final class SwiftNetworkIPTests: NetTestCase {
     }
 
     func ipEcho(clientEndpoint: Endpoint, serverEndpoint: Endpoint, messages: [[UInt8]]) {
-        let clientParameters = Parameters()
+        nonisolated(unsafe) let clientEndpoint = clientEndpoint
+        nonisolated(unsafe) let serverEndpoint = serverEndpoint
         let expectation = XCTestExpectation()
-        let context = clientParameters.context
+        let context = NetworkContext.implicitContext
         context.async {
             defer { expectation.fulfill() }
+            var clientParameters = Parameters()
+            clientParameters.context = context
             let clientPath = PathProperties(parameters: clientParameters)
             let clientReference = IPProtocol.instance(context: clientParameters.context)
             let clientOptions = IPProtocol.options()

--- a/Tests/SwiftNetworkTests/SwiftNetworkMultiplexingTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkMultiplexingTests.swift
@@ -29,17 +29,24 @@ final class SwiftNetworkMultiplexingTests: NetTestCase {
     static let inputMessage: [UInt8] = [0x0d, 0x0c, 0x0b, 0x0a, 0x01]
 
     func testMultiplexingProtocol() {
-        let parameters = Parameters()
-        let context = parameters.context
-        let path = PathProperties(parameters: parameters)
+        let context = NetworkContext.implicitContext
+        nonisolated(unsafe) var parameters = Parameters()
+        parameters.context = context
+        nonisolated(unsafe) let path = PathProperties(parameters: parameters)
 
-        let localEndpoint = Endpoint(address: IPv4Address(SwiftNetworkUDPTests.localIPv4Address)!, port: 1234)
-        let remoteEndpoint = Endpoint(address: IPv4Address(SwiftNetworkUDPTests.localIPv4Address)!, port: 2345)
+        nonisolated(unsafe) let localEndpoint = Endpoint(
+            address: IPv4Address(SwiftNetworkUDPTests.localIPv4Address)!,
+            port: 1234
+        )
+        nonisolated(unsafe) let remoteEndpoint = Endpoint(
+            address: IPv4Address(SwiftNetworkUDPTests.localIPv4Address)!,
+            port: 2345
+        )
 
-        var instance: TestMultiplexingProtocol? = nil
-        var upperHarness1: DatagramUpperHarness?
-        var lowerHarness: DatagramLowerHarness?
-        var listenerHarness: NewDatagramFlowHarness?
+        nonisolated(unsafe) var instance: TestMultiplexingProtocol? = nil
+        nonisolated(unsafe) var upperHarness1: DatagramUpperHarness?
+        nonisolated(unsafe) var lowerHarness: DatagramLowerHarness?
+        nonisolated(unsafe) var listenerHarness: NewDatagramFlowHarness?
         let expectation = XCTestExpectation()
         context.async {
             instance = TestMultiplexingProtocol(context: context)
@@ -110,6 +117,9 @@ final class SwiftNetworkMultiplexingTests: NetTestCase {
         guard let upperHarness1, let lowerHarness, let listenerHarness else {
             return
         }
+        nonisolated(unsafe) let unsafeUpperHarness1 = upperHarness1
+        nonisolated(unsafe) let unsafeLowerHarness = lowerHarness
+        nonisolated(unsafe) let unsafeListenerHarness = listenerHarness
 
         let dataExpectation = XCTestExpectation()
         context.async {
@@ -121,11 +131,11 @@ final class SwiftNetworkMultiplexingTests: NetTestCase {
             let outputMessage = SwiftNetworkMultiplexingTests.outputMessage
             let inputMessage = SwiftNetworkMultiplexingTests.inputMessage
 
-            let wrote = upperHarness1.write(outputMessage)
+            let wrote = unsafeUpperHarness1.write(outputMessage)
 
             XCTAssertTrue(wrote, "Failed to write")
 
-            let lastPacketData = lowerHarness.extractLastOutboundPacket()
+            let lastPacketData = unsafeLowerHarness.extractLastOutboundPacket()
             XCTAssertNotNil(lastPacketData, "Failed to get multiplexed outbound packet")
             guard let lastPacketData else {
                 return
@@ -135,9 +145,9 @@ final class SwiftNetworkMultiplexingTests: NetTestCase {
             XCTAssertEqual(lastPacketData, expectedPacketData, "Failed to generate expected multiplexed output packet")
 
             let inputPacketData = inputMessage.withUnsafeBytes { [UInt8]($0) }
-            lowerHarness.setNextInboundPacket(inputPacketData)
+            unsafeLowerHarness.setNextInboundPacket(inputPacketData)
 
-            let readApplicationBytes = upperHarness1.read()
+            let readApplicationBytes = unsafeUpperHarness1.read()
             XCTAssertNotNil(readApplicationBytes, "Failed to get multiplexed input packet")
             guard let readApplicationBytes else {
                 return
@@ -147,7 +157,7 @@ final class SwiftNetworkMultiplexingTests: NetTestCase {
             XCTAssertEqual(inputPacketData, readApplicationData, "Failed to read expected multiplexed input data")
 
             instance.triggerNewFlowCreation()
-            XCTAssertEqual(listenerHarness.upperHarnesses.count, 1, "Listener expects to have 1 inbound flows")
+            XCTAssertEqual(unsafeListenerHarness.upperHarnesses.count, 1, "Listener expects to have 1 inbound flows")
 
             let upperHarness2 = DatagramUpperHarness(
                 identifier: "Client2",
@@ -184,7 +194,7 @@ final class SwiftNetworkMultiplexingTests: NetTestCase {
             let wrote2 = upperHarness2.write(outputMessage)
             XCTAssertTrue(wrote2, "Failed to write, second flow")
 
-            let lastPacketData2 = lowerHarness.extractLastOutboundPacket()
+            let lastPacketData2 = unsafeLowerHarness.extractLastOutboundPacket()
             XCTAssertNotNil(lastPacketData, "Failed to get multiplexed output packet, second flow")
             guard let lastPacketData2 else {
                 return
@@ -198,33 +208,40 @@ final class SwiftNetworkMultiplexingTests: NetTestCase {
                 "Failed to generate expected multiplexed output packet, second flow"
             )
 
-            upperHarness1.stop()
+            unsafeUpperHarness1.stop()
             upperHarness2.stop()
             upperHarness3.stop()
 
-            upperHarness1.teardown()
+            unsafeUpperHarness1.teardown()
             upperHarness2.teardown()
             upperHarness3.teardown()
 
-            listenerHarness.teardown()
+            unsafeListenerHarness.teardown()
         }
 
         wait(for: [dataExpectation], timeout: 5.0)
     }
 
     func testMultiplexingProtocolPendingStreams() {
-        let parameters = Parameters()
-        let context = parameters.context
-        let path = PathProperties(parameters: parameters)
+        let context = NetworkContext.implicitContext
+        nonisolated(unsafe) var parameters = Parameters()
+        parameters.context = context
+        nonisolated(unsafe) let path = PathProperties(parameters: parameters)
 
-        let localEndpoint = Endpoint(address: IPv4Address(SwiftNetworkUDPTests.localIPv4Address)!, port: 1234)
-        let remoteEndpoint = Endpoint(address: IPv4Address(SwiftNetworkUDPTests.localIPv4Address)!, port: 2345)
+        nonisolated(unsafe) let localEndpoint = Endpoint(
+            address: IPv4Address(SwiftNetworkUDPTests.localIPv4Address)!,
+            port: 1234
+        )
+        nonisolated(unsafe) let remoteEndpoint = Endpoint(
+            address: IPv4Address(SwiftNetworkUDPTests.localIPv4Address)!,
+            port: 2345
+        )
 
         // Use a high number of streams to ensure that we don't have poor scaling
         let upperHarnessCount = 1000
-        var upperHarnesses = [DatagramUpperHarness]()
-        var lowerHarness: DatagramLowerHarness?
-        var listenerHarness: NewDatagramFlowHarness?
+        nonisolated(unsafe) var upperHarnesses = [DatagramUpperHarness]()
+        nonisolated(unsafe) var lowerHarness: DatagramLowerHarness?
+        nonisolated(unsafe) var listenerHarness: NewDatagramFlowHarness?
         let expectation = XCTestExpectation()
         context.async {
             var instance = TestMultiplexingProtocol(context: context)
@@ -302,6 +319,7 @@ final class SwiftNetworkMultiplexingTests: NetTestCase {
         guard upperHarnesses.count == upperHarnessCount, let listenerHarness else {
             return
         }
+        nonisolated(unsafe) let unsafeListenerHarness = listenerHarness
 
         let closeExpectation = XCTestExpectation()
         context.async {
@@ -310,8 +328,8 @@ final class SwiftNetworkMultiplexingTests: NetTestCase {
                 upperHarness.stop()
                 upperHarness.teardown()
             }
-            listenerHarness.stop()
-            listenerHarness.teardown()
+            unsafeListenerHarness.stop()
+            unsafeListenerHarness.teardown()
 
             closeExpectation.fulfill()
         }

--- a/Tests/SwiftNetworkTests/SwiftNetworkMutexTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkMutexTests.swift
@@ -20,8 +20,8 @@ final class SwiftNetworkMutexTests: NetTestCase {
     func testMutexWithoutStorage() throws {
         let context = NetworkContext.implicitContext
 
-        var protectedFlag = false
-        var protectedValue = 0
+        nonisolated(unsafe) var protectedFlag = false
+        nonisolated(unsafe) var protectedValue = 0
 
         let mutex = NetworkMutex(())
 

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICEarlyDataTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICEarlyDataTests.swift
@@ -49,7 +49,7 @@ internal import os
 #if IMPORT_SWIFTTLS
 #if canImport(SwiftTLS)
 @available(Network 0.1.0, *)
-final class SwiftNetworkQUICEarlyDataTests: NetTestCase {
+final class SwiftNetworkQUICEarlyDataTests: NetTestCase, @unchecked Sendable {
 
     // 10.0.0.20
     static let localIPv4Address: [UInt8] = [0x0a, 0x00, 0x00, 0x14]
@@ -239,26 +239,30 @@ final class SwiftNetworkQUICEarlyDataTests: NetTestCase {
         expectFailure: Bool = false,
         resendRejectedEarlyDataAutomatically: Bool = false
     ) -> [UInt8]? {
-        let clientParameters = Parameters()
+        nonisolated(unsafe) let clientEndpoint = clientEndpoint
+        nonisolated(unsafe) let serverEndpoint = serverEndpoint
+        let context = NetworkContext.implicitContext
 
         let expectation = XCTestExpectation()
-        let context = clientParameters.context
-        var clientConnected = false
-        var serverConnected = false
-        var clientUpperHarness: StreamUpperHarness?
-        var serverUpperHarness: NewStreamFlowHarness?
-        var clientQUICReference: ProtocolInstanceReference?
-        var serverQUICReference: ProtocolInstanceReference?
+        nonisolated(unsafe) var clientConnected = false
+        nonisolated(unsafe) var serverConnected = false
+        nonisolated(unsafe) var clientUpperHarness: StreamUpperHarness?
+        nonisolated(unsafe) var serverUpperHarness: NewStreamFlowHarness?
+        nonisolated(unsafe) var clientQUICReference: ProtocolInstanceReference?
+        nonisolated(unsafe) var serverQUICReference: ProtocolInstanceReference?
 
-        var pairedPathsArray = [PairedUDPIPPaths]()
+        nonisolated(unsafe) var pairedPathsArray = [PairedUDPIPPaths]()
 
-        var earlyDataRejected = false
-        var remoteTransportParameters: [UInt8]? = nil
+        nonisolated(unsafe) var earlyDataRejected = false
+        nonisolated(unsafe) var remoteTransportParameters: [UInt8]? = nil
         let rejectedExpectation = XCTestExpectation()
         let errorExpectation = XCTestExpectation()
 
         context.async {
             defer { expectation.fulfill() }
+
+            var clientParameters = Parameters()
+            clientParameters.context = context
 
             let pairedPaths = PairedUDPIPPaths(
                 context: context,
@@ -417,7 +421,7 @@ final class SwiftNetworkQUICEarlyDataTests: NetTestCase {
                 let receiveExpectation = XCTestExpectation()
                 context.async {
                     Logger.test.info("Trying to read data")
-                    func attemptServerRead() {
+                    @Sendable func attemptServerRead() {
                         if pairedPathsArray.first?.transferPackets() == 0 {
                             // Wait for new writes from the client to be sent
                             context.async {

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICKeepaliveTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICKeepaliveTests.swift
@@ -61,7 +61,7 @@ final class SwiftNetworkQUICKeepaliveTests: NetTestCase {
         let serverOptions = QUICProtocol.options()
         serverOptions.connectionOptions.pmtudUpdateInterval = .seconds(1)
 
-        var networkError: NetworkError? = nil
+        nonisolated(unsafe) var networkError: NetworkError? = nil
 
         QUICTestHarness().runQUICTest(
             clientOptions: clientOptions,
@@ -99,7 +99,7 @@ final class SwiftNetworkQUICKeepaliveTests: NetTestCase {
         let serverOptions = QUICProtocol.options()
         serverOptions.connectionOptions.pmtud = false
 
-        var networkError: NetworkError? = nil
+        nonisolated(unsafe) var networkError: NetworkError? = nil
 
         QUICTestHarness().runQUICTest(
             clientOptions: clientOptions,

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICQlogTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICQlogTests.swift
@@ -48,6 +48,7 @@ internal import os
 
 #if QlogOutput
 
+@available(Network 0.1.0, *)
 final class SwiftNetworkQUICQlogTests: NetTestCase {
     func testQUICWriteClientQlogFileOnDataTransfer() throws {
         let dataBlock: [UInt8] = Array("Hello World!".utf8)
@@ -68,7 +69,7 @@ final class SwiftNetworkQUICQlogTests: NetTestCase {
         let qlogExpectation = XCTestExpectation(description: "Loop until the qlog is written")
         // Validate the qlog file is present (based on how it creates the file)
         let finalPath = path + "/qlog_client_\(title)_C1.qlog"
-        func checkQlogFileExists() {
+        @Sendable func checkQlogFileExists() {
             if FileManager.default.fileExists(atPath: finalPath) {
                 qlogExpectation.fulfill()
             }
@@ -110,7 +111,7 @@ final class SwiftNetworkQUICQlogTests: NetTestCase {
         let qlogExpectation = XCTestExpectation(description: "Loop until the qlog is written")
         // Validate the qlog file is present (based on how it creates the file)
         let finalPath = path + "qlog_server_\(title)_C1.qlog"
-        func checkQlogFileExists() {
+        @Sendable func checkQlogFileExists() {
             if FileManager.default.fileExists(atPath: finalPath) {
                 qlogExpectation.fulfill()
             }

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICShortLHPacketTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICShortLHPacketTests.swift
@@ -49,9 +49,9 @@ internal import os
 #if IMPORT_SWIFTTLS
 #if canImport(SwiftTLS)
 @available(Network 0.1.0, *)
-final class SwiftNetworkQUICShortLHPacketTests: NetTestCase {
+final class SwiftNetworkQUICShortLHPacketTests: NetTestCase, @unchecked Sendable {
 
-    var serverSigningKey = P256.Signing.PrivateKey()
+    let serverSigningKey = P256.Signing.PrivateKey()
     func createQUICTestOptions(server: Bool = false) -> ProtocolOptions<QUICProtocol> {
         var tlsOptions = SwiftTLSProtocol.Options()
         tlsOptions.applicationProtocols = ["h3"]
@@ -150,24 +150,31 @@ final class SwiftNetworkQUICShortLHPacketTests: NetTestCase {
         ]
 
     func testShortQUICInitialParsing() {
-        let clientEndpoint = Endpoint(address: IPv4Address(SwiftNetworkQUICStackTests.localIPv4Address)!, port: 1234)
-        let serverEndpoint = Endpoint(address: IPv4Address(SwiftNetworkQUICStackTests.localIPv4Address)!, port: 8080)
-
-        var serverParameters = Parameters()
-        serverParameters.isServer = true
-        let context = serverParameters.context
-        let serverPath = PathProperties(parameters: serverParameters)
-        let serverQUIC = QUICProtocol.instance(context: context)
-
-        let serverQUICOptions = self.createQUICTestOptions(server: true)
-        serverQUICOptions.setLogID(prefix: "L", parent: "1", protocolLogIDNumber: 1)
-        serverQUICOptions.setProtocolInstance(serverQUIC)
-
-        serverParameters.defaultStack.prepend(applicationProtocol: .quic(serverQUICOptions))
-
         let expectation = XCTestExpectation()
+        let context = NetworkContext.implicitContext
         context.async {
             defer { expectation.fulfill() }
+
+            let clientEndpoint = Endpoint(
+                address: IPv4Address(SwiftNetworkQUICStackTests.localIPv4Address)!,
+                port: 1234
+            )
+            let serverEndpoint = Endpoint(
+                address: IPv4Address(SwiftNetworkQUICStackTests.localIPv4Address)!,
+                port: 8080
+            )
+
+            var serverParameters = Parameters()
+            serverParameters.isServer = true
+            serverParameters.context = context
+            let serverPath = PathProperties(parameters: serverParameters)
+            let serverQUIC = QUICProtocol.instance(context: context)
+
+            let serverQUICOptions = self.createQUICTestOptions(server: true)
+            serverQUICOptions.setLogID(prefix: "L", parent: "1", protocolLogIDNumber: 1)
+            serverQUICOptions.setProtocolInstance(serverQUIC)
+
+            serverParameters.defaultStack.prepend(applicationProtocol: .quic(serverQUICOptions))
 
             let serverListenerLinkage = StreamListenerLinkage(reference: serverQUIC)
             let serverUpperHarness = StreamUpperHarness(

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICSpinBitTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICSpinBitTests.swift
@@ -59,7 +59,7 @@ final class SwiftNetworkQUICSpinBitTests: NetTestCase {
         // If the spin bit is disabled then the test short circuits and ends, if it is enable then it verified
         // it from the server.
 
-        var hasSpinBit = true
+        nonisolated(unsafe) var hasSpinBit = true
         QUICTestHarness().runQUICTest(
             dataBlock: Array("Hello World!".utf8),
             afterHandshake: { harness in

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICStackTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICStackTests.swift
@@ -49,7 +49,7 @@ internal import os
 #if IMPORT_SWIFTTLS
 #if canImport(SwiftTLS)
 @available(Network 0.1.0, *)
-final class SwiftNetworkQUICStackTests: NetTestCase {
+final class SwiftNetworkQUICStackTests: NetTestCase, @unchecked Sendable {
 
     // 10.0.0.20
     static let localIPv4Address: [UInt8] = [0x0a, 0x00, 0x00, 0x14]
@@ -234,21 +234,25 @@ final class SwiftNetworkQUICStackTests: NetTestCase {
         migrateCount: Int = 0,
         dataToSend: [UInt8]? = nil
     ) {
-        let clientParameters = Parameters()
+        nonisolated(unsafe) let clientEndpoint = clientEndpoint
+        nonisolated(unsafe) let serverEndpoint = serverEndpoint
 
         let expectation = XCTestExpectation()
-        let context = clientParameters.context
-        var clientConnected = false
-        var serverConnected = false
-        var clientUpperHarness: StreamUpperHarness?
-        var serverUpperHarness: NewStreamFlowHarness?
-        var clientQUICReference: ProtocolInstanceReference?
-        var serverQUICReference: ProtocolInstanceReference?
+        let context = NetworkContext.implicitContext
+        nonisolated(unsafe) var clientConnected = false
+        nonisolated(unsafe) var serverConnected = false
+        nonisolated(unsafe) var clientUpperHarness: StreamUpperHarness?
+        nonisolated(unsafe) var serverUpperHarness: NewStreamFlowHarness?
+        nonisolated(unsafe) var clientQUICReference: ProtocolInstanceReference?
+        nonisolated(unsafe) var serverQUICReference: ProtocolInstanceReference?
 
-        var pairedPathsArray = [PairedUDPIPPaths]()
+        nonisolated(unsafe) var pairedPathsArray = [PairedUDPIPPaths]()
 
         context.async {
             defer { expectation.fulfill() }
+
+            var clientParameters = Parameters()
+            clientParameters.context = context
 
             let pairedPaths = PairedUDPIPPaths(
                 context: context,
@@ -308,6 +312,7 @@ final class SwiftNetworkQUICStackTests: NetTestCase {
             }
 
             var serverParameters = Parameters()
+            serverParameters.context = context
             serverParameters.isServer = true
             let serverPath = PathProperties(parameters: serverParameters)
             let serverQUIC = QUICProtocol.instance(context: context)
@@ -376,6 +381,8 @@ final class SwiftNetworkQUICStackTests: NetTestCase {
         guard let clientQUICReference, let serverQUICReference else {
             return
         }
+        nonisolated(unsafe) let clientQUICRef = clientQUICReference
+        nonisolated(unsafe) let serverQUICRef = serverQUICReference
 
         let eventExpectation = XCTestExpectation()
         context.async {
@@ -422,14 +429,14 @@ final class SwiftNetworkQUICStackTests: NetTestCase {
                     let serverParameters = Parameters()
                     let severPath = PathProperties(parameters: Parameters())
 
-                    try clientQUICReference.attachLowerDatagramProtocolForNewPath(
+                    try clientQUICRef.attachLowerDatagramProtocolForNewPath(
                         pairedPaths.clientTop,
                         remote: serverEndpoint,
                         local: clientEndpoint,
                         parameters: clientParameters,
                         path: clientPath
                     )
-                    try serverQUICReference.attachLowerDatagramProtocolForNewPath(
+                    try serverQUICRef.attachLowerDatagramProtocolForNewPath(
                         pairedPaths.serverTop,
                         remote: clientEndpoint,
                         local: serverEndpoint,

--- a/Tests/SwiftNetworkTests/SwiftNetworkUDPTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkUDPTests.swift
@@ -81,12 +81,14 @@ final class SwiftNetworkUDPTests: NetTestCase {
         secondaryInputPacket: [UInt8]? = nil,
         expectBadInput: Bool = false
     ) {
-        let parameters = Parameters()
-
+        nonisolated(unsafe) let localEndpoint = localEndpoint
+        nonisolated(unsafe) let remoteEndpoint = remoteEndpoint
         let expectation = XCTestExpectation()
-        let context = parameters.context
+        let context = NetworkContext.implicitContext
         context.async {
             defer { expectation.fulfill() }
+            var parameters = Parameters()
+            parameters.context = context
             let path = PathProperties(parameters: parameters)
 
             let reference = UDPProtocol.instance(context: context)
@@ -236,13 +238,16 @@ final class SwiftNetworkUDPTests: NetTestCase {
     }
 
     func udpEcho(clientEndpoint: Endpoint, serverEndpoint: Endpoint, messages: [[UInt8]]) {
-        let clientParameters = Parameters()
+        nonisolated(unsafe) let clientEndpoint = clientEndpoint
+        nonisolated(unsafe) let serverEndpoint = serverEndpoint
 
         let expectation = XCTestExpectation()
-        let context = clientParameters.context
+        let context = NetworkContext.implicitContext
         context.async {
             defer { expectation.fulfill() }
 
+            var clientParameters = Parameters()
+            clientParameters.context = context
             let clientPath = PathProperties(parameters: clientParameters)
             let clientReference = UDPProtocol.instance(context: clientParameters.context)
             let clientOptions = UDPProtocol.options()


### PR DESCRIPTION
Adding Sendable marking to the async block for NetworkContext that can be used from off-context. The async call within the stack to schedule a block on the context itself validates that it is on the right context already, and is now called "isolatedAsync" within the NetworkContext.

This also requires a lot of changes to mark unsafe sendability in the tests that use async heavily along with expectations to do step-by-step testing.