### PR TITLE
Reuse the sent packet deque across sendFrames calls

### DIFF
--- a/Sources/SwiftNetwork/QUIC/Preferences.swift
+++ b/Sources/SwiftNetwork/QUIC/Preferences.swift
@@ -29,6 +29,7 @@ struct QUICPreferences {
     let initialMaxData: Int? = nil
     let initialMaxStreamBidirectionalLocalData: Int? = nil
     let maxConnectivityProbes: Int = 3
+    let maxSentPacketsCapacity: Int = 512
 
     private init() {}
 }
@@ -54,6 +55,7 @@ struct QUICPreferences: ~Copyable, Sendable {
     let migrationKeepaliveThreshold: Int
     let quiclogDirectory: String
     let maxConnectivityProbes: Int
+    let maxSentPacketsCapacity: Int
 
     // Flow Control
     let initialStreamReceiveSpace: Int?
@@ -109,6 +111,10 @@ struct QUICPreferences: ~Copyable, Sendable {
         maxConnectivityProbes = QUICPreferences.findSetting(
             "max_connectivity_probes",
             defaultValue: 3
+        )
+        maxSentPacketsCapacity = QUICPreferences.findSetting(
+            "max_sent_packets_capacity",
+            defaultValue: 512
         )
         quiclogDirectory = QUICPreferences.findSetting("quiclog_directory", defaultValue: "")
 

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -2967,6 +2967,9 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
     // Indicates whether the asynchronous send continuation is running or not
     private var asyncSendRunning = false
 
+    // Storage for the packets recorded by a single sendFrames() call.
+    private var sentPackets = NetworkUniqueDeque<SentPacketRecord>(minimumCapacity: 10)
+
     private func capacityForPacketNumberSpace() -> Int {
         let packetNumberSpace = PacketNumberSpace.fromKeyState(keyState: self.keyState)
         if packetNumberSpace == .applicationData {
@@ -2977,6 +2980,16 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             }
         } else {
             return 1
+        }
+    }
+
+    private func shrinkSentPacketsIfNecessary() {
+        assert(self.sentPackets.isEmpty)
+        // 'sentPackets' is held onto for the lifetime of the connection. If a send burst grows it
+        // beyond a certain limit then drop the capacity. This avoids bursty traffic bloating memory
+        // indefinitely.
+        if self.sentPackets.capacity > 512 {
+            self.sentPackets = NetworkUniqueDeque()
         }
     }
 
@@ -2998,22 +3011,24 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             return false
         }
         return withCurrentPath { path in
-            var sentPackets = NetworkUniqueDeque<SentPacketRecord>(minimumCapacity: capacityForPacketNumberSpace())
+            self.sentPackets.reserveCapacity(capacityForPacketNumberSpace())
             var discardInitialRecoveryState = false
+
             let success = sendFramesInternal(
                 path: path,
                 ignoreCongestionWindow: ignoreCongestionWindow,
                 retransmission: false,
-                sentPackets: &sentPackets,
+                sentPackets: &self.sentPackets,
                 discardInitialRecoveryState: &discardInitialRecoveryState
             )
 
             // Trigger PMTUD if necessary
             var pmtudPackets = path.pmtudState.sendProbe(on: path)
             while let pmtudPacket = pmtudPackets.popFirst() {
-                sentPackets.append(pmtudPacket)
+                self.sentPackets.append(pmtudPacket)
             }
-            recovery.recordSentPackets(sentPackets, connection: self)
+            recovery.recordSentPackets(&self.sentPackets, connection: self)
+            self.shrinkSentPacketsIfNecessary()
             if discardInitialRecoveryState {
                 recovery.resetPNSpace(packetNumberSpace: .initial, connection: self)
                 withCurrentPath {
@@ -3030,16 +3045,17 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         ignoreCongestionWindow: Bool = false,
         retransmission: Bool = false
     ) -> Bool {
-        var sentPackets = NetworkUniqueDeque<SentPacketRecord>(minimumCapacity: capacityForPacketNumberSpace())
+        self.sentPackets.reserveCapacity(capacityForPacketNumberSpace())
         var discardInitialRecoveryState = false
         let success = sendFramesInternal(
             path: path,
             ignoreCongestionWindow: ignoreCongestionWindow,
             retransmission: retransmission,
-            sentPackets: &sentPackets,
+            sentPackets: &self.sentPackets,
             discardInitialRecoveryState: &discardInitialRecoveryState
         )
-        recovery.recordSentPackets(sentPackets, connection: self)
+        recovery.recordSentPackets(&self.sentPackets, connection: self)
+        self.shrinkSentPacketsIfNecessary()
         if discardInitialRecoveryState {
             recovery.resetPNSpace(packetNumberSpace: .initial, connection: self)
             withCurrentPath {
@@ -3068,8 +3084,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
     }
 
     func recordSentPackets(_ block: () -> NetworkUniqueDeque<SentPacketRecord>) {
-        let sentPackets = block()
-        recovery.recordSentPackets(sentPackets, connection: self)
+        var sentPackets = block()
+        recovery.recordSentPackets(&sentPackets, connection: self)
     }
 
     public func handleOutboundRoomAvailableEvent(path pathID: MultiplexingPathIdentifier) {
@@ -4884,8 +4900,8 @@ extension QUICConnection {
         )
 
         // Check if we need to send probes
-        let sentPackets = path.pmtudState.tryToSend(on: path)
-        recovery.recordSentPackets(sentPackets, connection: self)
+        var sentPackets = path.pmtudState.tryToSend(on: path)
+        recovery.recordSentPackets(&sentPackets, connection: self)
         return true
     }
 

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -2988,7 +2988,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         // 'sentPackets' is held onto for the lifetime of the connection. If a send burst grows it
         // beyond a certain limit then drop the capacity. This avoids bursty traffic bloating memory
         // indefinitely.
-        if self.sentPackets.capacity > 512 {
+        if self.sentPackets.capacity > QUICPreferences.shared.maxSentPacketsCapacity {
             self.sentPackets = NetworkUniqueDeque()
         }
     }

--- a/Sources/SwiftNetwork/QUIC/Recovery.swift
+++ b/Sources/SwiftNetwork/QUIC/Recovery.swift
@@ -748,13 +748,12 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
         }
     }
 
+    // Note: drains 'sentPackets', leaving the caller's storage empty and reusable.
     mutating func recordSentPackets(
-        _ sentPackets: consuming NetworkUniqueDeque<SentPacketRecord>,
+        _ sentPackets: inout NetworkUniqueDeque<SentPacketRecord>,
         connection: QUICConnection
     ) {
-        var sentPackets = sentPackets
-        while !sentPackets.isEmpty {
-            let packet = sentPackets.remove(at: 0)
+        while let packet = sentPackets.popFirst() {
             sentPacket(packet, time: connection.now, connection: connection)
         }
         if inBatch {
@@ -971,8 +970,8 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
 
         // We may have lost a PMTUD probe, so check if we want to resend it
         connection.withCurrentPath { path in
-            let sentPackets = path.pmtudState.tryToSend(on: path)
-            recordSentPackets(sentPackets, connection: connection)
+            var sentPackets = path.pmtudState.tryToSend(on: path)
+            recordSentPackets(&sentPackets, connection: connection)
             return
         }
     }
@@ -1019,8 +1018,8 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
             // want to resend it.
             let path = path ?? connection.currentPath
             if let path {
-                let sentPackets = path.pmtudState.tryToSend(on: path)
-                recordSentPackets(sentPackets, connection: connection)
+                var sentPackets = path.pmtudState.tryToSend(on: path)
+                recordSentPackets(&sentPackets, connection: connection)
             }
             connection.sendAllEnqueuedOutboundDatagrams()
         }
@@ -1247,11 +1246,11 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
             innerState.largerPacketCount > 0
         }
         if hasLargerPacketCount {
-            let sentPackets = path.pmtudState.ptoEvent(
+            var sentPackets = path.pmtudState.ptoEvent(
                 on: path,
                 ptoCount: path.recoveryState.PTOCount
             )
-            recordSentPackets(sentPackets, connection: connection)
+            recordSentPackets(&sentPackets, connection: connection)
         }
     }
 

--- a/Tests/QUICTests/RecoveryTests.swift
+++ b/Tests/QUICTests/RecoveryTests.swift
@@ -72,7 +72,7 @@ final class RecoveryTests: XCTestCase {
     func sentPacket(_ sentPacket: consuming SentPacketRecord, connection: QUICConnection) {
         var packets = NetworkUniqueDeque<SentPacketRecord>()
         packets.append(sentPacket)
-        connection.recovery.recordSentPackets(packets, connection: connection)
+        connection.recovery.recordSentPackets(&packets, connection: connection)
     }
 
     func testInitialValues() {


### PR DESCRIPTION
Motivation:

Both sendFrames() overloads create a new deque of SentPacketRecord on every call, only to hand its contents to recovery and throw the storage away.

Modifications:

- Store a deque on the QUICConnection and reuse it.
- Take 'sentPackets' inout rather than consuming in Recovery.recordSentPackets. It already drained the storage in place so now the connection can reuse the empty deque.

Result:

- Fewer allocations