### PR TITLE
SwiftQUIC: Calculate mock header length by hand

### DIFF
--- a/Sources/SwiftNetwork/QUIC/QUICFrame.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICFrame.swift
@@ -1709,13 +1709,9 @@ struct FrameStreamSendMetadata: QUICFrameProtocol {
         let streamID = stream.streamID!.value
         let roomBeforeAddingHeader = frame.unclaimedLength
 
-        let mockHeaderLength = Serializer.length { write in
-            write.vle(0)
-            write.vle(streamID)
-            if offset > 0 {
-                write.vle(offset)
-            }
-        }
+        // Calculate the mockHeaderLength by defining:
+        // (0 - variableLengthSize = 1) + streamID.variableLengthSize + (offset if present)
+        let mockHeaderLength = 1 + streamID.variableLengthSize + (offset > 0 ? offset.variableLengthSize : 0)
 
         guard roomBeforeAddingHeader >= mockHeaderLength else {
             // Not even room for the header


### PR DESCRIPTION
This is a very small performance win that I noticed while trying to optimize `FrameStreamSendMetadata`.
This change calculates the `mockHeaderLength` in `FrameStreamSendMetadata` by hand instead of going through the Serializer.  This now allows the Swift optimizer to optimize this path entirely away.  Saves about 10 megacycles.
