### PR TITLE
Remove overhead from Logger metadata in the datapath

### DIFF
--- a/Sources/SwiftNetwork/Protocols/Frame.swift
+++ b/Sources/SwiftNetwork/Protocols/Frame.swift
@@ -268,7 +268,9 @@ public struct Frame: ~Copyable {
     public mutating func claim(fromStart: Int, fromEnd: Int = 0, adjustSingleIPAggregate: Bool = true) -> Bool {
         if adjustSingleIPAggregate && isSingleIPAggregate {
             guard fromEnd == 0 else {
-                Logger.proto.fault("Trying to claim at the end \(fromEnd) bytes from a single-IP aggregate")
+                #if !DisableErrorLogging
+                Logger.proto.error("Trying to claim at the end \(fromEnd) bytes from a single-IP aggregate")
+                #endif
                 return false
             }
             aggregateBufferLength -= fromStart
@@ -278,9 +280,11 @@ public struct Frame: ~Copyable {
         let newEnd = endOffset + fromEnd
         guard newStart <= effectiveBufferLength - newEnd else {
             let effectiveLength = effectiveBufferLength
+            #if !DisableErrorLogging
             Logger.proto.error(
                 "Claiming bytes failed because start (\(newStart)) is beyond end (\(effectiveLength) - \(newEnd))"
             )
+            #endif
             return false
         }
 
@@ -297,7 +301,9 @@ public struct Frame: ~Copyable {
     public mutating func unclaim(fromStart: Int, fromEnd: Int = 0, adjustSingleIPAggregate: Bool = true) -> Bool {
         if adjustSingleIPAggregate && isSingleIPAggregate {
             guard fromEnd == 0 else {
-                Logger.proto.fault("Trying to unclaim at the end \(fromEnd) bytes from a single-IP aggregate")
+                #if !DisableErrorLogging
+                Logger.proto.error("Trying to unclaim at the end \(fromEnd) bytes from a single-IP aggregate")
+                #endif
                 return false
             }
             aggregateBufferLength += fromStart
@@ -305,13 +311,17 @@ public struct Frame: ~Copyable {
 
         guard fromStart <= startOffset else {
             let startOffset = startOffset
+            #if !DisableErrorLogging
             Logger.proto.error("Frame cannot unclaim \(fromStart) start bytes (has \(startOffset) left)")
+            #endif
             return false
         }
 
         guard fromEnd <= endOffset else {
             let endOffset = endOffset
+            #if !DisableErrorLogging
             Logger.proto.error("Frame cannot unclaim \(fromEnd) end bytes (has \(endOffset) left)")
+            #endif
             return false
         }
 
@@ -581,7 +591,9 @@ public struct Frame: ~Copyable {
                 return
             }
             guard newValue < 64 else {
-                Logger.proto.fault("Cannot set DSCP value of \(newValue)")
+                #if !DisableErrorLogging
+                Logger.proto.error("Cannot set DSCP value of \(newValue)")
+                #endif
                 return
             }
             if ipPacketValues == nil {

--- a/Sources/SwiftNetwork/Protocols/IPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/IPProtocol.swift
@@ -914,7 +914,9 @@ public struct IPProtocol: NetworkProtocol {
                     try write.uint16(value)
                 }
                 if !checksumResult.isValid {
+                    #if !DisableErrorLogging
                     Logger.proto.error("Serializing IPv4 checksum failed with result: \(checksumResult)")
+                    #endif
                 }
             }
 
@@ -992,7 +994,9 @@ public struct IPProtocol: NetworkProtocol {
                                 try write.uint32(remoteAddressValue)
                             }
                             guard result.isValid else {
+                                #if !DisableErrorLogging
                                 Logger.proto.error("Serializing IPv4 fragment failed with result: \(result)")
+                                #endif
                                 fragmentFrame.finalize(success: false)
                                 fragmentationSucceeded = false
                                 break
@@ -1016,7 +1020,9 @@ public struct IPProtocol: NetworkProtocol {
                                     self.setChecksumValue(frame: &fragmentFrame, value: checksumValue)
                                 }
                             } catch {
+                                #if !DisableErrorLogging
                                 Logger.proto.error("Failed to compute IPv4 fragment checksum")
+                                #endif
                                 fragmentFrame.finalize(success: false)
                                 fragmentationSucceeded = false
                                 break
@@ -1051,7 +1057,9 @@ public struct IPProtocol: NetworkProtocol {
                         try write.uint32(remoteAddressValue)
                     }
                     if !result.isValid {
+                        #if !DisableErrorLogging
                         Logger.proto.error("Serializing IPv4 packet failed with result: \(result)")
+                        #endif
                         frame.finalize(success: false)
                         return .removeFrameAndContinue
                     }
@@ -1077,7 +1085,9 @@ public struct IPProtocol: NetworkProtocol {
                             }
                         }
                     } catch {
+                        #if !DisableErrorLogging
                         Logger.proto.error("Failed to finalize IP checksum")
+                        #endif
                         frame.finalize(success: false)
                         return .removeFrameAndContinue
                     }

--- a/Sources/SwiftNetwork/QUIC/Packet.swift
+++ b/Sources/SwiftNetwork/QUIC/Packet.swift
@@ -308,18 +308,22 @@ struct Packet: ~Copyable {
     var overrideSentNumberSize: EncodedPacketNumber.Size? {
         get {
             if let _overrideSentNumberSize {
+                #if !DisableErrorLogging
                 Logger.proto.error(
                     "WARNING: Reading overrideSentNumberSize only be used for unit testing!"
                 )
+                #endif
                 return _overrideSentNumberSize
             }
             return nil
         }
         set(newValue) {
             if let newValue {
+                #if !DisableErrorLogging
                 Logger.proto.error(
                     "WARNING: Setting overrideSentNumberSize only be used for unit testing!"
                 )
+                #endif
                 _overrideSentNumberSize = newValue
             } else {
                 _overrideSentNumberSize = nil

--- a/Sources/SwiftNetwork/QUIC/QUICConnectionID.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnectionID.swift
@@ -88,8 +88,10 @@ public struct QUICConnectionID: Sendable, Equatable, CustomStringConvertible {
     // Creates a QUICConnectionID from an array.
     public init?(_ connectionID: [UInt8]) {
         guard connectionID.count <= QUICConnectionID.maximumSize else {
+            #if !DisableErrorLogging
             let connectionIDCount = connectionID.count
-            Logger.proto.fault("Invalid QUICConnectionID length \(connectionIDCount)")
+            Logger.proto.error("Invalid QUICConnectionID length \(connectionIDCount)")
+            #endif
             return nil
         }
         actualLength = connectionID.count
@@ -101,15 +103,19 @@ public struct QUICConnectionID: Sendable, Equatable, CustomStringConvertible {
         if size <= QUICConnectionID.maximumSize {
             actualLength = size
         } else {
-            Logger.proto.fault("Invalid QUICConnectionID length \(size)")
+            #if !DisableErrorLogging
+            Logger.proto.error("Invalid QUICConnectionID length \(size)")
+            #endif
             actualLength = QUICConnectionID.maximumSize
         }
     }
 
     public init?(_ connectionID: Span<UInt8>) {
         guard connectionID.count <= QUICConnectionID.maximumSize else {
+            #if !DisableErrorLogging
             let connectionIDCount = connectionID.count
-            Logger.proto.fault("Invalid QUICConnectionID length \(connectionIDCount)")
+            Logger.proto.error("Invalid QUICConnectionID length \(connectionIDCount)")
+            #endif
             return nil
         }
         actualLength = connectionID.count
@@ -120,7 +126,9 @@ public struct QUICConnectionID: Sendable, Equatable, CustomStringConvertible {
     public init(_ size: Int) {
         var size = size
         if size > QUICConnectionID.maximumSize {
-            Logger.proto.fault("Invalid QUICConnectionID length \(size)")
+            #if !DisableErrorLogging
+            Logger.proto.error("Invalid QUICConnectionID length \(size)")
+            #endif
             size = QUICConnectionID.maximumSize
         }
         if size != 0 && size < 4 {
@@ -133,7 +141,9 @@ public struct QUICConnectionID: Sendable, Equatable, CustomStringConvertible {
     // Creates a QUICConnectionID from a buffer with a specific size.
     init?(_ buffer: [UInt8], size: Int) {
         guard size <= QUICConnectionID.maximumSize, buffer.count >= size else {
-            Logger.proto.fault("Invalid QUICConnectionID length \(size)")
+            #if !DisableErrorLogging
+            Logger.proto.error("Invalid QUICConnectionID length \(size)")
+            #endif
             return nil
         }
         let cidBytes = Array(buffer[0..<min(size, QUICConnectionID.maximumSize)])

--- a/Sources/SwiftNetwork/QUIC/StreamSendBuffer.swift
+++ b/Sources/SwiftNetwork/QUIC/StreamSendBuffer.swift
@@ -70,9 +70,11 @@ struct StreamSendBuffer: ~Copyable {
             // currentSendOffset is at bytes we no longer have, they're already ACKd?
             // Could be re-ordering problem?
             let _storageStartOffset = storageStartOffset
+            #if !DisableErrorLogging
             Logger.proto.error(
                 "currentSendOffset \(currentSendOffset) is out of date, storageStartOffset \(_storageStartOffset)"
             )
+            #endif
             return 0
         }
         return offsetPastLastByte - currentSendOffset


### PR DESCRIPTION
I noticed in our datapath functions in QUIC and IP we take a CPU hit for using the Logger object in a function, even if the code path is not being exercised.
These are typically error or fault logs and in the QUICTransfer benchmark accumulated to be over 319 megacycles:

```
319.39 M 100.0%	-	 type metadata accessor for Logger	
```

The majority of these hits are taken when a QUICConnectionID is created or when a frame claims or unclaims.
It will drop this in the CPU trace:

```
15.00 M 4.7%	15.00 M	  type metadata accessor for Logger	
3.47 M  1.1%	3.47 M 	  DYLD-STUB$$type metadata accessor for Logger	
```

This change almost completely eradicates that for QUICTransfer and brings that 319 megacycle number down to: ~ 1 megacycle

```
1.04 M 100.0%	-	 type metadata accessor for Logger		
```

I also consistently noticed a 3 gigacycle drop in the overall CPU used over many runs, but its hard to correlate where that drop is coming from.