### PR TITLE
Fix sequence number bounds check for RETIRE_CONNECTION_ID frames

### DIFF
--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -6154,10 +6154,12 @@ extension QUICConnection {
             return false
         }
 
+        // RFC 9000 §19.16:
+        //
         // Receipt of a RETIRE_CONNECTION_ID frame containing a sequence number
-        // greater than any previously sent to the peer MAY be treated as a
+        // greater than any previously sent to the peer MUST be treated as a
         // connection error of type PROTOCOL_VIOLATION.
-        guard frame.sequence < largestSentLocalCIDSequenceNumber else {
+        if frame.sequence > largestSentLocalCIDSequenceNumber {
             log.error(
                 "Received RETIRE_CONNECTION_ID with sequence number greater than what we have ever sent in a NEW_CONNECTION_ID"
             )


### PR DESCRIPTION
Per RFC 9000 §19.16, a RETIRE_CONNECTION_ID frame with a sequence number greater than any previously sent to the peer must be treated as a connection error.

However, the logic incorrectly included the largest previously seen sequence number as well leading to incorrect connection errors.

- Replace `guard` with `if` so the condition matches the text.
- Update the text as the RFC says "MUST" not "MAY"