### PR TITLE
Avoid allocating in FrameArray empty init

### DIFF
--- a/Sources/SwiftNetwork/Protocols/FrameArray.swift
+++ b/Sources/SwiftNetwork/Protocols/FrameArray.swift
@@ -36,7 +36,7 @@ public struct FrameArray: ~Copyable {
     }
 
     public init() {
-        self.frames = NetworkUniqueDeque<Frame>(minimumCapacity: 1)
+        self.frames = NetworkUniqueDeque<Frame>()
     }
 
     public init(capacity: Int) {

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -3196,11 +3196,14 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         else {
             return false
         }
-        var datagramBatch = FrameArray()
+
+        var datagramBatch: FrameArray
         if self.flowControlState.pendingOutboundBytesToSend > 0 && availableCongestionWindow > 0 {
             datagramBatch = buildOutboundFrameBatch(
                 availableCongestionWindow: (availableCongestionWindow - totalSendBytes)
             )
+        } else {
+            datagramBatch = FrameArray()
         }
 
         // Sending on the current path.


### PR DESCRIPTION
`FrameArray()` sets the minimum capacity to one which allocates a backing storage. This is a foot gun which is already triggered on a number of code paths: an empty `FrameArray()` is initialized only to be assigned over shortly after, resulting in an avoidable temporary allocation. 

This pattern is avoidable but takes care. A simpler solution which removes the foot gun altogether is to not request capacity in `FrameArray()`. When capacity is known users should use `FrameArray(capacity:)` instead.

This change reduces allocations by ~7% and CPU cycles by ~5% in the QUIC benchmarks I ran.