### PR TITLE
SwiftQUIC: Provide path events when QUICPath changes or is validated

### DIFF
--- a/Sources/SwiftNetwork/Endpoint/AddressEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/AddressEndpoint.swift
@@ -24,9 +24,9 @@ internal import os
 
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-public struct AddressEndpoint: EndpointProtocol, EndpointCommonProtocol {
+public struct AddressEndpoint: Sendable, EndpointProtocol, EndpointCommonProtocol {
     public var common: EndpointCommon
-    public enum AddressEndpointType: Equatable {
+    public enum AddressEndpointType: Sendable, Equatable {
         case v4(IPv4Address, UInt16)
         case v6(IPv6Address, UInt16)
         case unix(String)

--- a/Sources/SwiftNetwork/Endpoint/EndpointCommon.swift
+++ b/Sources/SwiftNetwork/Endpoint/EndpointCommon.swift
@@ -91,7 +91,7 @@ protocol EndpointProtocol: CustomStringConvertible {
 
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-public struct EndpointCommon: Equatable, Hashable {
+public struct EndpointCommon: Sendable, Equatable, Hashable {
     let interface: Interface?
     #if NETWORK_PRIVATE
     let commonPrivate: EndpointCommon_Private?

--- a/Sources/SwiftNetwork/Endpoint/EthernetAddress.swift
+++ b/Sources/SwiftNetwork/Endpoint/EthernetAddress.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 @available(Network 0.1.0, *)
-public struct EthernetAddress: Hashable, CustomDebugStringConvertible {
+public struct EthernetAddress: Sendable, Hashable, CustomDebugStringConvertible {
 
     public static var broadcast: EthernetAddress {
         EthernetAddress(EthernetAddressStorage(repeating: 0xff))

--- a/Sources/SwiftNetwork/Protocols/HarnessProtocols.swift
+++ b/Sources/SwiftNetwork/Protocols/HarnessProtocols.swift
@@ -759,6 +759,8 @@ public class NewFlowHarness<LinkageType: InboundFlowLinkage, HarnessType: UpperH
         public var disconnected: (() -> Void)?
         var newFlow = Deque<(() -> Void)>()
         public var error: ((NetworkError) -> Void)?  // invoked when error detected
+        public var pathChanged: ((QUICPathInfo) -> Void)?
+        public var pathValidated: ((QUICPathInfo) -> Void)?
         public init() {}
     }
     public var completions: Completions = .init()
@@ -818,6 +820,14 @@ public class NewFlowHarness<LinkageType: InboundFlowLinkage, HarnessType: UpperH
             switch quicEvent {
             case .newInboundConnectionID: newInboundCIDEventCount += 1
             case .newOutboundConnectionID: newOutboundCIDEventCount += 1
+            case .pathChanged(let info):
+                if let completion = completions.pathChanged {
+                    completion(info)
+                }
+            case .pathValidated(let info):
+                if let completion = completions.pathValidated {
+                    completion(info)
+                }
             default: break
             }
         }

--- a/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
@@ -253,6 +253,29 @@ public protocol MultiplexingPath: UpperProtocolHandler {
 public protocol MultiplexingDatapathPath: MultiplexingPath
 where LowerProtocol: OutboundDataLinkage, ParentProtocol: ManyToManyDatapathProtocol {}
 
+@_spi(ProtocolProvider)
+@available(Network 0.1.0, *)
+public enum PathAddress: Sendable, Equatable {
+    case v4(IPv4Address, port: UInt16)
+    case v6(IPv6Address, port: UInt16)
+    var endpoint: Endpoint {
+        switch self {
+        case .v4(let address, let port): return Endpoint(address: address, port: port)
+        case .v6(let address, let port): return Endpoint(address: address, port: port)
+        }
+    }
+}
+
+@_spi(ProtocolProvider)
+@available(Network 0.1.0, *)
+public struct DatagramPathEndpoints: Sendable, Equatable {
+    let local: PathAddress
+    let remote: PathAddress
+    public static func == (lhs: DatagramPathEndpoints, rhs: DatagramPathEndpoints) -> Bool {
+        lhs.local == rhs.local && lhs.remote == rhs.remote
+    }
+}
+
 // MARK: Implementations
 
 @available(Network 0.1.0, *)

--- a/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
@@ -255,22 +255,9 @@ where LowerProtocol: OutboundDataLinkage, ParentProtocol: ManyToManyDatapathProt
 
 @_spi(ProtocolProvider)
 @available(Network 0.1.0, *)
-public enum PathAddress: Sendable, Equatable {
-    case v4(IPv4Address, port: UInt16)
-    case v6(IPv6Address, port: UInt16)
-    var endpoint: Endpoint {
-        switch self {
-        case .v4(let address, let port): return Endpoint(address: address, port: port)
-        case .v6(let address, let port): return Endpoint(address: address, port: port)
-        }
-    }
-}
-
-@_spi(ProtocolProvider)
-@available(Network 0.1.0, *)
 public struct DatagramPathEndpoints: Sendable, Equatable {
-    let local: PathAddress
-    let remote: PathAddress
+    let local: AddressEndpoint
+    let remote: AddressEndpoint
     public static func == (lhs: DatagramPathEndpoints, rhs: DatagramPathEndpoints) -> Bool {
         lhs.local == rhs.local && lhs.remote == rhs.remote
     }

--- a/Sources/SwiftNetwork/Protocols/NetworkEvents.swift
+++ b/Sources/SwiftNetwork/Protocols/NetworkEvents.swift
@@ -22,15 +22,9 @@ public struct NetworkEventDomain: Sendable, Hashable, CustomStringConvertible {
 @_spi(ProtocolProvider)
 @available(Network 0.1.0, *)
 public struct QUICPathInfo: Sendable, Equatable {
-    private var datagramPathEndpoints: DatagramPathEndpoints
     public let isValidated: Bool
-    public var remote: Endpoint { datagramPathEndpoints.remote.endpoint }
-    public var local: Endpoint { datagramPathEndpoints.local.endpoint }
-
-    init(datagramPathEndpoints: DatagramPathEndpoints, isValidated: Bool) {
-        self.datagramPathEndpoints = datagramPathEndpoints
-        self.isValidated = isValidated
-    }
+    public let remote: AddressEndpoint
+    public let local: AddressEndpoint
 }
 
 @_spi(ProtocolProvider)

--- a/Sources/SwiftNetwork/Protocols/NetworkEvents.swift
+++ b/Sources/SwiftNetwork/Protocols/NetworkEvents.swift
@@ -22,27 +22,13 @@ public struct NetworkEventDomain: Sendable, Hashable, CustomStringConvertible {
 @_spi(ProtocolProvider)
 @available(Network 0.1.0, *)
 public struct QUICPathInfo: Sendable, Equatable {
-    public enum PathAddress: Sendable, Equatable {
-        case v4(IPv4Address, port: UInt16)
-        case v6(IPv6Address, port: UInt16)
-
-        var endpoint: Endpoint {
-            switch self {
-            case .v4(let address, let port): return Endpoint(address: address, port: port)
-            case .v6(let address, let port): return Endpoint(address: address, port: port)
-            }
-        }
-    }
-    private let _local: PathAddress?
-    private let _remote: PathAddress?
+    private var datagramPathEndpoints: DatagramPathEndpoints
     public let isValidated: Bool
+    public var remote: Endpoint { datagramPathEndpoints.remote.endpoint }
+    public var local: Endpoint { datagramPathEndpoints.local.endpoint }
 
-    public var local: Endpoint? { _local?.endpoint }
-    public var remote: Endpoint? { _remote?.endpoint }
-
-    init(local: PathAddress?, remote: PathAddress?, isValidated: Bool) {
-        self._local = local
-        self._remote = remote
+    init(datagramPathEndpoints: DatagramPathEndpoints, isValidated: Bool) {
+        self.datagramPathEndpoints = datagramPathEndpoints
         self.isValidated = isValidated
     }
 }
@@ -283,10 +269,10 @@ public enum QUICEvent: DomainSpecificNetworkProtocolEvent {
             return "QUIC: Received remote transport parameters"
         case .pathChanged(let pathInfo):
             return
-                "QUIC: Path changed local: \(pathInfo.local?.description ?? "N/A") remote: \(pathInfo.remote?.description ?? "N/A") validated: \(pathInfo.isValidated)"
+                "QUIC: Path changed local: \(pathInfo.local.description) remote: \(pathInfo.remote.description) validated: \(pathInfo.isValidated)"
         case .pathValidated(let pathInfo):
             return
-                "QUIC: Path validated local: \(pathInfo.local?.description ?? "N/A") remote: \(pathInfo.remote?.description ?? "N/A")"
+                "QUIC: Path validated local: \(pathInfo.local.description) remote: \(pathInfo.remote.description)"
         }
     }
 }

--- a/Sources/SwiftNetwork/Protocols/NetworkEvents.swift
+++ b/Sources/SwiftNetwork/Protocols/NetworkEvents.swift
@@ -21,6 +21,34 @@ public struct NetworkEventDomain: Sendable, Hashable, CustomStringConvertible {
 
 @_spi(ProtocolProvider)
 @available(Network 0.1.0, *)
+public struct QUICPathInfo: Sendable, Equatable {
+    public enum PathAddress: Sendable, Equatable {
+        case v4(IPv4Address, port: UInt16)
+        case v6(IPv6Address, port: UInt16)
+
+        var endpoint: Endpoint {
+            switch self {
+            case .v4(let address, let port): return Endpoint(address: address, port: port)
+            case .v6(let address, let port): return Endpoint(address: address, port: port)
+            }
+        }
+    }
+    private let _local: PathAddress?
+    private let _remote: PathAddress?
+    public let isValidated: Bool
+
+    public var local: Endpoint? { _local?.endpoint }
+    public var remote: Endpoint? { _remote?.endpoint }
+
+    init(local: PathAddress?, remote: PathAddress?, isValidated: Bool) {
+        self._local = local
+        self._remote = remote
+        self.isValidated = isValidated
+    }
+}
+
+@_spi(ProtocolProvider)
+@available(Network 0.1.0, *)
 /// An extensible event that a lower protocol reports to upper protocols.
 public struct NetworkProtocolEvent: Sendable, Equatable, CustomStringConvertible {
     enum InternalEvent: Equatable {
@@ -226,6 +254,8 @@ public enum QUICEvent: DomainSpecificNetworkProtocolEvent {
     case maxStreamsLimitUnidirectionalUpdated(maximumStreams: Int)
     case earlyDataRejected
     case receivedRemoteTransportParameters(transportParameters: [UInt8])
+    case pathChanged(_ info: QUICPathInfo)
+    case pathValidated(_ info: QUICPathInfo)
 
     public var description: String {
         switch self {
@@ -251,6 +281,12 @@ public enum QUICEvent: DomainSpecificNetworkProtocolEvent {
             return "QUIC: Early data rejected"
         case .receivedRemoteTransportParameters:
             return "QUIC: Received remote transport parameters"
+        case .pathChanged(let pathInfo):
+            return
+                "QUIC: Path changed local: \(pathInfo.local?.description ?? "N/A") remote: \(pathInfo.remote?.description ?? "N/A") validated: \(pathInfo.isValidated)"
+        case .pathValidated(let pathInfo):
+            return
+                "QUIC: Path validated local: \(pathInfo.local?.description ?? "N/A") remote: \(pathInfo.remote?.description ?? "N/A")"
         }
     }
 }

--- a/Sources/SwiftNetwork/Protocols/ProtocolControlHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolControlHandlers.swift
@@ -895,6 +895,17 @@ extension ProtocolInstanceReference {
         }
     }
 
+    public func getPathEndpoints(
+        _ from: ProtocolInstanceReference
+    ) -> (local: QUICPathInfo.PathAddress, remote: QUICPathInfo.PathAddress)? {
+        self.handleCallFromUpperProtocol {
+            switch self.reference {
+            case .udp(let index): return context.udpInstances[index].pathEndpoints()
+            default: return nil
+            }
+        }
+    }
+
     public func getMetrics(
         _ from: ProtocolInstanceReference,
         requestedNetworkMetric: RequestedNetworkMetrics

--- a/Sources/SwiftNetwork/Protocols/ProtocolControlHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolControlHandlers.swift
@@ -897,7 +897,7 @@ extension ProtocolInstanceReference {
 
     public func getPathEndpoints(
         _ from: ProtocolInstanceReference
-    ) -> (local: QUICPathInfo.PathAddress, remote: QUICPathInfo.PathAddress)? {
+    ) -> DatagramPathEndpoints? {
         guard !isNone else { return nil }
         return self.handleCallFromUpperProtocol {
             switch self.reference {

--- a/Sources/SwiftNetwork/Protocols/ProtocolControlHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolControlHandlers.swift
@@ -898,7 +898,8 @@ extension ProtocolInstanceReference {
     public func getPathEndpoints(
         _ from: ProtocolInstanceReference
     ) -> (local: QUICPathInfo.PathAddress, remote: QUICPathInfo.PathAddress)? {
-        self.handleCallFromUpperProtocol {
+        guard !isNone else { return nil }
+        return self.handleCallFromUpperProtocol {
             switch self.reference {
             case .udp(let index): return context.udpInstances[index].pathEndpoints()
             default: return nil

--- a/Sources/SwiftNetwork/Protocols/ProtocolLinkage.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolLinkage.swift
@@ -287,7 +287,7 @@ public struct OutboundDatagramLinkage: OutboundDataLinkage {
 
     public func invokeGetPathEndpoints(
         _ from: ProtocolInstanceReference
-    ) -> (local: QUICPathInfo.PathAddress, remote: QUICPathInfo.PathAddress)? {
+    ) -> DatagramPathEndpoints? {
         reference.getPathEndpoints(from)
     }
 }

--- a/Sources/SwiftNetwork/Protocols/ProtocolLinkage.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolLinkage.swift
@@ -284,6 +284,12 @@ public struct OutboundDatagramLinkage: OutboundDataLinkage {
     ) throws(NetworkError) {
         try reference.sendDatagrams(from, datagrams: datagrams)
     }
+
+    public func invokeGetPathEndpoints(
+        _ from: ProtocolInstanceReference
+    ) -> (local: QUICPathInfo.PathAddress, remote: QUICPathInfo.PathAddress)? {
+        reference.getPathEndpoints(from)
+    }
 }
 
 @_spi(ProtocolProvider)

--- a/Sources/SwiftNetwork/Protocols/UDPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/UDPProtocol.swift
@@ -485,6 +485,20 @@ public struct UDPProtocol: NetworkProtocol {
             snapshot.receivedTransportByteCount = UInt64(receiveByteCount)
             snapshot.sentTransportByteCount = UInt64(transmitByteCount)
         }
+
+        func pathEndpoints() -> (local: QUICPathInfo.PathAddress, remote: QUICPathInfo.PathAddress)? {
+            if isIPv4 {
+                return (
+                    local: .v4(ipv4Local, port: localPort),
+                    remote: .v4(ipv4Remote, port: remotePort)
+                )
+            } else {
+                return (
+                    local: .v6(ipv6Local, port: localPort),
+                    remote: .v6(ipv6Remote, port: remotePort)
+                )
+            }
+        }
     }
 
     public init() {}

--- a/Sources/SwiftNetwork/Protocols/UDPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/UDPProtocol.swift
@@ -486,14 +486,14 @@ public struct UDPProtocol: NetworkProtocol {
             snapshot.sentTransportByteCount = UInt64(transmitByteCount)
         }
 
-        func pathEndpoints() -> (local: QUICPathInfo.PathAddress, remote: QUICPathInfo.PathAddress)? {
+        func pathEndpoints() -> DatagramPathEndpoints? {
             if isIPv4 {
-                return (
+                return DatagramPathEndpoints(
                     local: .v4(ipv4Local, port: localPort),
                     remote: .v4(ipv4Remote, port: remotePort)
                 )
             } else {
-                return (
+                return DatagramPathEndpoints(
                     local: .v6(ipv6Local, port: localPort),
                     remote: .v6(ipv6Remote, port: remotePort)
                 )

--- a/Sources/SwiftNetwork/Protocols/UDPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/UDPProtocol.swift
@@ -489,13 +489,13 @@ public struct UDPProtocol: NetworkProtocol {
         func pathEndpoints() -> DatagramPathEndpoints? {
             if isIPv4 {
                 return DatagramPathEndpoints(
-                    local: .v4(ipv4Local, port: localPort),
-                    remote: .v4(ipv4Remote, port: remotePort)
+                    local: AddressEndpoint(address: ipv4Local, port: localPort),
+                    remote: AddressEndpoint(address: ipv4Remote, port: remotePort)
                 )
             } else {
                 return DatagramPathEndpoints(
-                    local: .v6(ipv6Local, port: localPort),
-                    remote: .v6(ipv6Remote, port: remotePort)
+                    local: AddressEndpoint(address: ipv6Local, port: localPort),
+                    remote: AddressEndpoint(address: ipv6Remote, port: remotePort)
                 )
             }
         }

--- a/Sources/SwiftNetwork/QUIC/Migration.swift
+++ b/Sources/SwiftNetwork/QUIC/Migration.swift
@@ -217,6 +217,14 @@ extension QUICConnection {
                 "Path \(path.identifier) \(path.state) over \(path.interface?.description ?? "nil")"
             )
         }
+        // Notify the stack about a path change event
+        let endpoints = path.lower.invokeGetPathEndpoints(path.reference)
+        let pathInfo = QUICPathInfo(
+            local: endpoints?.local,
+            remote: endpoints?.remote,
+            isValidated: path.isValidated
+        )
+        deliverNetworkProtocolEvent(flow: .allFlows, event: .init(quicEvent: .pathChanged(pathInfo)))
 
         // This is a new primary path. Migrate to it if we are the client.
         if !isServer, path != currentPath, isPrimary, path.isRouteEstablished {

--- a/Sources/SwiftNetwork/QUIC/Migration.swift
+++ b/Sources/SwiftNetwork/QUIC/Migration.swift
@@ -218,12 +218,8 @@ extension QUICConnection {
             )
         }
         // Notify the stack about a path change event
-        if let endpoints = path.lower.invokeGetPathEndpoints(path.reference) {
-            let pathInfo = QUICPathInfo(
-                local: endpoints.local,
-                remote: endpoints.remote,
-                isValidated: path.isValidated
-            )
+        if let datagramPathEndpoints = path.lower.invokeGetPathEndpoints(path.reference) {
+            let pathInfo = QUICPathInfo(datagramPathEndpoints: datagramPathEndpoints, isValidated: path.isValidated)
             deliverNetworkProtocolEvent(flow: .allFlows, event: .init(quicEvent: .pathChanged(pathInfo)))
         }
 

--- a/Sources/SwiftNetwork/QUIC/Migration.swift
+++ b/Sources/SwiftNetwork/QUIC/Migration.swift
@@ -219,7 +219,11 @@ extension QUICConnection {
         }
         // Notify the stack about a path change event
         if let datagramPathEndpoints = path.lower.invokeGetPathEndpoints(path.reference) {
-            let pathInfo = QUICPathInfo(datagramPathEndpoints: datagramPathEndpoints, isValidated: path.isValidated)
+            let pathInfo = QUICPathInfo(
+                isValidated: path.isValidated,
+                remote: datagramPathEndpoints.remote,
+                local: datagramPathEndpoints.local
+            )
             deliverNetworkProtocolEvent(flow: .allFlows, event: .init(quicEvent: .pathChanged(pathInfo)))
         }
 

--- a/Sources/SwiftNetwork/QUIC/Migration.swift
+++ b/Sources/SwiftNetwork/QUIC/Migration.swift
@@ -218,13 +218,14 @@ extension QUICConnection {
             )
         }
         // Notify the stack about a path change event
-        let endpoints = path.lower.invokeGetPathEndpoints(path.reference)
-        let pathInfo = QUICPathInfo(
-            local: endpoints?.local,
-            remote: endpoints?.remote,
-            isValidated: path.isValidated
-        )
-        deliverNetworkProtocolEvent(flow: .allFlows, event: .init(quicEvent: .pathChanged(pathInfo)))
+        if let endpoints = path.lower.invokeGetPathEndpoints(path.reference) {
+            let pathInfo = QUICPathInfo(
+                local: endpoints.local,
+                remote: endpoints.remote,
+                isValidated: path.isValidated
+            )
+            deliverNetworkProtocolEvent(flow: .allFlows, event: .init(quicEvent: .pathChanged(pathInfo)))
+        }
 
         // This is a new primary path. Migrate to it if we are the client.
         if !isServer, path != currentPath, isPrimary, path.isRouteEstablished {

--- a/Sources/SwiftNetwork/QUIC/QUICPath.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICPath.swift
@@ -620,7 +620,11 @@ public final class QUICPath: MultiplexingDatagramPath<QUICConnection>, Equatable
         parentProtocol.migration.resetTimer(connection: parentProtocol)
         // Notify the stack about the path becoming validated
         if let datagramPathEndpoints = lower.invokeGetPathEndpoints(reference) {
-            let pathInfo = QUICPathInfo(datagramPathEndpoints: datagramPathEndpoints, isValidated: state.isValidated)
+            let pathInfo = QUICPathInfo(
+                isValidated: self.isValidated,
+                remote: datagramPathEndpoints.remote,
+                local: datagramPathEndpoints.local
+            )
             parentProtocol.deliverNetworkProtocolEvent(
                 flow: .allFlows,
                 event: .init(quicEvent: .pathValidated(pathInfo))

--- a/Sources/SwiftNetwork/QUIC/QUICPath.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICPath.swift
@@ -619,13 +619,17 @@ public final class QUICPath: MultiplexingDatagramPath<QUICConnection>, Equatable
         rtt.processNewSample(ackDuration: responseDuration, packetAckedTime: now, ackDelay: .zero)
         parentProtocol.migration.resetTimer(connection: parentProtocol)
         // Notify the stack about the path becoming validated
-        let endpoints = lower.invokeGetPathEndpoints(reference)
-        let pathInfo = QUICPathInfo(
-            local: endpoints?.local,
-            remote: endpoints?.remote,
-            isValidated: state.isValidated
-        )
-        parentProtocol.deliverNetworkProtocolEvent(flow: .allFlows, event: .init(quicEvent: .pathValidated(pathInfo)))
+        if let endpoints = lower.invokeGetPathEndpoints(reference) {
+            let pathInfo = QUICPathInfo(
+                local: endpoints.local,
+                remote: endpoints.remote,
+                isValidated: state.isValidated
+            )
+            parentProtocol.deliverNetworkProtocolEvent(
+                flow: .allFlows,
+                event: .init(quicEvent: .pathValidated(pathInfo))
+            )
+        }
         if migrationPending {
             migrationPending = false
             parentProtocol.migration.migrate(to: self, connection: parentProtocol)

--- a/Sources/SwiftNetwork/QUIC/QUICPath.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICPath.swift
@@ -618,6 +618,14 @@ public final class QUICPath: MultiplexingDatagramPath<QUICConnection>, Equatable
         // Initialize RTT based on the PATH_RESPONSE duration so that we have a proper RTT estimate when we reset the timers.
         rtt.processNewSample(ackDuration: responseDuration, packetAckedTime: now, ackDelay: .zero)
         parentProtocol.migration.resetTimer(connection: parentProtocol)
+        // Notify the stack about the path becoming validated
+        let endpoints = lower.invokeGetPathEndpoints(reference)
+        let pathInfo = QUICPathInfo(
+            local: endpoints?.local,
+            remote: endpoints?.remote,
+            isValidated: state.isValidated
+        )
+        parentProtocol.deliverNetworkProtocolEvent(flow: .allFlows, event: .init(quicEvent: .pathValidated(pathInfo)))
         if migrationPending {
             migrationPending = false
             parentProtocol.migration.migrate(to: self, connection: parentProtocol)

--- a/Sources/SwiftNetwork/QUIC/QUICPath.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICPath.swift
@@ -619,12 +619,8 @@ public final class QUICPath: MultiplexingDatagramPath<QUICConnection>, Equatable
         rtt.processNewSample(ackDuration: responseDuration, packetAckedTime: now, ackDelay: .zero)
         parentProtocol.migration.resetTimer(connection: parentProtocol)
         // Notify the stack about the path becoming validated
-        if let endpoints = lower.invokeGetPathEndpoints(reference) {
-            let pathInfo = QUICPathInfo(
-                local: endpoints.local,
-                remote: endpoints.remote,
-                isValidated: state.isValidated
-            )
+        if let datagramPathEndpoints = lower.invokeGetPathEndpoints(reference) {
+            let pathInfo = QUICPathInfo(datagramPathEndpoints: datagramPathEndpoints, isValidated: state.isValidated)
             parentProtocol.deliverNetworkProtocolEvent(
                 flow: .allFlows,
                 event: .init(quicEvent: .pathValidated(pathInfo))

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICStackTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICStackTests.swift
@@ -538,6 +538,221 @@ final class SwiftNetworkQUICStackTests: NetTestCase {
             dataToSend: Array("Hello World!".utf8)
         )
     }
+
+    func testQUICPathEvents() {
+        // 10.0.0.99 - new client address simulating the client switching network interfaces
+        // So this test would be client initiated migration
+        let newLocalIPv4Address: [UInt8] = [0x0a, 0x00, 0x00, 0x63]
+
+        let clientEndpoint = Endpoint(
+            address: IPv4Address(SwiftNetworkQUICStackTests.localIPv4Address)!,
+            port: 1234
+        )
+        let serverEndpoint = Endpoint(
+            address: IPv4Address(SwiftNetworkQUICStackTests.localIPv4Address)!,
+            port: 8080
+        )
+        // The client gets a new source address; the server address stays fixed.
+        let newClientEndpoint = Endpoint(
+            address: IPv4Address(newLocalIPv4Address)!,
+            port: 4321
+        )
+
+        let clientParameters = Parameters()
+        let context = clientParameters.context
+
+        let handshakeExpectation = XCTestExpectation(description: "QUIC handshake complete")
+        let pathChangedExpectation = XCTestExpectation(description: "pathChanged event received")
+        let pathValidatedExpectation = XCTestExpectation(description: "pathValidated event received")
+
+        var clientQUICReference: ProtocolInstanceReference?
+        var serverQUICReference: ProtocolInstanceReference?
+        var clientUpperHarness: StreamUpperHarness?
+        var serverUpperHarness: NewStreamFlowHarness?
+        var pairedPathsArray = [PairedUDPIPPaths]()
+
+        var receivedPathChangedInfo: QUICPathInfo?
+        var receivedPathValidatedInfo: QUICPathInfo?
+
+        context.async {
+            defer { handshakeExpectation.fulfill() }
+
+            let initialPaths = PairedUDPIPPaths(
+                context: context,
+                identifier: "1",
+                clientEndpoint: clientEndpoint,
+                serverEndpoint: serverEndpoint
+            )
+            pairedPathsArray.append(initialPaths)
+
+            let clientQUICOptions = self.createQUICTestOptions(
+                server: false,
+                sourceConnectionIDLength: 8
+            )
+            clientQUICOptions.setLogID(prefix: "C", parent: "pathEvents", protocolLogIDNumber: 1)
+            let clientQUIC = QUICProtocol.instance(context: context)
+            clientQUICOptions.setProtocolInstance(clientQUIC)
+            clientQUICReference = clientQUIC
+
+            clientParameters.defaultStack.prepend(applicationProtocol: .quic(clientQUICOptions))
+
+            let clientPath = PathProperties(parameters: clientParameters)
+            let clientListenerLinkage = StreamListenerLinkage(reference: clientQUIC)
+            clientUpperHarness = StreamUpperHarness(
+                identifier: "Client",
+                local: clientEndpoint,
+                remote: serverEndpoint,
+                parameters: clientParameters,
+                path: clientPath,
+                context: context,
+                listenerProtocol: clientListenerLinkage
+            )
+            XCTAssertNotNil(clientUpperHarness)
+            guard let clientUpperHarness else { return }
+
+            try! clientQUIC.attachLowerDatagramProtocolForNewPath(
+                initialPaths.clientTop,
+                remote: serverEndpoint,
+                local: clientEndpoint,
+                parameters: clientParameters,
+                path: clientPath
+            )
+
+            var serverParameters = Parameters()
+            serverParameters.isServer = true
+            let serverPath = PathProperties(parameters: serverParameters)
+            let serverQUICOptions = self.createQUICTestOptions(server: true)
+            serverQUICOptions.setLogID(prefix: "L", parent: "pathEvents", protocolLogIDNumber: 1)
+            let serverQUIC = QUICProtocol.instance(context: context)
+            serverQUICOptions.setProtocolInstance(serverQUIC)
+            serverQUICReference = serverQUIC
+
+            serverParameters.defaultStack.prepend(applicationProtocol: .quic(serverQUICOptions))
+
+            let serverListenerLinkage = StreamListenerLinkage(reference: serverQUIC)
+            serverUpperHarness = NewStreamFlowHarness(
+                identifier: "Server",
+                local: serverEndpoint,
+                remote: clientEndpoint,
+                parameters: serverParameters,
+                path: serverPath,
+                context: context,
+                listenerProtocol: serverListenerLinkage
+            )
+            XCTAssertNotNil(serverUpperHarness)
+            guard let serverUpperHarness else { return }
+
+            try! serverQUIC.attachLowerDatagramProtocolForNewPath(
+                initialPaths.serverTop,
+                remote: clientEndpoint,
+                local: serverEndpoint,
+                parameters: serverParameters,
+                path: serverPath
+            )
+
+            // Register path event callbacks on the server-side connection harness
+            serverUpperHarness.completions.pathChanged = { pathInfo in
+                receivedPathChangedInfo = pathInfo
+                pathChangedExpectation.fulfill()
+            }
+            serverUpperHarness.completions.pathValidated = { pathInfo in
+                receivedPathValidatedInfo = pathInfo
+                pathValidatedExpectation.fulfill()
+            }
+
+            var serverConnected = false
+            serverUpperHarness.start { connected in
+                serverConnected = true
+                XCTAssertTrue(connected)
+                handshakeExpectation.fulfill()
+            }
+
+            clientUpperHarness.start { connected in
+                XCTAssertTrue(connected)
+            }
+
+            while !serverConnected {
+                if initialPaths.transferPackets() == 0 { break }
+            }
+        }
+
+        wait(for: [handshakeExpectation], timeout: 10.0)
+        XCTAssertNotNil(clientQUICReference)
+        XCTAssertNotNil(serverQUICReference)
+        guard let clientQUICReference, let serverQUICReference else { return }
+
+        // Migration: client switches to a new source address, server address is unchanged
+        let migrationExpectation = XCTestExpectation(description: "migration path complete")
+        context.async {
+            defer { migrationExpectation.fulfill() }
+
+            // The server endpoint is the same — only the clients source address changes.
+            let migrationPaths = PairedUDPIPPaths(
+                context: context,
+                identifier: "2",
+                clientEndpoint: newClientEndpoint,
+                serverEndpoint: serverEndpoint,
+                maximumDatagramSize: 1500
+            )
+            pairedPathsArray.append(migrationPaths)
+
+            let clientMigrationParameters = Parameters()
+            let serverMigrationParameters = Parameters()
+
+            try! clientQUICReference.attachLowerDatagramProtocolForNewPath(
+                migrationPaths.clientTop,
+                remote: serverEndpoint,
+                local: newClientEndpoint,
+                parameters: clientMigrationParameters,
+                path: PathProperties(parameters: clientMigrationParameters)
+            )
+            try! serverQUICReference.attachLowerDatagramProtocolForNewPath(
+                migrationPaths.serverTop,
+                remote: newClientEndpoint,
+                local: serverEndpoint,
+                parameters: serverMigrationParameters,
+                path: PathProperties(parameters: serverMigrationParameters)
+            )
+
+            migrationPaths.server.deliverPathIsNotPrimary()
+            migrationPaths.client.deliverPathIsPrimary()
+
+            for _ in 0..<10 {
+                if migrationPaths.transferPackets() == 0 { break }
+            }
+        }
+
+        wait(for: [migrationExpectation], timeout: 10.0)
+        wait(for: [pathChangedExpectation, pathValidatedExpectation], timeout: 10.0)
+
+        XCTAssertNotNil(receivedPathChangedInfo, "Expected pathChanged event")
+        XCTAssertNotNil(receivedPathValidatedInfo, "Expected pathValidated event")
+
+        // This validations are for the server side so the remote should change here
+        if let pathInfo = receivedPathValidatedInfo {
+            XCTAssertTrue(pathInfo.isValidated)
+            XCTAssertNotNil(pathInfo.local!)
+            XCTAssertNotNil(pathInfo.remote!)
+            XCTAssertTrue(pathInfo.local! == serverEndpoint)
+            XCTAssertTrue(pathInfo.remote! == newClientEndpoint)
+        }
+        if let pathInfo = receivedPathChangedInfo {
+            XCTAssertNotNil(pathInfo.local!)
+            XCTAssertNotNil(pathInfo.remote!)
+            XCTAssertTrue(pathInfo.local! == serverEndpoint)
+            XCTAssertTrue(pathInfo.remote! == newClientEndpoint)
+        }
+
+        let stopExpectation = XCTestExpectation(description: "stop")
+        context.async {
+            clientUpperHarness?.stop()
+            serverUpperHarness?.stop()
+            clientUpperHarness?.teardown()
+            serverUpperHarness?.teardown()
+            stopExpectation.fulfill()
+        }
+        wait(for: [stopExpectation], timeout: 10.0)
+    }
 }
 #endif
 #endif

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICStackTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICStackTests.swift
@@ -548,14 +548,18 @@ final class SwiftNetworkQUICStackTests: NetTestCase {
             address: IPv4Address(SwiftNetworkQUICStackTests.localIPv4Address)!,
             port: 1234
         )
+        let serverAddress = IPv4Address(SwiftNetworkQUICStackTests.localIPv4Address)!
+        let serverPort: UInt16 = UInt16(8080)
         let serverEndpoint = Endpoint(
-            address: IPv4Address(SwiftNetworkQUICStackTests.localIPv4Address)!,
-            port: 8080
+            address: serverAddress,
+            port: serverPort
         )
         // The client gets a new source address; the server address stays fixed.
+        let newClientAddress = IPv4Address(newLocalIPv4Address)!
+        let newCLientPort = UInt16(4321)
         let newClientEndpoint = Endpoint(
-            address: IPv4Address(newLocalIPv4Address)!,
-            port: 4321
+            address: newClientAddress,
+            port: newCLientPort
         )
 
         let clientParameters = Parameters()
@@ -731,12 +735,12 @@ final class SwiftNetworkQUICStackTests: NetTestCase {
         // This validations are for the server side so the remote should change here
         if let pathInfo = receivedPathValidatedInfo {
             XCTAssertTrue(pathInfo.isValidated)
-            XCTAssertTrue(pathInfo.local == serverEndpoint)
-            XCTAssertTrue(pathInfo.remote == newClientEndpoint)
+            XCTAssertTrue(pathInfo.local == AddressEndpoint(address: serverAddress, port: serverPort))
+            XCTAssertTrue(pathInfo.remote == AddressEndpoint(address: newClientAddress, port: newCLientPort))
         }
         if let pathInfo = receivedPathChangedInfo {
-            XCTAssertTrue(pathInfo.local == serverEndpoint)
-            XCTAssertTrue(pathInfo.remote == newClientEndpoint)
+            XCTAssertTrue(pathInfo.local == AddressEndpoint(address: serverAddress, port: serverPort))
+            XCTAssertTrue(pathInfo.remote == AddressEndpoint(address: newClientAddress, port: newCLientPort))
         }
 
         let stopExpectation = XCTestExpectation(description: "stop")

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICStackTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICStackTests.swift
@@ -731,16 +731,12 @@ final class SwiftNetworkQUICStackTests: NetTestCase {
         // This validations are for the server side so the remote should change here
         if let pathInfo = receivedPathValidatedInfo {
             XCTAssertTrue(pathInfo.isValidated)
-            XCTAssertNotNil(pathInfo.local!)
-            XCTAssertNotNil(pathInfo.remote!)
-            XCTAssertTrue(pathInfo.local! == serverEndpoint)
-            XCTAssertTrue(pathInfo.remote! == newClientEndpoint)
+            XCTAssertTrue(pathInfo.local == serverEndpoint)
+            XCTAssertTrue(pathInfo.remote == newClientEndpoint)
         }
         if let pathInfo = receivedPathChangedInfo {
-            XCTAssertNotNil(pathInfo.local!)
-            XCTAssertNotNil(pathInfo.remote!)
-            XCTAssertTrue(pathInfo.local! == serverEndpoint)
-            XCTAssertTrue(pathInfo.remote! == newClientEndpoint)
+            XCTAssertTrue(pathInfo.local == serverEndpoint)
+            XCTAssertTrue(pathInfo.remote == newClientEndpoint)
         }
 
         let stopExpectation = XCTestExpectation(description: "stop")


### PR DESCRIPTION
There is a need for swift-nio-quic to observe events when `QUICPath` changes or becomes validated. This typically happens during connection migration.  It is not appropriate to expose `QUICPath` directly so this change exposes a new type called `QUICPathInfo` that carries local and remote Endpoint information about the new datagram path underneath QUIC when it changes.  When `QUICPath` changes or becomes validated `QUIC` checks with the lower protocol (UDP) to obtain the endpoints of the new path below it and sends a `QUICEvent` that can be observed at the connection level through an object such as `NewStreamFlowHarness` and the application level can update needed info based on these events.

Design considerations: `QUICPathInfo` needs to be `Sendable` because `DomainSpecificNetworkProtocolEvent` is `Sendable`.  `Endpoint` is not `Sendable` and so I had to expose it through a computed property here.   That is the need for `PathAddress` on `QUICPathInfo`.