### PR TITLE
SwiftQUIC: PERF: Avoid per-path scan unless round trip time has elapsed

### DIFF
--- a/Sources/SwiftNetwork/QUIC/FlowControl.swift
+++ b/Sources/SwiftNetwork/QUIC/FlowControl.swift
@@ -751,21 +751,12 @@ extension QUICStreamInstance {
         // Here, we estimate if the bandwidth measured in this RTT
         // is more than a certain value of the bandwidth measured
         // in the previous RTT.
-        let smoothedRTT = connection.currentPath?.smoothedRTT ?? .zero
-        if now >= flowControlStreamState.receiveHighWaterMarkTime.advanced(by: smoothedRTT) {
+        let rtt = connection.currentPath?.smoothedRTT ?? .zero
+        if now >= flowControlStreamState.receiveHighWaterMarkTime.advanced(by: rtt) {
             if flowControlStreamState.receiveHighWaterMarkCount
                 > flowControlStreamState.receiveHighWaterMarkPreviousCount
             {
-                var mss: UInt64 = 0
-                var rtt: NetworkDuration = .zero
-                connection.applyToAllPaths { path in
-                    if path.mss > mss {
-                        mss = UInt64(path.mss)
-                    }
-                    if path.rtt.smoothedRTT > rtt {
-                        rtt = path.rtt.smoothedRTT
-                    }
-                }
+                let mss = UInt64(connection.currentPath?.mss ?? 0)
                 let shift: Int
                 if flowControlStreamState.receiveHighWaterMarkCount
                     > (flowControlStreamState.receiveHighWaterMarkPreviousCount

--- a/Sources/SwiftNetwork/QUIC/FlowControl.swift
+++ b/Sources/SwiftNetwork/QUIC/FlowControl.swift
@@ -709,22 +709,9 @@ extension QUICStreamInstance {
             return false
         }
 
-        var largestPathMSS: UInt64 = 0
-        var largestPathRTT: NetworkDuration = .zero
-
-        connection.applyToAllPaths { path in
-            if path.mss > largestPathMSS {
-                largestPathMSS = UInt64(path.mss)
-            }
-            if path.rtt.smoothedRTT > largestPathRTT {
-                largestPathRTT = path.rtt.smoothedRTT
-            }
-        }
-
         let increment = computeReceiveHighWaterMarkIncrease(
             dataLength: dataLengthAdded,
-            rtt: largestPathRTT,
-            mss: largestPathMSS,
+            connection: connection,
             now: connection.now
         )
 
@@ -749,8 +736,7 @@ extension QUICStreamInstance {
 
     fileprivate func computeReceiveHighWaterMarkIncrease(
         dataLength: UInt64,
-        rtt: NetworkDuration,
-        mss: UInt64,
+        connection: QUICConnection,
         now: NetworkClock.Instant
     ) -> UInt64 {
         if flowControlStreamState.receiveHighWaterMarkTime > now {
@@ -765,10 +751,21 @@ extension QUICStreamInstance {
         // Here, we estimate if the bandwidth measured in this RTT
         // is more than a certain value of the bandwidth measured
         // in the previous RTT.
-        if now >= flowControlStreamState.receiveHighWaterMarkTime.advanced(by: rtt) {
+        let smoothedRTT = connection.currentPath?.smoothedRTT ?? .zero
+        if now >= flowControlStreamState.receiveHighWaterMarkTime.advanced(by: smoothedRTT) {
             if flowControlStreamState.receiveHighWaterMarkCount
                 > flowControlStreamState.receiveHighWaterMarkPreviousCount
             {
+                var mss: UInt64 = 0
+                var rtt: NetworkDuration = .zero
+                connection.applyToAllPaths { path in
+                    if path.mss > mss {
+                        mss = UInt64(path.mss)
+                    }
+                    if path.rtt.smoothedRTT > rtt {
+                        rtt = path.rtt.smoothedRTT
+                    }
+                }
                 let shift: Int
                 if flowControlStreamState.receiveHighWaterMarkCount
                     > (flowControlStreamState.receiveHighWaterMarkPreviousCount

--- a/Sources/SwiftNetwork/QUIC/QUICPath.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICPath.swift
@@ -258,6 +258,7 @@ public final class QUICPath: MultiplexingDatagramPath<QUICConnection>, Equatable
 
     var isRouteEstablished: Bool { state.isRouteEstablished }
 
+    @_optimize(speed)
     var smoothedRTT: NetworkDuration {
         rtt.smoothedRTT
     }


### PR DESCRIPTION
Each call to updateMaximumUnreadInboundBytesAllowed does a per-path scan on each inbound packet to tune the receive buffer.
This change gates the per-path scan behind a full round trip elapsing.  This is based on the smoothedRTT of the current path.

Top of tree:
```
98.93 M 52.6%		  QUICStreamInstance.updateMaximumUnreadInboundBytesAllowed(dataLengthAdded:connection:)
84.00 M 44.7%	-      	specialized ManyToManyProtocolHandler.applyToAllPaths(_:)
44.00 M 23.4%	-      	  specialized Sequence.forEach(_:)
40.00 M 21.3%	-      	  protocol witness for ManyToManyProtocolHandler.multiplexingPaths.getter in conformance QUICConnection
2.00 M  1.1%	-	    FlowControlGlobals.shared.unsafeMutableAddressor
1.00 M  0.5%	- 	    QUICStreamInstance.computeReceiveHighWaterMarkIncrease(dataLength:rtt:mss:now:)
```

With this change:
```
42.62 M 48.1%	-      	QUICStreamInstance.updateMaximumUnreadInboundBytesAllowed(dataLengthAdded:connection:)
42.62 M 48.1%	-	      QUICStreamInstance.computeReceiveHighWaterMarkIncrease(dataLength:connection:now:)
35.62 M 40.2%	-      	   QUICPath.smoothedRTT.getter
22.00 M 24.8%	-	        swift_beginAccess	
8.19 M  9.2%	-	        <deduplicated_symbol>	
5.42 M  6.1%	- 	        DYLD-STUB$$swift_beginAccess
```

Savings of 56 megacycles for both client and server so 112 megacycles total.