### PR TITLE
Avoid allocating while parsing packet numbers

### DIFF
--- a/Sources/SwiftNetwork/QUIC/PacketParser.swift
+++ b/Sources/SwiftNetwork/QUIC/PacketParser.swift
@@ -717,13 +717,13 @@ extension Deserializer where Factory: ~Escapable {
             value = PacketNumber(Int64(pn))
         case 3:
             // 3 bytes
-            var packetNumberBytes = [UInt8](repeating: 0, count: 3)
-            try self.uint8(&packetNumberBytes[2])
-            try self.uint8(&packetNumberBytes[1])
-            try self.uint8(&packetNumberBytes[0])
-            let pn =
-                UInt32(packetNumberBytes[2]) << 16 | UInt32(packetNumberBytes[1]) << 8
-                | UInt32(packetNumberBytes[0])
+            var high: UInt8 = 0
+            var middle: UInt8 = 0
+            var low: UInt8 = 0
+            try self.uint8(&high)
+            try self.uint8(&middle)
+            try self.uint8(&low)
+            let pn = UInt32(high) << 16 | UInt32(middle) << 8 | UInt32(low)
             value = PacketNumber(Int64(pn))
         case 4:
             // 4 bytes

--- a/Tests/QUICTests/QUICPacketTests.swift
+++ b/Tests/QUICTests/QUICPacketTests.swift
@@ -430,6 +430,43 @@ final class PacketTests: XCTestCase {
             "Stateless Reset packet bytes should be zero due to a invalid packet size"
         )
     }
+
+    func testDeserializePacketNumber() throws {
+        typealias Vector = (
+            description: String,
+            bytes: [UInt8],
+            pnSize: UInt8,
+            expected: PacketNumber
+        )
+        let testVectors: [Vector] = [
+            ("1-byte packet number", [0x7f], 1, 0x7f),
+            ("2-byte packet number", [0x7f, 0xff], 2, 0x7fff),
+            ("3-byte packet number, low byte only", [0x00, 0x00, 0xff], 3, 0xff),
+            ("3-byte packet number, middle byte only", [0x00, 0xff, 0x00], 3, 0xff00),
+            ("3-byte packet number, high byte only", [0xff, 0x00, 0x00], 3, 0xff_0000),
+            ("3-byte packet number, all bytes", [0x12, 0x34, 0x56], 3, 0x12_3456),
+            ("4-byte packet number", [0x7f, 0xff, 0xff, 0xff], 4, 0x7fff_ffff),
+        ]
+
+        for vector in testVectors {
+            var frame = Frame(copyBuffer: vector.bytes)
+            defer {
+                frame.finalize(success: true)
+            }
+
+            var packetNumber = PacketNumber.none
+            let result = Deserializer.deserialize(&frame, claim: true) {
+                read throws(DeserializationError) in
+                try read.packetNumber(&packetNumber, pnSize: vector.pnSize)
+            }
+            XCTAssertEqual(
+                result,
+                .success(parsedBytes: vector.bytes.count, remainingBytes: 0),
+                "Failed test: \(vector.description)"
+            )
+            XCTAssertEqual(packetNumber, vector.expected, "Failed test: \(vector.description)")
+        }
+    }
 }
 
 #endif


### PR DESCRIPTION
Motivation:

Parsing a 3-byte packet number allocated a temporary 3-element array to hold the bytes while they were shifted into place.

Modifications:

- Read the three bytes into locals rather than an array.

Result:

- Fewer allocations