### PR TITLE
Move SHIM_CRYPTO_SPAN_APIS to a trait that disables the shim

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,13 +17,13 @@ jobs:
         bash -c '
         rc=0;
         echo "=== xcodebuild macOS ===";
-        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=macos,variant=macos" build && macos=PASSED || { rc=1; macos=FAILED; };
+        /usr/bin/xcodebuild -DSHIM_CRYPTO_SPAN_APIS -quiet -scheme swift-network-evolution-Package -destination "generic/platform=macos,variant=macos" build && macos=PASSED || { rc=1; macos=FAILED; };
         echo "=== macOS build: $macos ===";
         echo "=== xcodebuild Mac Catalyst ===";
-        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=macos,variant=Mac Catalyst" build && catalyst=PASSED || { rc=1; catalyst=FAILED; };
+        /usr/bin/xcodebuild -DSHIM_CRYPTO_SPAN_APIS -quiet -scheme swift-network-evolution-Package -destination "generic/platform=macos,variant=Mac Catalyst" build && catalyst=PASSED || { rc=1; catalyst=FAILED; };
         echo "=== Mac Catalyst build: $catalyst ===";
         echo "=== xcodebuild iOS ===";
-        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=ios" build && ios=PASSED || { rc=1; ios=FAILED; };
+        /usr/bin/xcodebuild -DSHIM_CRYPTO_SPAN_APIS -quiet -scheme swift-network-evolution-Package -destination "generic/platform=ios" build && ios=PASSED || { rc=1; ios=FAILED; };
         echo "=== iOS build: $ios ===";
         echo "=== xcodebuild watchOS ===";
         /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=watchos" build && watchos=PASSED || { rc=1; watchos=FAILED; };
@@ -32,10 +32,10 @@ jobs:
         /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=tvos" build && tvos=PASSED || { rc=1; tvos=FAILED; };
         echo "=== tvOS build: $tvos ===";
         echo "=== xcodebuild visionOS ===";
-        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=visionos" build && visionos=PASSED || { rc=1; visionos=FAILED; };
+        /usr/bin/xcodebuild - -quiet -scheme swift-network-evolution-Package -destination "generic/platform=visionos" build && visionos=PASSED || { rc=1; visionos=FAILED; };
         echo "=== visionOS build: $visionos ===";
         echo "=== xcrun swift test ===";
-        xcrun swift test --quiet "$@" && tests=PASSED || { rc=1; tests=FAILED; };
+        xcrun swift test --traits SHIM_CRYPTO_SPAN_APIS --quiet "$@" && tests=PASSED || { rc=1; tests=FAILED; };
         echo "=== swift test: $tests ===";
         echo "=== Summary ===";
         printf "%-20s %s\n" "macOS build:" "$macos";

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,7 @@ jobs:
         /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=tvos" build && tvos=PASSED || { rc=1; tvos=FAILED; };
         echo "=== tvOS build: $tvos ===";
         echo "=== xcodebuild visionOS ===";
-        /usr/bin/xcodebuild - -quiet -scheme swift-network-evolution-Package -destination "generic/platform=visionos" build && visionos=PASSED || { rc=1; visionos=FAILED; };
+        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=visionos" build && visionos=PASSED || { rc=1; visionos=FAILED; };
         echo "=== visionOS build: $visionos ===";
         echo "=== xcrun swift test ===";
         xcrun swift test --quiet "$@" && tests=PASSED || { rc=1; tests=FAILED; };

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,13 +17,13 @@ jobs:
         bash -c '
         rc=0;
         echo "=== xcodebuild macOS ===";
-        /usr/bin/xcodebuild -DSHIM_CRYPTO_SPAN_APIS -quiet -scheme swift-network-evolution-Package -destination "generic/platform=macos,variant=macos" build && macos=PASSED || { rc=1; macos=FAILED; };
+        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=macos,variant=macos" build && macos=PASSED || { rc=1; macos=FAILED; };
         echo "=== macOS build: $macos ===";
         echo "=== xcodebuild Mac Catalyst ===";
-        /usr/bin/xcodebuild -DSHIM_CRYPTO_SPAN_APIS -quiet -scheme swift-network-evolution-Package -destination "generic/platform=macos,variant=Mac Catalyst" build && catalyst=PASSED || { rc=1; catalyst=FAILED; };
+        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=macos,variant=Mac Catalyst" build && catalyst=PASSED || { rc=1; catalyst=FAILED; };
         echo "=== Mac Catalyst build: $catalyst ===";
         echo "=== xcodebuild iOS ===";
-        /usr/bin/xcodebuild -DSHIM_CRYPTO_SPAN_APIS -quiet -scheme swift-network-evolution-Package -destination "generic/platform=ios" build && ios=PASSED || { rc=1; ios=FAILED; };
+        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=ios" build && ios=PASSED || { rc=1; ios=FAILED; };
         echo "=== iOS build: $ios ===";
         echo "=== xcodebuild watchOS ===";
         /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=watchos" build && watchos=PASSED || { rc=1; watchos=FAILED; };
@@ -35,7 +35,7 @@ jobs:
         /usr/bin/xcodebuild - -quiet -scheme swift-network-evolution-Package -destination "generic/platform=visionos" build && visionos=PASSED || { rc=1; visionos=FAILED; };
         echo "=== visionOS build: $visionos ===";
         echo "=== xcrun swift test ===";
-        xcrun swift test --traits SHIM_CRYPTO_SPAN_APIS --quiet "$@" && tests=PASSED || { rc=1; tests=FAILED; };
+        xcrun swift test --quiet "$@" && tests=PASSED || { rc=1; tests=FAILED; };
         echo "=== swift test: $tests ===";
         echo "=== Summary ===";
         printf "%-20s %s\n" "macOS build:" "$macos";

--- a/Package.swift
+++ b/Package.swift
@@ -45,11 +45,7 @@ let settings: [SwiftSetting] = [
     .define("EXPORT_SWIFTTLS"),
     .define("IMPORT_CRYPTO"),
     .define("SWIFTTLS_CERTIFICATE_VERIFICATION"),
-    // To support back to macOS 26, provide a shim on top of crypto APIs
-    // that allows passing spans. This is a less performant path, so for
-    // performance-sensitive cases, remove this define and require at least
-    // macOS 27.
-    .define("SHIM_CRYPTO_SPAN_APIS", .when(platforms: allApplePlatforms)),
+    //.define("SHIM_CRYPTO_SPAN_APIS", .when(platforms: allApplePlatforms)),
     .unsafeFlags(["-Xfrontend", "-experimental-spi-only-imports"]),
     .enableExperimentalFeature("Lifetimes"),
     .enableExperimentalFeature("AnyAppleOSAvailability"),
@@ -90,7 +86,15 @@ let package = Package(
             name: "SignpostOutput",
             description: "Enables `OSSignposter` output from the QUIC implementation."
         ),
-        .default(enabledTraits: []),
+        // To support back to macOS 26, provide a shim on top of crypto APIs
+        // that allows passing spans. This is a less performant path, so for
+        // performance-sensitive cases, remove this define and require at least
+        // macOS 27.
+        .trait(
+            name: "SHIM_CRYPTO_SPAN_APIS",
+            description: "To support back to macOS 26, provide a shim on top of crypto APIs that allows passing spans"
+        ),
+        .default(enabledTraits: ["SHIM_CRYPTO_SPAN_APIS"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,6 @@ let settings: [SwiftSetting] = [
     .define("EXPORT_SWIFTTLS"),
     .define("IMPORT_CRYPTO"),
     .define("SWIFTTLS_CERTIFICATE_VERIFICATION"),
-    //.define("SHIM_CRYPTO_SPAN_APIS", .when(platforms: allApplePlatforms)),
     .unsafeFlags(["-Xfrontend", "-experimental-spi-only-imports"]),
     .enableExperimentalFeature("Lifetimes"),
     .enableExperimentalFeature("AnyAppleOSAvailability"),
@@ -94,7 +93,7 @@ let package = Package(
             name: "SHIM_CRYPTO_SPAN_APIS",
             description: "To support back to macOS 26, provide a shim on top of crypto APIs that allows passing spans"
         ),
-        .default(enabledTraits: ["SHIM_CRYPTO_SPAN_APIS"]),
+        .default(enabledTraits: []),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -89,10 +89,10 @@ let package = Package(
         // that allows passing spans. This is a less performant path, so for
         // performance-sensitive cases, remove this define and require at least
         // macOS 27.
-//        .trait(
-//            name: "SHIM_CRYPTO_SPAN_APIS",
-//            description: "To support back to macOS 26, provide a shim on top of crypto APIs that allows passing spans"
-//        ),
+       .trait(
+           name: "SHIM_CRYPTO_SPAN_APIS",
+           description: "To support back to macOS 26, provide a shim on top of crypto APIs that allows passing spans"
+       ),
         .default(enabledTraits: []),
     ],
     dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -89,10 +89,10 @@ let package = Package(
         // that allows passing spans. This is a less performant path, so for
         // performance-sensitive cases, remove this define and require at least
         // macOS 27.
-        .trait(
-            name: "SHIM_CRYPTO_SPAN_APIS",
-            description: "To support back to macOS 26, provide a shim on top of crypto APIs that allows passing spans"
-        ),
+//        .trait(
+//            name: "SHIM_CRYPTO_SPAN_APIS",
+//            description: "To support back to macOS 26, provide a shim on top of crypto APIs that allows passing spans"
+//        ),
         .default(enabledTraits: []),
     ],
     dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -87,11 +87,11 @@ let package = Package(
         ),
         // To support back to macOS 26, provide a shim on top of crypto APIs
         // that allows passing spans is provided. This is a less performant path, so for
-        // performance-sensitive cases, pass in this trait to disable this shim. 
-       .trait(
-           name: "DISABLE_SHIM_CRYPTO_SPAN_APIS",
-           description: "Disable backwards compatible crypto shim for performance sensitive cases"
-       ),
+        // performance-sensitive cases, pass in this trait to disable this shim.
+        .trait(
+            name: "DISABLE_SHIM_CRYPTO_SPAN_APIS",
+            description: "Disable backwards compatible crypto shim for performance sensitive cases"
+        ),
         .default(enabledTraits: []),
     ],
     dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -86,12 +86,11 @@ let package = Package(
             description: "Enables `OSSignposter` output from the QUIC implementation."
         ),
         // To support back to macOS 26, provide a shim on top of crypto APIs
-        // that allows passing spans. This is a less performant path, so for
-        // performance-sensitive cases, remove this define and require at least
-        // macOS 27.
+        // that allows passing spans is provided. This is a less performant path, so for
+        // performance-sensitive cases, pass in this trait to disable this shim. 
        .trait(
-           name: "SHIM_CRYPTO_SPAN_APIS",
-           description: "To support back to macOS 26, provide a shim on top of crypto APIs that allows passing spans"
+           name: "DISABLE_SHIM_CRYPTO_SPAN_APIS",
+           description: "Disable backwards compatible crypto shim for performance sensitive cases"
        ),
         .default(enabledTraits: []),
     ],

--- a/Sources/SwiftNetwork/Utilities/CryptoWrappers.swift
+++ b/Sources/SwiftNetwork/Utilities/CryptoWrappers.swift
@@ -15,7 +15,7 @@
 // Wrappers over older Crypto functions when span-based APIs are not available.
 // This path exists for compatibility, but is significantly less efficient.
 
-#if !SHIM_CRYPTO_SPAN_APIS
+#if !DISABLE_SHIM_CRYPTO_SPAN_APIS
 #if canImport(Foundation)
 import Foundation
 #elseif canImport(SwiftSystem)

--- a/Sources/SwiftNetwork/Utilities/CryptoWrappers.swift
+++ b/Sources/SwiftNetwork/Utilities/CryptoWrappers.swift
@@ -15,7 +15,7 @@
 // Wrappers over older Crypto functions when span-based APIs are not available.
 // This path exists for compatibility, but is significantly less efficient.
 
-#if SHIM_CRYPTO_SPAN_APIS
+#if !SHIM_CRYPTO_SPAN_APIS
 #if canImport(Foundation)
 import Foundation
 #elseif canImport(SwiftSystem)


### PR DESCRIPTION
For projects that want to take advantage of the new Crypto Span APIs on Mac they should be able to do so without manually altering the project.  For example right now there is a build flag that would manually need to be removed.  This change moves the `SHIM_CRYPTO_SPAN_APIS` flag to a trait named: `DISABLE_SHIM_CRYPTO_SPAN_APIS`  and flips the polarity on it so it will be on by default and then when it needs to be disabled for performance sensitive cases the trait can be passed in to disable this path.

