### PR TITLE
Support attaching application-layer stream protocols to existing flows

### DIFF
--- a/Sources/SwiftNetwork/EndpointFlow/EndpointFlowProtocols.swift
+++ b/Sources/SwiftNetwork/EndpointFlow/EndpointFlowProtocols.swift
@@ -446,6 +446,13 @@ final class StreamEndpointFlowProtocol: EndpointFlowProtocol<InboundStreamLinkag
         throw NetworkError.posix(EINVAL)
     }
 
+    func attachLowerStreamProtocolToExistingFlow(
+        listener: StreamListenerLinkage,
+        flowReference: ProtocolInstanceReference
+    ) throws(NetworkError) {
+        throw NetworkError.posix(EINVAL)
+    }
+
     convenience init(
         identifier: String = "",
         local: Endpoint?,

--- a/Sources/SwiftNetwork/Protocols/OneToOneProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/OneToOneProtocol.swift
@@ -702,6 +702,22 @@ extension OneToOneProtocolHandler where Self: ~Copyable, LowerProtocol == Outbou
         )
     }
 
+    public mutating func attachLowerStreamProtocolToExistingFlow(
+        listener: StreamListenerLinkage,
+        flowReference: ProtocolInstanceReference
+    ) throws(NetworkError) {
+        guard lower.isDetached else {
+            throw NetworkError.posix(EALREADY)
+        }
+        if upper.isDetached {
+            passthroughEvents = false
+        }
+        self.lower = try listener.invokeAttachUpperStreamProtocolToExistingFlow(
+            effectiveSelfReference,
+            flowReference: flowReference
+        )
+    }
+
     public mutating func invokeReceiveStreamData(
         minimumBytes: Int,
         maximumBytes: Int

--- a/Sources/SwiftNetwork/Protocols/ProtocolControlHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolControlHandlers.swift
@@ -761,6 +761,31 @@ extension ProtocolInstanceReference {
         }
     }
 
+    public func attachLowerStreamProtocolToExistingFlow(
+        listener: StreamListenerLinkage,
+        flowReference: ProtocolInstanceReference
+    ) throws(NetworkError) {
+        try self.fromExternal { () throws(NetworkError) in
+            switch self.reference {
+            case .none: fatalError("Cannot attach to empty protocol")
+            case .tls(var instance):
+                try instance.attachLowerStreamProtocolToExistingFlow(listener: listener, flowReference: flowReference)
+            case .streamEndpointFlow(let instance):
+                try instance.attachLowerStreamProtocolToExistingFlow(listener: listener, flowReference: flowReference)
+            #if !NETWORK_EMBEDDED
+            case .custom(let container, let index):
+                try container.accessInboundStreamHandler(at: index) { instance throws(NetworkError) in
+                    try instance.attachLowerStreamProtocolToExistingFlow(
+                        listener: listener,
+                        flowReference: flowReference
+                    )
+                }
+            #endif
+            default: fatalError("Protocol cannot accept attachLowerStreamProtocolToExistingFlow call")
+            }
+        }
+    }
+
     #if !NETWORK_EMBEDDED
     public func attachLowerProtocolForNewPath(
         _ lowerProtocol: ProtocolInstanceReference,

--- a/Sources/SwiftNetwork/Protocols/ProtocolListenerHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolListenerHandlers.swift
@@ -383,4 +383,19 @@ extension ProtocolInstanceReference {
             }
         }
     }
+
+    func deliverEnqueuedInboundStreamData(flowReference: ProtocolInstanceReference) throws(NetworkError) {
+        try self.fromExternal { () throws(NetworkError) in
+            switch self.reference {
+            #if !NETWORK_NO_SWIFT_QUIC
+            case .quic(let instance):
+                try instance.deliverEnqueuedInboundStreamData(
+                    flow: MultiplexedFlowIdentifier(inboundReference: flowReference)
+                )
+            #endif
+            default:
+                return
+            }
+        }
+    }
 }

--- a/Sources/SwiftNetwork/Protocols/ProtocolOptions.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolOptions.swift
@@ -154,6 +154,10 @@ public class AbstractProtocolOptions: PerProtocolOptions, Hashable {
         self.protocolInstance = reference
     }
 
+    public func newProtocolInstance(context: NetworkContext) -> ProtocolInstanceReference? {
+        nil
+    }
+
     public var identifier: ProtocolIdentifier
 
     public var topID: Int? = nil
@@ -230,6 +234,10 @@ public final class ProtocolOptions<P: NetworkProtocol>: AbstractProtocolOptions 
 
     public override func serialize() -> [UInt8]? {
         perProtocolOptions?.serialize() ?? nil
+    }
+
+    public override func newProtocolInstance(context: NetworkContext) -> ProtocolInstanceReference? {
+        P().newProtocolInstance(context: context)
     }
 
     public init(protocolIdentifier: ProtocolIdentifier, perProtocolOptions: P.Options?) {

--- a/Sources/SwiftNetwork/Protocols/ProtocolStreamHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolStreamHandlers.swift
@@ -150,6 +150,11 @@ public protocol InboundStreamHandler: ~Copyable, InboundDataHandler where LowerP
         path: PathProperties?
     ) throws(NetworkError)
 
+    mutating func attachLowerStreamProtocolToExistingFlow(
+        listener: StreamListenerLinkage,
+        flowReference: ProtocolInstanceReference
+    ) throws(NetworkError)
+
     mutating func handleInboundAbortedEvent(_ from: ProtocolInstanceReference, error: NetworkError?)
     mutating func handleOutboundAbortedEvent(_ from: ProtocolInstanceReference, error: NetworkError?)
 }

--- a/Sources/SwiftNetwork/Protocols/TopProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/TopProtocol.swift
@@ -324,6 +324,19 @@ extension TopProtocolHandler where Self: ~Copyable, LowerProtocol == OutboundStr
             path: path
         )
     }
+
+    public mutating func attachLowerStreamProtocolToExistingFlow(
+        listener: StreamListenerLinkage,
+        flowReference: ProtocolInstanceReference
+    ) throws(NetworkError) {
+        guard lower.isDetached else {
+            throw NetworkError.posix(EALREADY)
+        }
+        self.lower = try listener.invokeAttachUpperStreamProtocolToExistingFlow(
+            reference,
+            flowReference: flowReference
+        )
+    }
 }
 
 @available(Network 0.1.0, *)

--- a/Sources/SwiftNetworkBenchmarks/StreamPerfTestHandler.swift
+++ b/Sources/SwiftNetworkBenchmarks/StreamPerfTestHandler.swift
@@ -284,6 +284,14 @@ extension StreamPerfTestHandler: UpperProtocolHandler {
         throw NetworkError.posix(ENOTSUP)
     }
 
+    // InboundStreamHandler conformance
+    public func attachLowerStreamProtocolToExistingFlow(
+        listener: StreamListenerLinkage,
+        flowReference: ProtocolInstanceReference
+    ) throws(NetworkError) {
+        throw NetworkError.posix(ENOTSUP)
+    }
+
     // UpperProtocolHandler conformance
     public func attachLowerProtocol(
         _ lowerProtocol: ProtocolInstanceReference,


### PR DESCRIPTION
Added a general primitive for attaching an upper stream protocol onto an already-existing flow, for cases where a listener's stack has as application-layer protocol that must be added on top of inbound streams.

All changes:
- `attachLowerStreamProtocolToExistingFlow(listener:flowReference:)` as an `InboundStreamHandler` requirement, with witnesses on the OneToOne and Top stream extensions, `EINVAL` on `StreamEndpointFlowProtocol` (its lower is wired at construction), and `ENOTSUP` on `StreamPerfTestHandler`. Reference dispatch covers `.tls`, `.streamEndpointFlow`, `.custom`
- `deliverEnqueuedInboundStreamData(flowReference:)` to replay data buffered before the upper protocol attached
- `newProtocolInstance(context:)` on protocol options (nil on `AbstractProtocolOptions`, overridden in `ProtocolOptions<P>`) so a custom application protocol can be materialized per flow without naming a concrete type