### PR TITLE
SwiftQUIC: PERF: Reduce CPU by 63% parsing QUIC header

### DIFF
--- a/Sources/SwiftNetwork/Protocols/Frame.swift
+++ b/Sources/SwiftNetwork/Protocols/Frame.swift
@@ -52,12 +52,12 @@ public struct Frame: ~Copyable {
         set { _endOffset = UInt32(newValue) }
     }
     private var _effectiveBufferLength: UInt32 = 0
-    var effectiveBufferLength: Int {
+    @usableFromInline var effectiveBufferLength: Int {
         get { Int(_effectiveBufferLength) }
         set { _effectiveBufferLength = UInt32(newValue) }
     }
     private var _aggregateBufferLength: UInt32 = 0
-    var aggregateBufferLength: Int {
+    @usableFromInline var aggregateBufferLength: Int {
         get { Int(_aggregateBufferLength) }
         set { _aggregateBufferLength = UInt32(newValue) }
     }
@@ -212,6 +212,11 @@ public struct Frame: ~Copyable {
         }
     }
 
+    @inline(__always)
+    public var firstOctet: UInt8? {
+        bytes?.unsafeLoad(fromUncheckedByteOffset: 0, as: UInt8.self)
+    }
+
     // Only unclaimed bytes in frame, for unsafe types
     private var unsafeUnclaimedBuffer: UnsafeMutableRawBufferPointer? {
         switch buffer {
@@ -261,6 +266,7 @@ public struct Frame: ~Copyable {
         }
     }
 
+    @inline(__always)
     public mutating func claim(fromStart: Int, fromEnd: Int = 0, adjustSingleIPAggregate: Bool = true) -> Bool {
         if adjustSingleIPAggregate && isSingleIPAggregate {
             guard fromEnd == 0 else {
@@ -786,6 +792,16 @@ extension Frame {
 
 @available(Network 0.1.0, *)
 extension Frame {
+
+    @inline(__always)
+    func copyInto(inlineArray: inout [20 of UInt8], length: Int) {
+        guard startOffset + length <= self._bytes.count else {
+            return
+        }
+        for i in 0..<length {
+            inlineArray[i] = self._bytes[startOffset + i]
+        }
+    }
     // Copy length bytes from offset in this Frame into destination Frame.
     // checking the source offset, length and destination fit.
     // Return the length that it was able to copy into destination.

--- a/Sources/SwiftNetwork/Protocols/Frame.swift
+++ b/Sources/SwiftNetwork/Protocols/Frame.swift
@@ -793,15 +793,6 @@ extension Frame {
 @available(Network 0.1.0, *)
 extension Frame {
 
-    //    @inline(__always)
-    //    func copyInto(inlineArray: inout [20 of UInt8], length: Int) {
-    //        guard startOffset + length <= self._bytes.count else {
-    //            return
-    //        }
-    //        for i in 0..<length {
-    //            inlineArray[i] = self._bytes[startOffset + i]
-    //        }
-    //    }
     // Copy length bytes from offset in this Frame into destination Frame.
     // checking the source offset, length and destination fit.
     // Return the length that it was able to copy into destination.

--- a/Sources/SwiftNetwork/Protocols/Frame.swift
+++ b/Sources/SwiftNetwork/Protocols/Frame.swift
@@ -212,11 +212,6 @@ public struct Frame: ~Copyable {
         }
     }
 
-    //    @inline(__always)
-    //    public var firstOctet: UInt8? {
-    //        bytes?.unsafeLoad(fromUncheckedByteOffset: 0, as: UInt8.self)
-    //    }
-
     // Only unclaimed bytes in frame, for unsafe types
     private var unsafeUnclaimedBuffer: UnsafeMutableRawBufferPointer? {
         switch buffer {

--- a/Sources/SwiftNetwork/Protocols/Frame.swift
+++ b/Sources/SwiftNetwork/Protocols/Frame.swift
@@ -212,10 +212,10 @@ public struct Frame: ~Copyable {
         }
     }
 
-    @inline(__always)
-    public var firstOctet: UInt8? {
-        bytes?.unsafeLoad(fromUncheckedByteOffset: 0, as: UInt8.self)
-    }
+    //    @inline(__always)
+    //    public var firstOctet: UInt8? {
+    //        bytes?.unsafeLoad(fromUncheckedByteOffset: 0, as: UInt8.self)
+    //    }
 
     // Only unclaimed bytes in frame, for unsafe types
     private var unsafeUnclaimedBuffer: UnsafeMutableRawBufferPointer? {
@@ -793,15 +793,15 @@ extension Frame {
 @available(Network 0.1.0, *)
 extension Frame {
 
-    @inline(__always)
-    func copyInto(inlineArray: inout [20 of UInt8], length: Int) {
-        guard startOffset + length <= self._bytes.count else {
-            return
-        }
-        for i in 0..<length {
-            inlineArray[i] = self._bytes[startOffset + i]
-        }
-    }
+    //    @inline(__always)
+    //    func copyInto(inlineArray: inout [20 of UInt8], length: Int) {
+    //        guard startOffset + length <= self._bytes.count else {
+    //            return
+    //        }
+    //        for i in 0..<length {
+    //            inlineArray[i] = self._bytes[startOffset + i]
+    //        }
+    //    }
     // Copy length bytes from offset in this Frame into destination Frame.
     // checking the source offset, length and destination fit.
     // Return the length that it was able to copy into destination.

--- a/Sources/SwiftNetwork/QUIC/PacketParser.swift
+++ b/Sources/SwiftNetwork/QUIC/PacketParser.swift
@@ -317,15 +317,10 @@ struct PacketParser: ~Copyable, PrefixedLoggable {
     }
 
     private func parseHeader(frame: inout Frame, dcidLength: Int) throws(QUICError) -> Packet {
-        var firstOctet: UInt8 = 0
         let originalLength = frame.unclaimedLength
-        guard let firstFrameOctet = frame.firstOctet else {
+        guard let firstOctet = try? InlineDeserializer.uint8(frame: &frame, claim: true) else {
             throw QUICError.packet(QUICPacketError.deserializationError)
         }
-        guard frame.claim(fromStart: 1) else {
-            throw QUICError.packet(QUICPacketError.deserializationError)
-        }
-        firstOctet = firstFrameOctet
         // Common short/long header bits
         let longHeader = (firstOctet & 0x80) != 0
 
@@ -525,8 +520,14 @@ struct PacketParser: ~Copyable, PrefixedLoggable {
             throw QUICError.packet(QUICPacketError.deserializationError)
         }
         var dcidStorage = QUICConnectionIDStorage.empty
-        frame.copyInto(inlineArray: &dcidStorage, length: Int(dcidLength))
-        guard frame.claim(fromStart: dcidLength) else {
+        guard
+            let _ = try? InlineDeserializer.connectionID(
+                frame: &frame,
+                storage: &dcidStorage,
+                length: Int(dcidLength),
+                claim: true
+            )
+        else {
             throw QUICError.packet(QUICPacketError.deserializationError)
         }
         return Packet(

--- a/Sources/SwiftNetwork/QUIC/PacketParser.swift
+++ b/Sources/SwiftNetwork/QUIC/PacketParser.swift
@@ -317,8 +317,11 @@ struct PacketParser: ~Copyable, PrefixedLoggable {
     }
 
     private func parseHeader(frame: inout Frame, dcidLength: Int) throws(QUICError) -> Packet {
+        var firstOctet: UInt8 = 0
         let originalLength = frame.unclaimedLength
-        guard let firstOctet = try? InlineDeserializer.uint8(frame: &frame, claim: true) else {
+        do throws(DeserializationError) {
+            firstOctet = try FrameDeserializer.uint8(frame: &frame, claim: true)
+        } catch {
             throw QUICError.packet(QUICPacketError.deserializationError)
         }
         // Common short/long header bits
@@ -520,14 +523,14 @@ struct PacketParser: ~Copyable, PrefixedLoggable {
             throw QUICError.packet(QUICPacketError.deserializationError)
         }
         var dcidStorage = QUICConnectionIDStorage.empty
-        guard
-            let _ = try? InlineDeserializer.connectionID(
+        do throws(DeserializationError) {
+            try FrameDeserializer.connectionID(
                 frame: &frame,
                 storage: &dcidStorage,
                 length: Int(dcidLength),
                 claim: true
             )
-        else {
+        } catch {
             throw QUICError.packet(QUICPacketError.deserializationError)
         }
         return Packet(

--- a/Sources/SwiftNetwork/QUIC/PacketParser.swift
+++ b/Sources/SwiftNetwork/QUIC/PacketParser.swift
@@ -319,11 +319,13 @@ struct PacketParser: ~Copyable, PrefixedLoggable {
     private func parseHeader(frame: inout Frame, dcidLength: Int) throws(QUICError) -> Packet {
         var firstOctet: UInt8 = 0
         let originalLength = frame.unclaimedLength
-        let result = Deserializer.deserialize(&frame, claim: true) { read throws(DeserializationError) in
-            try read.uint8(&firstOctet)
+        guard let firstFrameOctet = frame.firstOctet else {
+            throw QUICError.packet(QUICPacketError.deserializationError)
         }
-        try validateDeserializationResult(result)
-
+        guard frame.claim(fromStart: 1) else {
+            throw QUICError.packet(QUICPacketError.deserializationError)
+        }
+        firstOctet = firstFrameOctet
         // Common short/long header bits
         let longHeader = (firstOctet & 0x80) != 0
 
@@ -342,7 +344,6 @@ struct PacketParser: ~Copyable, PrefixedLoggable {
                 originalLength: originalLength
             )
         }
-        packet.framesReceived.reserveCapacity(1)
         return packet
     }
 
@@ -523,16 +524,13 @@ struct PacketParser: ~Copyable, PrefixedLoggable {
             log.error("Short header fixed bit is zero")
             throw QUICError.packet(QUICPacketError.deserializationError)
         }
-
         var dcidStorage = QUICConnectionIDStorage.empty
-        let result = Deserializer.deserialize(&frame, claim: true) { read throws(DeserializationError) in
-            try read.connectionID(&dcidStorage, length: dcidLength)
+        frame.copyInto(inlineArray: &dcidStorage, length: Int(dcidLength))
+        guard frame.claim(fromStart: dcidLength) else {
+            throw QUICError.packet(QUICPacketError.deserializationError)
         }
-        try validateDeserializationResult(result)
-
-        let destinationConnectionID = QUICConnectionID(storage: dcidStorage, size: Int(dcidLength))
         return Packet(
-            destinationConnectionID: destinationConnectionID,
+            destinationConnectionID: QUICConnectionID(storage: dcidStorage, size: Int(dcidLength)),
             headerLength: UInt16(originalLength - frame.unclaimedLength),
             spin: spinValue
         )

--- a/Sources/SwiftNetwork/QUIC/QUICConnectionID.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnectionID.swift
@@ -88,8 +88,10 @@ public struct QUICConnectionID: Sendable, Equatable, CustomStringConvertible {
     // Creates a QUICConnectionID from an array.
     public init?(_ connectionID: [UInt8]) {
         guard connectionID.count <= QUICConnectionID.maximumSize else {
+            #if !DisableErrorLogging
             let connectionIDCount = connectionID.count
-            Logger.proto.fault("Invalid QUICConnectionID length \(connectionIDCount)")
+            Logger.proto.error("Invalid QUICConnectionID length \(connectionIDCount)")
+            #endif
             return nil
         }
         actualLength = connectionID.count
@@ -101,15 +103,19 @@ public struct QUICConnectionID: Sendable, Equatable, CustomStringConvertible {
         if size <= QUICConnectionID.maximumSize {
             actualLength = size
         } else {
-            Logger.proto.fault("Invalid QUICConnectionID length \(size)")
+            #if !DisableErrorLogging
+            Logger.proto.error("Invalid QUICConnectionID length \(size)")
+            #endif
             actualLength = QUICConnectionID.maximumSize
         }
     }
 
     public init?(_ connectionID: Span<UInt8>) {
         guard connectionID.count <= QUICConnectionID.maximumSize else {
+            #if !DisableErrorLogging
             let connectionIDCount = connectionID.count
-            Logger.proto.fault("Invalid QUICConnectionID length \(connectionIDCount)")
+            Logger.proto.error("Invalid QUICConnectionID length \(connectionIDCount)")
+            #endif
             return nil
         }
         actualLength = connectionID.count
@@ -120,7 +126,9 @@ public struct QUICConnectionID: Sendable, Equatable, CustomStringConvertible {
     public init(_ size: Int) {
         var size = size
         if size > QUICConnectionID.maximumSize {
-            Logger.proto.fault("Invalid QUICConnectionID length \(size)")
+            #if !DisableErrorLogging
+            Logger.proto.error("Invalid QUICConnectionID length \(size)")
+            #endif
             size = QUICConnectionID.maximumSize
         }
         if size != 0 && size < 4 {
@@ -133,7 +141,9 @@ public struct QUICConnectionID: Sendable, Equatable, CustomStringConvertible {
     // Creates a QUICConnectionID from a buffer with a specific size.
     init?(_ buffer: [UInt8], size: Int) {
         guard size <= QUICConnectionID.maximumSize, buffer.count >= size else {
-            Logger.proto.fault("Invalid QUICConnectionID length \(size)")
+            #if !DisableErrorLogging
+            Logger.proto.error("Invalid QUICConnectionID length \(size)")
+            #endif
             return nil
         }
         let cidBytes = Array(buffer[0..<min(size, QUICConnectionID.maximumSize)])

--- a/Sources/SwiftNetwork/Utilities/Deserializer.swift
+++ b/Sources/SwiftNetwork/Utilities/Deserializer.swift
@@ -74,10 +74,10 @@ public enum DeserializationResult: CustomStringConvertible, Equatable, Sendable 
 
 @_spi(ProtocolProvider)
 @available(Network 0.1.0, *)
-public struct InlineDeserializer {}
+public struct FrameDeserializer {}
 
 @available(Network 0.1.0, *)
-extension InlineDeserializer {
+extension FrameDeserializer {
     @inline(__always)
     static func uint8(frame: inout Frame, claim: Bool = false) throws(DeserializationError) -> UInt8 {
         guard frame._bytes.count > 0 else {
@@ -90,6 +90,81 @@ extension InlineDeserializer {
             }
         }
         return value
+    }
+
+    @inline(__always)
+    static func uint16(frame: inout Frame, claim: Bool = false) throws(DeserializationError) -> UInt16 {
+        guard frame.startOffset + 2 <= frame._bytes.count else {
+            throw DeserializationError.bufferTooShort
+        }
+        let value = frame._bytes.span.bytes.unsafeLoadUnaligned(
+            fromByteOffset: frame.startOffset,
+            as: UInt16.self
+        )
+        if claim {
+            guard frame.claim(fromStart: 2) else {
+                throw DeserializationError.bufferTooShort
+            }
+        }
+        return value
+    }
+
+    @inline(__always)
+    static func uint16NetworkByteOrder(
+        frame: inout Frame,
+        claim: Bool = false
+    ) throws(DeserializationError) -> UInt16 {
+        UInt16(bigEndian: try uint16(frame: &frame, claim: claim))
+    }
+
+    @inline(__always)
+    static func uint32(frame: inout Frame, claim: Bool = false) throws(DeserializationError) -> UInt32 {
+        guard frame.startOffset + 4 <= frame._bytes.count else {
+            throw DeserializationError.bufferTooShort
+        }
+        let value = frame._bytes.span.bytes.unsafeLoadUnaligned(
+            fromByteOffset: frame.startOffset,
+            as: UInt32.self
+        )
+        if claim {
+            guard frame.claim(fromStart: 4) else {
+                throw DeserializationError.bufferTooShort
+            }
+        }
+        return value
+    }
+
+    @inline(__always)
+    static func uint32NetworkByteOrder(
+        frame: inout Frame,
+        claim: Bool = false
+    ) throws(DeserializationError) -> UInt32 {
+        UInt32(bigEndian: try uint32(frame: &frame, claim: claim))
+    }
+
+    @inline(__always)
+    static func uint64(frame: inout Frame, claim: Bool = false) throws(DeserializationError) -> UInt64 {
+        guard frame.startOffset + 8 <= frame._bytes.count else {
+            throw DeserializationError.bufferTooShort
+        }
+        let value = frame._bytes.span.bytes.unsafeLoadUnaligned(
+            fromByteOffset: frame.startOffset,
+            as: UInt64.self
+        )
+        if claim {
+            guard frame.claim(fromStart: 8) else {
+                throw DeserializationError.bufferTooShort
+            }
+        }
+        return value
+    }
+
+    @inline(__always)
+    static func uint64NetworkByteOrder(
+        frame: inout Frame,
+        claim: Bool = false
+    ) throws(DeserializationError) -> UInt64 {
+        UInt64(bigEndian: try uint64(frame: &frame, claim: claim))
     }
 
     @inline(__always)
@@ -110,6 +185,10 @@ extension InlineDeserializer {
                 throw DeserializationError.bufferTooShort
             }
         }
+    }
+
+    static func claim(frame: inout Frame, length: Int) -> Bool {
+        frame.claim(fromStart: length)
     }
 }
 

--- a/Sources/SwiftNetwork/Utilities/Deserializer.swift
+++ b/Sources/SwiftNetwork/Utilities/Deserializer.swift
@@ -74,6 +74,47 @@ public enum DeserializationResult: CustomStringConvertible, Equatable, Sendable 
 
 @_spi(ProtocolProvider)
 @available(Network 0.1.0, *)
+public struct InlineDeserializer {}
+
+@available(Network 0.1.0, *)
+extension InlineDeserializer {
+    @inline(__always)
+    static func uint8(frame: inout Frame, claim: Bool = false) throws(DeserializationError) -> UInt8 {
+        guard frame._bytes.count > 0 else {
+            throw DeserializationError.bufferTooShort
+        }
+        let value: UInt8 = frame._bytes[0]
+        if claim {
+            guard frame.claim(fromStart: 1) else {
+                throw DeserializationError.bufferTooShort
+            }
+        }
+        return value
+    }
+
+    @inline(__always)
+    static func connectionID(
+        frame: inout Frame,
+        storage: inout [20 of UInt8],
+        length: Int,
+        claim: Bool = false
+    ) throws(DeserializationError) {
+        guard frame.startOffset + length <= frame._bytes.count else {
+            return
+        }
+        for i in 0..<length {
+            storage[i] = frame._bytes[frame.startOffset + i]
+        }
+        if claim {
+            guard frame.claim(fromStart: length) else {
+                throw DeserializationError.bufferTooShort
+            }
+        }
+    }
+}
+
+@_spi(ProtocolProvider)
+@available(Network 0.1.0, *)
 public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escapable>: ~Copyable, ~Escapable {
     private var factory: Factory
     private var currentSpan: RawSpan

--- a/Sources/SwiftNetwork/Utilities/Deserializer.swift
+++ b/Sources/SwiftNetwork/Utilities/Deserializer.swift
@@ -83,7 +83,7 @@ extension InlineDeserializer {
         guard frame._bytes.count > 0 else {
             throw DeserializationError.bufferTooShort
         }
-        let value: UInt8 = frame._bytes[0]
+        let value: UInt8 = frame._bytes[frame.startOffset]
         if claim {
             guard frame.claim(fromStart: 1) else {
                 throw DeserializationError.bufferTooShort

--- a/Tests/SwiftNetworkTests/SwiftNetworkFrameDeserializerTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkFrameDeserializerTests.swift
@@ -1,0 +1,92 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+#if canImport(SwiftNetwork)
+@_spi(Essentials) @_spi(ProtocolProvider) @testable import SwiftNetwork
+#elseif canImport(Network)
+@_spi(Essentials) @_spi(ProtocolProvider) @testable import Network
+#endif
+
+@available(Network 0.1.0, *)
+final class SwiftNetworkFrameDeserializerTests: NetTestCase {
+
+    func testUInt8InlineValue() throws {
+        var frame = Frame(copyBuffer: [0xAB] as [UInt8])
+        defer { frame.finalize(success: false) }
+        do throws(DeserializationError) {
+            let value = try FrameDeserializer.uint8(frame: &frame, claim: true)
+            XCTAssertEqual(value, 0xAB)
+        } catch {
+            XCTFail("Unexpected deserialization error: \(error)")
+        }
+    }
+
+    func testUInt8PeekDoesNotAdvanceOffset() throws {
+        var frame = Frame(copyBuffer: [0xCD, 0xEF] as [UInt8])
+        defer { frame.finalize(success: false) }
+        do throws(DeserializationError) {
+            let firstUnclaimed = try FrameDeserializer.uint8(frame: &frame, claim: false)
+            let nextClaimed = try FrameDeserializer.uint8(frame: &frame, claim: true)
+            XCTAssertEqual(firstUnclaimed, 0xCD)
+            XCTAssertEqual(nextClaimed, 0xCD)
+            XCTAssertEqual(frame.unclaimedLength, 1)
+        } catch {
+            XCTFail("Unexpected deserialization error: \(error)")
+        }
+    }
+
+    func testUInt64InlineValue() throws {
+        let bytes: [UInt8] = [0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41]
+        var frame = Frame(copyBuffer: bytes)
+        defer { frame.finalize(success: false) }
+        do throws(DeserializationError) {
+            let value = try FrameDeserializer.uint64(frame: &frame, claim: true)
+            XCTAssertEqual(value, 0x4141_4141_4141_4141)
+            XCTAssertEqual(frame.unclaimedLength, 0)
+        } catch {
+            XCTFail("Unexpected deserialization error: \(error)")
+        }
+    }
+
+    func testUInt64NetworkByteOrderInlineValue() throws {
+        let bytes: [UInt8] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
+        var frame = Frame(copyBuffer: bytes)
+        defer { frame.finalize(success: false) }
+        do throws(DeserializationError) {
+            let value = try FrameDeserializer.uint64NetworkByteOrder(frame: &frame, claim: true)
+            XCTAssertEqual(value, 0x0102_0304_0506_0708)
+            XCTAssertEqual(frame.unclaimedLength, 0)
+        } catch {
+            XCTFail("Unexpected deserialization error: \(error)")
+        }
+    }
+
+    func testUInt64NetworkByteOrderThenUInt8Sequential() throws {
+        let bytes: [UInt8] = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x42]
+        var frame = Frame(copyBuffer: bytes)
+        defer { frame.finalize(success: false) }
+        do throws(DeserializationError) {
+            let high = try FrameDeserializer.uint64NetworkByteOrder(frame: &frame, claim: true)
+            let low = try FrameDeserializer.uint8(frame: &frame, claim: true)
+            XCTAssertEqual(high, 0x0000_0000_0000_00FF)
+            XCTAssertEqual(low, 0x42)
+            XCTAssertEqual(frame.unclaimedLength, 0)
+        } catch {
+            XCTFail("Unexpected deserialization error: \(error)")
+        }
+    }
+
+}


### PR DESCRIPTION
Parsing QUIC headers with `Deserializer.deserialize` uses a lot more CPU than expected for what should be a very fast operation.  Parsing the firstOctet and short headers are by far the common cases when parsing QUIC packets, and the paths that should be the most performant.  This change is to provide a fast-path option for these operations and cut the CPU usage here by 63% when parsing QUIC headers in the QUICTransfer benchmark.  

Savings of about 260 megacycles.

Current top of tree:
```
417.04 M 52.8%  -                                             PacketParser.parseHeader(frame:dcidLength:)   
417.04 M 52.8%  30.48 M                                        specialized PacketParser.parseHeader(frame:dcidLength:)  
153.60 M 19.5%  12.00 M                                         PacketParser.parseShortHeader(frame:firstOctet:dcidLength:originalLength:)  
107.87 M 13.7%  5.00 M                                           static Deserializer<>.deserialize<>(_:claim:_:)    
41.72 M  5.3%  5.00 M                                            Frame.claim(fromStart:fromEnd:adjustSingleIPAggregate:)   
27.11 M  3.4%  27.11 M                                            0x192be0ce8 (libsystem_pthread.dylib +0x1ce9) <56F332B8-6B78-3DB7-A58C-F3F4EC03D383> 
5.00 M   0.6%  5.00 M                                             type metadata accessor for Logger    
2.60 M   0.3%  2.60 M                                             Frame.startOffset.setter 
2.00 M   0.3%  2.00 M                                             DYLD-STUB$$type metadata accessor for Logger 
38.15 M  4.8%  -                                                 static Deserializer<>.deserialize<>(_:_:) 
23.00 M  2.9%  22.00 M                                           Frame.bytes.getter    
26.73 M  3.4%  -                                                QUICConnectionID.init(storage:size:)   
26.73 M  3.4%  9.13 M                                            specialized QUICConnectionID.init(storage:size:)  
7.00 M   0.9%  -                                                Packet.init(destinationConnectionID:headerLength:spin:)    
133.11 M 16.9%  -                                               specialized UniqueDeque<>.reserveCapacity(_:)   
133.11 M 16.9%  -                                                specialized RigidDeque<>.reserveCapacity(_:)   
133.11 M 16.9%  -                                                 specialized RigidDeque<>.reallocate(capacity:)    
133.11 M 16.9%  4.57 M                                             specialized _UnsafeDequeHandle<>.reallocate(capacity:)   
99.84 M  12.6%  10.00 M                                         static Deserializer<>.deserialize<>(_:claim:_:) 
50.82 M  6.4%  9.00 M                                           Frame.claim(fromStart:fromEnd:adjustSingleIPAggregate:)    
34.82 M  4.4%  34.82 M                                           0x192be0ce8 (libsystem_pthread.dylib +0x1ce9) <56F332B8-6B78-3DB7-A58C-F3F4EC03D383>  
4.00 M   0.5%  4.00 M                                            Frame.startOffset.setter  
3.00 M   0.4%  3.00 M                                            DYLD-STUB$$type metadata accessor for Logger  
23.00 M  2.9%  22.00 M                                          Frame.bytes.getter 
1.00 M   0.1%  -                                                 specialized UniqueArray<>.span.getter 
12.01 M  1.5%  -                                                static Deserializer<>.deserialize<>(_:_:)  
12.01 M  1.5%  3.01 M                                            specialized static Deserializer<>.deserialize(_:_:)   
4.00 M   0.5%  4.00 M                                           type metadata accessor for Logger
```

And with this change:
```
158.20 M 47.8%  20.74 M                                           specialized PacketParser.parseHeader(frame:dcidLength:)  
120.46 M 36.4%  149.52 k                                            PacketParser.parseShortHeader(frame:firstOctet:dcidLength:originalLength:)  
120.31 M 36.3%  50.91 M                                              specialized PacketParser.parseShortHeader(frame:firstOctet:dcidLength:originalLength:) 
44.43 M  13.4%  11.91 M                                               Frame.copyInto(inlineArray:length:)   
9.00 M   2.7%  9.00 M                                                Frame.unclaimedLength.getter  
7.00 M   2.1%  -                                                     static InlineArray<>.empty.getter 
5.00 M   1.5%  5.00 M                                                Frame.claim(fromStart:fromEnd:adjustSingleIPAggregate:)   
3.97 M   1.2%  -                                                     Packet.init(destinationConnectionID:headerLength:spin:)   
16.00 M  4.8%  -                                                   Frame.firstOctet.getter 
1.00 M   0.3%  -                                                   Frame.claim(fromStart:fromEnd:adjustSingleIPAggregate:) 
```