### PR TITLE
Use closeMutex for setting closeWithErrorHandler

### DIFF
--- a/Sources/SwiftNetwork/Protocols/QUICConnectionProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/QUICConnectionProtocol.swift
@@ -1006,7 +1006,7 @@ public struct QUICConnectionProtocol: NetworkProtocol {
         }
 
         func setCloseWithError(handler: @escaping QUICMetadataSetterHandler) {
-            mutex.withLock { _ in
+            closeMutex.withLock { _ in
                 self.closeWithErrorHandler = handler
             }
         }


### PR DESCRIPTION
Fix the lock being used for setting closeWithErrorHandler, to match the lock used when accessing closeWithErrorHandler.