### PR TITLE
Add SemVer machinery.

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: SemVer Major
+      labels:
+        - ⚠️ semver/major
+    - title: SemVer Minor
+      labels:
+        - 🆕 semver/minor
+    - title: SemVer Patch
+      labels:
+        - 🔨 semver/patch
+    - title: Other Changes
+      labels:
+        - semver/none

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -1,0 +1,21 @@
+name: PR label
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, reopened, synchronize]
+
+jobs:
+  semver-label-check:
+    name: Semantic version label check
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Check for Semantic Version label
+        uses: apple/swift-nio/.github/actions/pull_request_semver_label_checker@0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b


### PR DESCRIPTION
The Swift Server ecosystem has machinery for making sure that SemVer is used for changes and reflected easily and correctly in releases. This PR adopts those tools so that we can more easily ensure we don't break downstream consumers of the package.

* Add PR workflow check for SemVer labels
* Add `release.yml` which will allow GitHub's release/tag flow to automatically group merged changes by SemVer level.