### PR TITLE
Reduce CPU usage for Deserializer

### DIFF
--- a/Sources/SwiftNetwork/Utilities/Deserializer.swift
+++ b/Sources/SwiftNetwork/Utilities/Deserializer.swift
@@ -42,6 +42,7 @@ public enum DeserializationResult: CustomStringConvertible, Equatable, Sendable 
     case success(parsedBytes: Int, remainingBytes: Int)
     case error(DeserializationError)
 
+    @usableFromInline
     static let success: Self = .success(parsedBytes: 0, remainingBytes: 0)
 
     public var description: String {
@@ -76,11 +77,11 @@ public enum DeserializationResult: CustomStringConvertible, Equatable, Sendable 
 @available(Network 0.1.0, *)
 public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escapable>: ~Copyable, ~Escapable {
     private var factory: Factory
-    private var currentSpan: RawSpan
-    private var currentSpanByteCount = 0
+    @usableFromInline internal var currentSpan: RawSpan
+    @usableFromInline internal var currentSpanByteCount = 0
     private var availableByteCount: Int
     private var scratchSpace: [16 of UInt8]?  // Initialized lazily
-    private var cursor = 0
+    @usableFromInline internal var cursor = 0
     private var previousSpanAggregateByteCount = 0
     private(set) var internalResult: DeserializationResult = .success
 
@@ -339,11 +340,32 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         moveCursorUnchecked(length)
     }
 
+    @_optimize(speed)
+    @inlinable
+    @inline(__always)
     public mutating func uint8(_ value: inout UInt8) throws(DeserializationError) {
-        try readFixedSize(&value)
+        guard cursor < currentSpanByteCount else {
+            // Fallback for multi-span cases
+            try readUInt8AtSpanBoundary(&value)
+            return
+        }
+        value = UInt8(currentSpan.unsafeLoadUnaligned(fromByteOffset: cursor, as: UInt8.self))
+        // Move by one byte
+        cursor &+= 1
     }
 
+    @_optimize(speed)
+    @inlinable
+    @inline(__always)
     public mutating func uint8(_ value: inout UInt8?) throws(DeserializationError) {
+        var temp: UInt8 = 0
+        try uint8(&temp)
+        value = temp
+    }
+
+    @usableFromInline
+    @inline(never)
+    internal mutating func readUInt8AtSpanBoundary(_ value: inout UInt8) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
@@ -363,11 +385,32 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         try validateValue(expect: value)
     }
 
+    @_optimize(speed)
+    @inlinable
+    @inline(__always)
     public mutating func uint16(_ value: inout UInt16) throws(DeserializationError) {
-        try readFixedSize(&value)
+        guard (currentSpanByteCount - cursor) >= 2 else {
+            // Fallback for multi-span cases
+            try readUInt16AtSpanBoundary(&value)
+            return
+        }
+        value = currentSpan.unsafeLoadUnaligned(fromByteOffset: cursor, as: UInt16.self)
+        // Move by two bytes
+        cursor &+= 2
     }
 
+    @_optimize(speed)
+    @inlinable
+    @inline(__always)
     public mutating func uint16(_ value: inout UInt16?) throws(DeserializationError) {
+        var temp: UInt16 = 0
+        try uint16(&temp)
+        value = temp
+    }
+
+    @usableFromInline
+    @inline(never)
+    internal mutating func readUInt16AtSpanBoundary(_ value: inout UInt16) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
@@ -387,11 +430,32 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         try validateValue(expect: value)
     }
 
+    @_optimize(speed)
+    @inlinable
+    @inline(__always)
     public mutating func uint32(_ value: inout UInt32) throws(DeserializationError) {
-        try readFixedSize(&value)
+        guard (currentSpanByteCount - cursor) >= 4 else {
+            // Fallback for multi-span cases
+            try readUInt32AtSpanBoundary(&value)
+            return
+        }
+        value = currentSpan.unsafeLoadUnaligned(fromByteOffset: cursor, as: UInt32.self)
+        // Move by four bytes
+        cursor &+= 4
     }
 
+    @_optimize(speed)
+    @inlinable
+    @inline(__always)
     public mutating func uint32(_ value: inout UInt32?) throws(DeserializationError) {
+        var temp: UInt32 = 0
+        try uint32(&temp)
+        value = temp
+    }
+
+    @usableFromInline
+    @inline(never)
+    internal mutating func readUInt32AtSpanBoundary(_ value: inout UInt32) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
@@ -399,11 +463,32 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         try validateValue(expect: value)
     }
 
+    @_optimize(speed)
+    @inlinable
+    @inline(__always)
     public mutating func uint64(_ value: inout UInt64) throws(DeserializationError) {
-        try readFixedSize(&value)
+        guard (currentSpanByteCount - cursor) >= 8 else {
+            // Fallback for multi-span cases
+            try readUInt64AtSpanBoundary(&value)
+            return
+        }
+        value = currentSpan.unsafeLoadUnaligned(fromByteOffset: cursor, as: UInt64.self)
+        // Move by eight bytes
+        cursor &+= 8
     }
 
+    @_optimize(speed)
+    @inlinable
+    @inline(__always)
     public mutating func uint64(_ value: inout UInt64?) throws(DeserializationError) {
+        var temp: UInt64 = 0
+        try uint64(&temp)
+        value = temp
+    }
+
+    @usableFromInline
+    @inline(never)
+    internal mutating func readUInt64AtSpanBoundary(_ value: inout UInt64) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
@@ -411,11 +496,32 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         try validateValue(expect: value)
     }
 
+    @_optimize(speed)
+    @inlinable
+    @inline(__always)
     public mutating func uint16NetworkByteOrder(_ value: inout UInt16) throws(DeserializationError) {
-        try readFixedSize(&value, networkByteOrder: true)
+        guard (currentSpanByteCount - cursor) >= 2 else {
+            // Fallback for multi-span cases
+            try readUInt16NBOAtSpanBoundary(&value)
+            return
+        }
+        value = UInt16(bigEndian: currentSpan.unsafeLoadUnaligned(fromByteOffset: cursor, as: UInt16.self))
+        // Move by two bytes
+        cursor &+= 2
     }
 
+    @_optimize(speed)
+    @inlinable
+    @inline(__always)
     public mutating func uint16NetworkByteOrder(_ value: inout UInt16?) throws(DeserializationError) {
+        var temp: UInt16 = 0
+        try uint16NetworkByteOrder(&temp)
+        value = temp
+    }
+
+    @usableFromInline
+    @inline(never)
+    internal mutating func readUInt16NBOAtSpanBoundary(_ value: inout UInt16) throws(DeserializationError) {
         try readFixedSize(&value, networkByteOrder: true)
     }
 
@@ -423,11 +529,32 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         try validateValue(expect: value.bigEndian)
     }
 
+    @_optimize(speed)
+    @inlinable
+    @inline(__always)
     public mutating func uint32NetworkByteOrder(_ value: inout UInt32) throws(DeserializationError) {
-        try readFixedSize(&value, networkByteOrder: true)
+        guard (currentSpanByteCount - cursor) >= 4 else {
+            // Fallback for multi-span cases
+            try readUInt32NBOAtSpanBoundary(&value)
+            return
+        }
+        value = UInt32(bigEndian: currentSpan.unsafeLoadUnaligned(fromByteOffset: cursor, as: UInt32.self))
+        // Move by four bytes
+        cursor &+= 4
     }
 
+    @_optimize(speed)
+    @inlinable
+    @inline(__always)
     public mutating func uint32NetworkByteOrder(_ value: inout UInt32?) throws(DeserializationError) {
+        var temp: UInt32 = 0
+        try uint32NetworkByteOrder(&temp)
+        value = temp
+    }
+
+    @usableFromInline
+    @inline(never)
+    internal mutating func readUInt32NBOAtSpanBoundary(_ value: inout UInt32) throws(DeserializationError) {
         try readFixedSize(&value, networkByteOrder: true)
     }
 
@@ -435,11 +562,32 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         try validateValue(expect: value.bigEndian)
     }
 
+    @_optimize(speed)
+    @inlinable
+    @inline(__always)
     public mutating func uint64NetworkByteOrder(_ value: inout UInt64) throws(DeserializationError) {
-        try readFixedSize(&value, networkByteOrder: true)
+        guard (currentSpanByteCount - cursor) >= 8 else {
+            // Fallback for multi-span cases
+            try readUInt64NBOAtSpanBoundary(&value)
+            return
+        }
+        value = UInt64(bigEndian: currentSpan.unsafeLoadUnaligned(fromByteOffset: cursor, as: UInt64.self))
+        // Move by eight bytes
+        cursor &+= 8
     }
 
+    @_optimize(speed)
+    @inlinable
+    @inline(__always)
     public mutating func uint64NetworkByteOrder(_ value: inout UInt64?) throws(DeserializationError) {
+        var temp: UInt64 = 0
+        try uint64NetworkByteOrder(&temp)
+        value = temp
+    }
+
+    @usableFromInline
+    @inline(never)
+    internal mutating func readUInt64NBOAtSpanBoundary(_ value: inout UInt64) throws(DeserializationError) {
         try readFixedSize(&value, networkByteOrder: true)
     }
 
@@ -827,6 +975,7 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     }
 
     @_optimize(speed)
+    @inlinable
     public static func deserialize(
         _ frame: inout Frame,
         claim: Bool,
@@ -846,6 +995,7 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
 
     #if !NETWORK_EMBEDDED
     @_optimize(speed)
+    @inlinable
     public static func deserialize(
         _ frameArray: inout FrameArray,
         claim: Bool,

--- a/Sources/SwiftNetwork/Utilities/Deserializer.swift
+++ b/Sources/SwiftNetwork/Utilities/Deserializer.swift
@@ -351,7 +351,7 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         }
         value = UInt8(currentSpan.unsafeLoadUnaligned(fromByteOffset: cursor, as: UInt8.self))
         // Move by one byte
-        cursor &+= 1
+        cursor &+= MemoryLayout<UInt8>.size
     }
 
     @_optimize(speed)
@@ -389,14 +389,13 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     @inlinable
     @inline(__always)
     public mutating func uint16(_ value: inout UInt16) throws(DeserializationError) {
-        guard (currentSpanByteCount - cursor) >= 2 else {
+        guard (currentSpanByteCount - cursor) >= MemoryLayout<UInt16>.size else {
             // Fallback for multi-span cases
             try readUInt16AtSpanBoundary(&value)
             return
         }
         value = currentSpan.unsafeLoadUnaligned(fromByteOffset: cursor, as: UInt16.self)
-        // Move by two bytes
-        cursor &+= 2
+        cursor &+= MemoryLayout<UInt16>.size
     }
 
     @_optimize(speed)
@@ -434,14 +433,13 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     @inlinable
     @inline(__always)
     public mutating func uint32(_ value: inout UInt32) throws(DeserializationError) {
-        guard (currentSpanByteCount - cursor) >= 4 else {
+        guard (currentSpanByteCount - cursor) >= MemoryLayout<UInt32>.size else {
             // Fallback for multi-span cases
             try readUInt32AtSpanBoundary(&value)
             return
         }
         value = currentSpan.unsafeLoadUnaligned(fromByteOffset: cursor, as: UInt32.self)
-        // Move by four bytes
-        cursor &+= 4
+        cursor &+= MemoryLayout<UInt32>.size
     }
 
     @_optimize(speed)
@@ -467,14 +465,14 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     @inlinable
     @inline(__always)
     public mutating func uint64(_ value: inout UInt64) throws(DeserializationError) {
-        guard (currentSpanByteCount - cursor) >= 8 else {
+        guard (currentSpanByteCount - cursor) >= MemoryLayout<UInt64>.size else {
             // Fallback for multi-span cases
             try readUInt64AtSpanBoundary(&value)
             return
         }
         value = currentSpan.unsafeLoadUnaligned(fromByteOffset: cursor, as: UInt64.self)
         // Move by eight bytes
-        cursor &+= 8
+        cursor &+= MemoryLayout<UInt64>.size
     }
 
     @_optimize(speed)
@@ -500,14 +498,13 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     @inlinable
     @inline(__always)
     public mutating func uint16NetworkByteOrder(_ value: inout UInt16) throws(DeserializationError) {
-        guard (currentSpanByteCount - cursor) >= 2 else {
+        guard (currentSpanByteCount - cursor) >= MemoryLayout<UInt16>.size else {
             // Fallback for multi-span cases
             try readUInt16NBOAtSpanBoundary(&value)
             return
         }
         value = UInt16(bigEndian: currentSpan.unsafeLoadUnaligned(fromByteOffset: cursor, as: UInt16.self))
-        // Move by two bytes
-        cursor &+= 2
+        cursor &+= MemoryLayout<UInt16>.size
     }
 
     @_optimize(speed)
@@ -533,14 +530,13 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     @inlinable
     @inline(__always)
     public mutating func uint32NetworkByteOrder(_ value: inout UInt32) throws(DeserializationError) {
-        guard (currentSpanByteCount - cursor) >= 4 else {
+        guard (currentSpanByteCount - cursor) >= MemoryLayout<UInt32>.size else {
             // Fallback for multi-span cases
             try readUInt32NBOAtSpanBoundary(&value)
             return
         }
         value = UInt32(bigEndian: currentSpan.unsafeLoadUnaligned(fromByteOffset: cursor, as: UInt32.self))
-        // Move by four bytes
-        cursor &+= 4
+        cursor &+= MemoryLayout<UInt32>.size
     }
 
     @_optimize(speed)
@@ -566,14 +562,13 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     @inlinable
     @inline(__always)
     public mutating func uint64NetworkByteOrder(_ value: inout UInt64) throws(DeserializationError) {
-        guard (currentSpanByteCount - cursor) >= 8 else {
+        guard (currentSpanByteCount - cursor) >= MemoryLayout<UInt64>.size else {
             // Fallback for multi-span cases
             try readUInt64NBOAtSpanBoundary(&value)
             return
         }
         value = UInt64(bigEndian: currentSpan.unsafeLoadUnaligned(fromByteOffset: cursor, as: UInt64.self))
-        // Move by eight bytes
-        cursor &+= 8
+        cursor &+= MemoryLayout<UInt64>.size
     }
 
     @_optimize(speed)

--- a/Sources/SwiftNetwork/Utilities/SerializationHelpers.swift
+++ b/Sources/SwiftNetwork/Utilities/SerializationHelpers.swift
@@ -100,6 +100,7 @@ public struct FrameArraySpanFactory: ~Copyable, ~Escapable, DeserializerSpanFact
     public private(set) var availableByteCount: Int
 
     /// Extracts the frame array from the factory, consuming the factory in the process.
+    @usableFromInline
     consuming func takeFrameArray() -> FrameArray {
         frameArray
     }
@@ -119,6 +120,7 @@ public struct FrameArraySpanFactory: ~Copyable, ~Escapable, DeserializerSpanFact
     // lifetime dependency. @_lifetime(immortal) is correct for a self-contained
     // ~Escapable type whose data is fully owned.
     @_lifetime(immortal)
+    @usableFromInline
     init(_ frameArray: consuming FrameArray) {
         self.spanCount = frameArray.count
         self.availableByteCount = frameArray.unclaimedLength


### PR DESCRIPTION
Change to help optimize generic operations on the Deserializer both internally and across module boundaries.
Running our Deserializer benchmark that creates 1 frame and runs the Deserializer on it 10,000,000 times I see this change cut the CPU usage in half.

Currently, top of tree:
```
434.41 M 89.1%	52.65 M	      specialized static Deserializer<>.deserialize<>(_:claim:_:)	
298.24 M 61.1%	13.00 M	       static Deserializer<>.deserialize<>(_:_:)	
262.99 M 53.9%	12.00 M	        specialized static Deserializer<>.deserialize<>(_:_:)	
191.63 M 39.3%	13.50 M	         partial apply for closure #1 in runtest()	
178.12 M 36.5%	25.97 M	          closure #1 in runtest()	
74.63 M  15.3%	27.44 M	           Deserializer<>.uint8(_:)	
27.00 M  5.5%	-      	           Deserializer<>.uint64NetworkByteOrder(_:)	
23.67 M  4.9%	-      	           Deserializer<>.uint16NetworkByteOrder(_:)	
14.54 M  3.0%	-      	           Deserializer<>.uint32NetworkByteOrder(_:)	
12.32 M  2.5%	12.32 M	           type metadata accessor for Deserializer<EmptySpanFactory>	
19.36 M  4.0%	19.36 M	         Deserializer<>.uint64NetworkByteOrder(_:)	
15.00 M  3.1%	15.00 M	         specialized Deserializer<>.finalResult.getter	
9.00 M   1.8%	9.00 M 	         Deserializer<>.init<>(_:)	
9.00 M   1.8%	9.00 M 	         Deserializer<>.uint32NetworkByteOrder(_:)	
7.00 M   1.4%	7.00 M 	         Deserializer<>.uint16NetworkByteOrder(_:)	
22.24 M  4.6%	22.24 M	        partial apply for closure #1 in runtest()	
83.53 M  17.1%	72.53 M	       Frame.bytes.getter	
11.00 M  2.3%	11.00 M	        Frame.startOffset.getter	
```

And with these changes:
```
217.45 M 87.5%	3.74 M 	      static Deserializer<>.deserialize<>(_:claim:_:)	
136.51 M 54.9%	21.00 M	       specialized static Deserializer<>.deserialize<>(_:_:)	
98.91 M  39.8%	3.42 M 	        partial apply for closure #1 in runtest()	
95.49 M  38.4%	-      	         closure #1 in runtest()	
42.62 M  17.1%	42.62 M	          specialized Deserializer<>.uint8(_:)	
19.24 M  7.7%	19.24 M	          specialized Deserializer<>.uint32NetworkByteOrder(_:)	
17.81 M  7.2%	17.81 M	          specialized Deserializer<>.uint16NetworkByteOrder(_:)	
15.81 M  6.4%	15.81 M	          specialized Deserializer<>.uint64NetworkByteOrder(_:)	
9.60 M   3.9%	9.60 M 	        Deserializer<>.init<>(_:)	
7.00 M   2.8%	7.00 M 	        specialized Deserializer<>.finalResult.getter	
57.63 M  23.2%	49.63 M	       Frame.bytes.getter	
19.57 M  7.9%	19.57 M	       partial apply for closure #1 in runtest()	
4.00 M   1.6%	-      	      specialized IndexingIterator.next()	
```

So as you can see these changes really help the generic functions optimize better.