### PR TITLE
SwiftQUIC: Bugfix in inboundShortheader

### DIFF
--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -2307,7 +2307,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         )
 
         guard
-            packet.destinationConnectionID == path.dcid
+            packet.destinationConnectionID == path.scid
                 || validateDCIDFromInboundPacket(packet, on: path)
         else {
             return false

--- a/Sources/SwiftNetwork/QUIC/QUICConnectionID.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnectionID.swift
@@ -169,7 +169,6 @@ public struct QUICConnectionID: Sendable, Equatable, CustomStringConvertible {
             return false
         }
         #if !NETWORK_EMBEDDED
-        // Contstant time equality
         return lhs.connectionIDStorage.span.withUnsafeBytes { left in
             rhs.connectionIDStorage.span.withUnsafeBytes { right in
                 memcmp(left.baseAddress!, right.baseAddress!, 20)

--- a/Sources/SwiftNetwork/QUIC/QUICConnectionID.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnectionID.swift
@@ -168,12 +168,24 @@ public struct QUICConnectionID: Sendable, Equatable, CustomStringConvertible {
         guard lhs.actualLength == rhs.actualLength else {
             return false
         }
+        #if !NETWORK_EMBEDDED
         // Contstant time equality
-        return lhs.connectionIDStorage.withUnsafeBytes { left in
-            rhs.connectionIDStorage.withUnsafeBytes { right in
+        return lhs.connectionIDStorage.span.withUnsafeBytes { left in
+            rhs.connectionIDStorage.span.withUnsafeBytes { right in
                 memcmp(left.baseAddress!, right.baseAddress!, 20)
             }
         } == 0
+        #else
+        // Fall back to comparing by index
+        let lhsSpan = lhs._connectionID.span
+        let rhsSpan = rhs._connectionID.span
+        for i in 0..<lhs.actualLength {
+            if lhsSpan[i] != rhsSpan[i] {
+                return false
+            }
+        }
+        return true
+        #endif
     }
 }
 

--- a/Sources/SwiftNetwork/QUIC/QUICConnectionID.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnectionID.swift
@@ -168,14 +168,12 @@ public struct QUICConnectionID: Sendable, Equatable, CustomStringConvertible {
         guard lhs.actualLength == rhs.actualLength else {
             return false
         }
-        let lhsSpan = lhs._connectionID.span
-        let rhsSpan = rhs._connectionID.span
-        for i in 0..<lhs.actualLength {
-            if lhsSpan[i] != rhsSpan[i] {
-                return false
+        // Contstant time equality
+        return lhs.connectionIDStorage.withUnsafeBytes { left in
+            rhs.connectionIDStorage.withUnsafeBytes { right in
+                memcmp(left.baseAddress!, right.baseAddress!, 20)
             }
-        }
-        return true
+        } == 0
     }
 }
 


### PR DESCRIPTION
This PR fixes incorrect logic when checking the packet DCID against what should be the path SCID in `handleInboundShortHeader`:
```
packet.destinationConnectionID == path.scid
```
This PR also optimizes the equality check for `QUICConnectionID` to now be constant time.  This is based on a helpful post from Karoy [here](https://forums.swift.org/t/how-to-check-two-array-instances-for-identity-equality-in-constant-time/78792/57).  In the `QUICStreamLoad` benchmark the CPU usage for this equality check no longer even shows up and is completely optimized away.