### PR TITLE
SwiftQUIC: Reduce CPU overhead in getting inbound stream data delivered to the stream

### DIFF
--- a/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
@@ -1632,6 +1632,16 @@ extension HeterogeneousManyToManyProtocolHandler where SecondaryFlow: AutomaticU
         guard let flow = self.secondaryFlow(for: flowID) else { throw NetworkError.posix(EINVAL) }
         flow.serviceUpperReceiveQueue()
     }
+
+    // Enqueue and delivery the datagrams all in one shot
+    public func deliverInboundDatagrams(
+        flow flowID: MultiplexedFlowIdentifier,
+        datagrams: consuming FrameArray
+    ) throws(NetworkError) {
+        guard var flow = self.secondaryFlow(for: flowID) else { throw NetworkError.posix(EINVAL) }
+        try flow.addToUpperReceiveQueue(datagrams)
+        flow.serviceUpperReceiveQueue()
+    }
 }
 
 @_spi(ProtocolProvider)

--- a/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
@@ -1590,6 +1590,16 @@ extension ManyToManyApplicationDatagramProtocol where Flow: AutomaticUpperDatagr
         guard let flow = self.flow(for: flowID) else { throw NetworkError.posix(EINVAL) }
         flow.serviceUpperReceiveQueue()
     }
+
+    // Enqueue and delivery the datagrams all in one shot
+    public func deliverInboundDatagrams(
+        flow flowID: MultiplexedFlowIdentifier,
+        datagrams: consuming FrameArray
+    ) throws(NetworkError) {
+        guard var flow = self.flow(for: flowID) else { throw NetworkError.posix(EINVAL) }
+        try flow.addToUpperReceiveQueue(datagrams)
+        flow.serviceUpperReceiveQueue()
+    }
 }
 
 @available(Network 0.1.0, *)

--- a/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
@@ -1388,6 +1388,15 @@ extension ManyToManyApplicationStreamProtocol where Flow: AutomaticUpperStreamPr
         guard let flow = self.flow(for: flowID) else { throw NetworkError.posix(EINVAL) }
         flow.serviceUpperReceiveQueue()
     }
+    // Enqueue and delivery the stream data all in one shot
+    public func deliverInboundStreamData(
+        flow flowID: MultiplexedFlowIdentifier,
+        streamData: consuming FrameArray
+    ) throws(NetworkError) {
+        guard var flow = self.flow(for: flowID) else { throw NetworkError.posix(EINVAL) }
+        try flow.addToUpperReceiveQueue(streamData)
+        flow.serviceUpperReceiveQueue()
+    }
 }
 
 @_spi(ProtocolProvider)

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -5562,8 +5562,7 @@ extension QUICConnection {
 
         var frame = frame.frame
         frame.metadataComplete = true
-        try? enqueueInboundDatagrams(flow: matchingFlowIdentifier, datagrams: .init(frame: frame))
-        try? deliverEnqueuedInboundDatagrams(flow: matchingFlowIdentifier)
+        try? deliverInboundDatagrams(flow: matchingFlowIdentifier, datagrams: .init(frame: frame))
         return true
     }
 }

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -2374,8 +2374,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
                 continue
             }
 
-            try? enqueueInboundStreamData(flow: flowID, streamData: frameArray)
-            try? deliverEnqueuedInboundStreamData(flow: flowID)
+            try? deliverInboundStreamData(flow: flowID, streamData: frameArray)
 
             // When the stream is already in `resetReceived` state,
             // it should be closed when we receive STOP_SENDING, so we
@@ -4317,8 +4316,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         }
         if let frameArray = stream.dequeueReassembledData(connection: self) {
             do {
-                try enqueueInboundStreamData(flow: flowID, streamData: frameArray)
-                try deliverEnqueuedInboundStreamData(flow: flowID)
+                try deliverInboundStreamData(flow: flowID, streamData: frameArray)
                 sendFrames()
             } catch {
                 log.error("Error sending frames on stream close: \(error)")

--- a/Sources/SwiftNetwork/QUIC/QUICStream.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICStream.swift
@@ -328,7 +328,7 @@ struct StreamListMembership: OptionSet {
 // Also note that a flow identifier can exist in multiple lists at one time.
 @available(Network 0.1.0, *)
 struct QUICStreamList: ~Copyable {
-    private var list: [MultiplexedFlowIdentifier] = []
+    private var list: Deque<MultiplexedFlowIdentifier> = []
     private let name: StaticString
     private let listType: StreamListMembership
 

--- a/Sources/SwiftNetwork/QUIC/QUICStream.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICStream.swift
@@ -328,7 +328,7 @@ struct StreamListMembership: OptionSet {
 // Also note that a flow identifier can exist in multiple lists at one time.
 @available(Network 0.1.0, *)
 struct QUICStreamList: ~Copyable {
-    private var list: Deque<MultiplexedFlowIdentifier> = []
+    private var list = Deque<MultiplexedFlowIdentifier>()
     private let name: StaticString
     private let listType: StreamListMembership
 

--- a/Tests/SwiftNetworkTests/TestMultiplexingProtocol.swift
+++ b/Tests/SwiftNetworkTests/TestMultiplexingProtocol.swift
@@ -91,8 +91,7 @@ final class TestMultiplexingProtocol: ManyToManyApplicationDatagramProtocol, Man
             return
         }
         accessReceivedDatagrams(path: path) { frames in
-            try? enqueueInboundDatagrams(flow: flow, datagrams: frames.drainArray())
-            try? deliverEnqueuedInboundDatagrams(flow: flow)
+            try? deliverInboundDatagrams(flow: flow, datagrams: frames.drainArray())
         }
     }
 


### PR DESCRIPTION
When looking at the CPU usage in `inboundStopping` for server workloads we enqueue stream data and then call `deliverEnqueuedInboundStreamData` to send it.
This incurs 2 dictionary lookups for the stream when we can condense it all into one with a new method called `deliverInboundStreamData`.  

Next, in `inboundStopping` we remove the first value from an array when delivering the stream data.  This would be more efficient with a Deque.

Top of tree CPU usage:
```
187.93 M  1.3%	3.54 M  	     specialized QUICConnection.inboundStopping(path:)
42.02 M   0.3%	-       	       specialized ManyToManyApplicationStreamProtocol<>.deliverEnqueuedInboundStreamData(flow:)
30.90 M   0.2%	-       	       specialized AutomaticUpperStreamProcessing<>.serviceUpperReceiveQueue()
11.12 M   0.1%	-       	       specialized ManyToManyProtocolHandler.flow(for:)
39.97 M   0.3%	-       	        QUICConnection.sendFrames(ignoreCongestionWindow:delayedACK:)
28.14 M   0.2%	-       	        QUICStreamList.removeFirst(connection:)
21.16 M   0.1%	-       	        QUICStreamInstance.dequeueReassembledData(connection:)
12.94 M   0.1%	-       	          specialized ManyToManyProtocolHandler.applyToAllFlows(_:)
7.06 M    0.0%	-       	          specialized ManyToManyApplicationStreamProtocol<>.enqueueInboundStreamData(flow:streamData:)
7.06 M    0.0%	-       	        specialized ManyToManyProtocolHandler.flow(for)
```

With this change:
```
131.45 M  97.8%		  specialized QUICConnection.inboundStopping(path:)
35.55 M  26.4%	-	    specialized ManyToManyApplicationStreamProtocol<>.deliverInboundStreamData(flow:streamData:)
23.44 M  17.4%	-	    QUICConnection.sendFrames(ignoreCongestionWindow:delayedACK:)
22.06 M  16.4%	-	    QUICStreamInstance.dequeueReassembledData(connection:)
18.44 M  13.7%	-	    QUICStreamList.removeFirst(connection:)
```

Overall reduction of about 50 megacycles in aggregate.
Note that this change just adds a new function named `deliverInboundStreamData` and does not delete the previous methods for `enqueueInboundStreamData` and `deliverEnqueuedInboundStreamData` as I can see the utility of them individually.