### PR TITLE
Update Package.swift to depend on SwiftTLS 0.1.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -96,7 +96,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.5.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "5.0.0-beta.1"),
-        .package(url: "https://github.com/apple/swift-tls.git", from: "0.1.0"),
+        .package(url: "https://github.com/apple/swift-tls.git", .upToNextMinor(from: "0.1.0")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -96,7 +96,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.5.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "5.0.0-beta.1"),
-        .package(url: "https://github.com/apple/swift-tls.git", branch: "main"),
+        .package(url: "https://github.com/apple/swift-tls.git", from: "0.1.0"),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Unit tests can also be run by filtering a specific class or function:
 
 All unit tests are run automatically upon creation or update of a Pull Request. See [CONTRIBUTING](https://github.com/apple/swift-network-evolution/blob/main/CONTRIBUTING.md) for details.
 
+### Versioning
+
+Whilst the library is in the `0.x.x` version range, you should adopt it using the `.upToNextMinor(from: "0.1.0")` specifier. During this period, breaking changes are intended to map to minor version bumps, so depending on the library this way picks up smaller, non-breaking changes automatically while protecting against API-breaking ones.
+
 ### Logging Levels
 
 By default, Swift Network will emit logs at `debug`, `info`, `notice`, `error`, and `fault` levels. There are also datapath-specific debug logs, referred to as `datapath` logs, that are disabled by default.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ All unit tests are run automatically upon creation or update of a Pull Request. 
 
 ### Versioning
 
-Whilst the library is in the `0.x.x` version range, you should adopt it using the `.upToNextMinor(from: "0.1.0")` specifier. During this period, breaking changes are intended to map to minor version bumps, so depending on the library this way picks up smaller, non-breaking changes automatically while protecting against API-breaking ones.
+While the library is in the `0.x.x` version range, you should adopt it using the `.upToNextMinor(from: "0.1.0")` specifier. During this period, breaking changes are intended to map to minor version bumps, so depending on the library this way picks up smaller, non-breaking changes automatically while protecting against API-breaking ones.
 
 ### Logging Levels
 


### PR DESCRIPTION
Update Package.swift to depend on SwiftTLS 0.1.0 now that it has a release.