### PR TITLE
Make endpoint types sendable

### DIFF
--- a/Sources/SwiftNetwork/Endpoint/AddressEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/AddressEndpoint.swift
@@ -24,9 +24,9 @@ internal import os
 
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-public struct AddressEndpoint: EndpointProtocol, EndpointCommonProtocol {
+public struct AddressEndpoint: EndpointProtocol, EndpointCommonProtocol, Sendable {
     public var common: EndpointCommon
-    public enum AddressEndpointType: Equatable {
+    public enum AddressEndpointType: Equatable, Sendable {
         case v4(IPv4Address, UInt16)
         case v6(IPv6Address, UInt16)
         case unix(String)

--- a/Sources/SwiftNetwork/Endpoint/ApplicationServiceEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/ApplicationServiceEndpoint.swift
@@ -12,10 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Synchronization)
-internal import Synchronization
-#endif
-
 @_spi(Essentials)
 @available(Network 0.1.0, *)
 public struct ApplicationServiceEndpoint: EndpointProtocol, EndpointCommonProtocol, Sendable {
@@ -48,7 +44,7 @@ public struct ApplicationServiceEndpoint: EndpointProtocol, EndpointCommonProtoc
         }
     }
 
-    internal final class AppSVCBackingClass: Hashable, Sendable {
+    internal final class AppSVCBackingClass: Hashable, @unchecked Sendable {
         static func == (
             lhs: ApplicationServiceEndpoint.AppSVCBackingClass,
             rhs: ApplicationServiceEndpoint.AppSVCBackingClass
@@ -70,17 +66,9 @@ public struct ApplicationServiceEndpoint: EndpointProtocol, EndpointCommonProtoc
         func copy() -> Self {
             .init(storage: self.storage)
         }
-        var storage: Storage {
-            get {
-                _storage.withLock { $0 }
-            }
-            set {
-                _storage.withLock { $0 = newValue }
-            }
-        }
-        private let _storage: NetworkMutex<Storage>
+        var storage: Storage
         init(storage: Storage) {
-            self._storage = NetworkMutex(storage)
+            self.storage = storage
         }
     }
     typealias Backing = AppSVCBackingClass

--- a/Sources/SwiftNetwork/Endpoint/ApplicationServiceEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/ApplicationServiceEndpoint.swift
@@ -12,6 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Synchronization)
+internal import Synchronization
+#endif
+
 @_spi(Essentials)
 @available(Network 0.1.0, *)
 public struct ApplicationServiceEndpoint: EndpointProtocol, EndpointCommonProtocol, Sendable {

--- a/Sources/SwiftNetwork/Endpoint/ApplicationServiceEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/ApplicationServiceEndpoint.swift
@@ -68,21 +68,16 @@ public struct ApplicationServiceEndpoint: EndpointProtocol, EndpointCommonProtoc
         }
 		var storage: Storage {
 			get {
-				lock.withLock { _ in
-					_storage
-				}
+				_storage.withLock { $0 }
 			}
 			set {
-				lock.withLock { _ in
-					_storage = newValue
-				}
+				_storage.withLock { $0 = newValue }
 			}
 		}
-		private nonisolated(unsafe) var _storage: Storage
-		private let lock = NetworkMutex(())
-        init(storage: Storage) {
-            self._storage = storage
-        }
+		private let _storage: NetworkMutex<Storage>
+		init(storage: Storage) {
+			self._storage = NetworkMutex(storage)
+		}
     }
     typealias Backing = AppSVCBackingClass
     var backing: Backing

--- a/Sources/SwiftNetwork/Endpoint/ApplicationServiceEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/ApplicationServiceEndpoint.swift
@@ -66,18 +66,18 @@ public struct ApplicationServiceEndpoint: EndpointProtocol, EndpointCommonProtoc
         func copy() -> Self {
             .init(storage: self.storage)
         }
-		var storage: Storage {
-			get {
-				_storage.withLock { $0 }
-			}
-			set {
-				_storage.withLock { $0 = newValue }
-			}
-		}
-		private let _storage: NetworkMutex<Storage>
-		init(storage: Storage) {
-			self._storage = NetworkMutex(storage)
-		}
+        var storage: Storage {
+            get {
+                _storage.withLock { $0 }
+            }
+            set {
+                _storage.withLock { $0 = newValue }
+            }
+        }
+        private let _storage: NetworkMutex<Storage>
+        init(storage: Storage) {
+            self._storage = NetworkMutex(storage)
+        }
     }
     typealias Backing = AppSVCBackingClass
     var backing: Backing

--- a/Sources/SwiftNetwork/Endpoint/ApplicationServiceEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/ApplicationServiceEndpoint.swift
@@ -14,7 +14,7 @@
 
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-public struct ApplicationServiceEndpoint: EndpointProtocol, EndpointCommonProtocol {
+public struct ApplicationServiceEndpoint: EndpointProtocol, EndpointCommonProtocol, Sendable {
     public var common: EndpointCommon {
         get { backing.storage.common }
         set {
@@ -44,7 +44,7 @@ public struct ApplicationServiceEndpoint: EndpointProtocol, EndpointCommonProtoc
         }
     }
 
-    internal final class AppSVCBackingClass: Hashable {
+    internal final class AppSVCBackingClass: Hashable, Sendable {
         static func == (
             lhs: ApplicationServiceEndpoint.AppSVCBackingClass,
             rhs: ApplicationServiceEndpoint.AppSVCBackingClass
@@ -54,7 +54,7 @@ public struct ApplicationServiceEndpoint: EndpointProtocol, EndpointCommonProtoc
         public func hash(into hasher: inout Hasher) {
             hasher.combine(storage)
         }
-        internal struct Storage: Hashable {
+        internal struct Storage: Hashable, Sendable {
             var common: EndpointCommon
             let name: String  // Name is informational for application-service endpoints.
             var applicationService: String
@@ -66,9 +66,22 @@ public struct ApplicationServiceEndpoint: EndpointProtocol, EndpointCommonProtoc
         func copy() -> Self {
             .init(storage: self.storage)
         }
-        var storage: Storage
+		var storage: Storage {
+			get {
+				lock.withLock { _ in
+					_storage
+				}
+			}
+			set {
+				lock.withLock { _ in
+					_storage = newValue
+				}
+			}
+		}
+		private nonisolated(unsafe) var _storage: Storage
+		private let lock = NetworkMutex(())
         init(storage: Storage) {
-            self.storage = storage
+            self._storage = storage
         }
     }
     typealias Backing = AppSVCBackingClass

--- a/Sources/SwiftNetwork/Endpoint/BonjourEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/BonjourEndpoint.swift
@@ -68,18 +68,18 @@ public struct BonjourEndpoint: EndpointProtocol, EndpointCommonProtocol, Sendabl
         func copy() -> Self {
             .init(storage: self.storage)
         }
-		var storage: Storage {
-			get {
-				_storage.withLock { $0 }
-			}
-			set {
-				_storage.withLock { $0 = newValue }
-			}
-		}
-		private let _storage: NetworkMutex<Storage>
-		init(storage: Storage) {
-			self._storage = NetworkMutex(storage)
-		}
+        var storage: Storage {
+            get {
+                _storage.withLock { $0 }
+            }
+            set {
+                _storage.withLock { $0 = newValue }
+            }
+        }
+        private let _storage: NetworkMutex<Storage>
+        init(storage: Storage) {
+            self._storage = NetworkMutex(storage)
+        }
     }
     private typealias Backing = BonjourBackingClass
     private var backing: Backing

--- a/Sources/SwiftNetwork/Endpoint/BonjourEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/BonjourEndpoint.swift
@@ -14,7 +14,7 @@
 
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-public struct BonjourEndpoint: EndpointProtocol, EndpointCommonProtocol {
+public struct BonjourEndpoint: EndpointProtocol, EndpointCommonProtocol, Sendable {
     public var common: EndpointCommon {
         get { backing.storage.common }
         set {
@@ -51,7 +51,7 @@ public struct BonjourEndpoint: EndpointProtocol, EndpointCommonProtocol {
         )
     }
 
-    private final class BonjourBackingClass: Hashable {
+    private final class BonjourBackingClass: Hashable, Sendable {
         static func == (lhs: BonjourEndpoint.BonjourBackingClass, rhs: BonjourEndpoint.BonjourBackingClass) -> Bool {
             lhs.storage == rhs.storage
         }
@@ -68,9 +68,22 @@ public struct BonjourEndpoint: EndpointProtocol, EndpointCommonProtocol {
         func copy() -> Self {
             .init(storage: self.storage)
         }
-        var storage: Storage
+		var storage: Storage {
+			get {
+				lock.withLock { _ in
+					_storage
+				}
+			}
+			set {
+				lock.withLock { _ in
+					_storage = newValue
+				}
+			}
+		}
+		private nonisolated(unsafe) var _storage: Storage
+		private let lock = NetworkMutex(())
         init(storage: Storage) {
-            self.storage = storage
+            self._storage = storage
         }
     }
     private typealias Backing = BonjourBackingClass

--- a/Sources/SwiftNetwork/Endpoint/BonjourEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/BonjourEndpoint.swift
@@ -12,10 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Synchronization)
-internal import Synchronization
-#endif
-
 @_spi(Essentials)
 @available(Network 0.1.0, *)
 public struct BonjourEndpoint: EndpointProtocol, EndpointCommonProtocol, Sendable {
@@ -28,10 +24,42 @@ public struct BonjourEndpoint: EndpointProtocol, EndpointCommonProtocol, Sendabl
             backing.storage.common = newValue
         }
     }
-    public var name: String { backing.storage.name }
-    public var type: String { backing.storage.type }
-    public var domain: String { backing.storage.domain }
-    public var composite: String { backing.storage.composite }
+    public var name: String {
+        get { backing.storage.name }
+        set {
+            if !isKnownUniquelyReferenced(&self.backing) {
+                self.backing = self.backing.copy()
+            }
+            backing.storage.name = newValue
+        }
+    }
+    public var type: String {
+        get { backing.storage.type }
+        set {
+            if !isKnownUniquelyReferenced(&self.backing) {
+                self.backing = self.backing.copy()
+            }
+            backing.storage.type = newValue
+        }
+    }
+    public var domain: String {
+        get { backing.storage.domain }
+        set {
+            if !isKnownUniquelyReferenced(&self.backing) {
+                self.backing = self.backing.copy()
+            }
+            backing.storage.domain = newValue
+        }
+    }
+    public var composite: String {
+        get { backing.storage.composite }
+        set {
+            if !isKnownUniquelyReferenced(&self.backing) {
+                self.backing = self.backing.copy()
+            }
+            backing.storage.composite = newValue
+        }
+    }
 
     // MARK: -- Initializers --
 
@@ -55,7 +83,7 @@ public struct BonjourEndpoint: EndpointProtocol, EndpointCommonProtocol, Sendabl
         )
     }
 
-    private final class BonjourBackingClass: Hashable, Sendable {
+    private final class BonjourBackingClass: Hashable, @unchecked Sendable {
         static func == (lhs: BonjourEndpoint.BonjourBackingClass, rhs: BonjourEndpoint.BonjourBackingClass) -> Bool {
             lhs.storage == rhs.storage
         }
@@ -64,26 +92,18 @@ public struct BonjourEndpoint: EndpointProtocol, EndpointCommonProtocol, Sendabl
         }
         internal struct Storage: Hashable {
             public var common: EndpointCommon
-            public let name: String  // Name is informational for application-service endpoints.
-            public let type: String
-            public let domain: String
-            public let composite: String
+            public var name: String  // Name is informational for application-service endpoints.
+            public var type: String
+            public var domain: String
+            public var composite: String
         }
         func copy() -> Self {
             .init(storage: self.storage)
         }
-        var storage: Storage {
-            get {
-                _storage.withLock { $0 }
-            }
-            set {
-                _storage.withLock { $0 = newValue }
-            }
-        }
-        private let _storage: NetworkMutex<Storage>
         init(storage: Storage) {
-            self._storage = NetworkMutex(storage)
+            self.storage = storage
         }
+        var storage: Storage
     }
     private typealias Backing = BonjourBackingClass
     private var backing: Backing

--- a/Sources/SwiftNetwork/Endpoint/BonjourEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/BonjourEndpoint.swift
@@ -12,6 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Synchronization)
+internal import Synchronization
+#endif
+
 @_spi(Essentials)
 @available(Network 0.1.0, *)
 public struct BonjourEndpoint: EndpointProtocol, EndpointCommonProtocol, Sendable {

--- a/Sources/SwiftNetwork/Endpoint/BonjourEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/BonjourEndpoint.swift
@@ -70,21 +70,16 @@ public struct BonjourEndpoint: EndpointProtocol, EndpointCommonProtocol, Sendabl
         }
 		var storage: Storage {
 			get {
-				lock.withLock { _ in
-					_storage
-				}
+				_storage.withLock { $0 }
 			}
 			set {
-				lock.withLock { _ in
-					_storage = newValue
-				}
+				_storage.withLock { $0 = newValue }
 			}
 		}
-		private nonisolated(unsafe) var _storage: Storage
-		private let lock = NetworkMutex(())
-        init(storage: Storage) {
-            self._storage = storage
-        }
+		private let _storage: NetworkMutex<Storage>
+		init(storage: Storage) {
+			self._storage = NetworkMutex(storage)
+		}
     }
     private typealias Backing = BonjourBackingClass
     private var backing: Backing

--- a/Sources/SwiftNetwork/Endpoint/Endpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/Endpoint.swift
@@ -33,7 +33,7 @@ public class EndpointParent: Hashable, Equatable {
 @_spi(Essentials)
 @available(Network 0.1.0, *)
 public final class Endpoint: EndpointParent, EndpointProtocol {
-    public enum EndpointType {
+	public enum EndpointType: Sendable {
         case address(AddressEndpoint)
         case applicationService(ApplicationServiceEndpoint)
         case bonjour(BonjourEndpoint)

--- a/Sources/SwiftNetwork/Endpoint/Endpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/Endpoint.swift
@@ -33,7 +33,7 @@ public class EndpointParent: Hashable, Equatable {
 @_spi(Essentials)
 @available(Network 0.1.0, *)
 public final class Endpoint: EndpointParent, EndpointProtocol {
-	public enum EndpointType: Sendable {
+    public enum EndpointType: Sendable {
         case address(AddressEndpoint)
         case applicationService(ApplicationServiceEndpoint)
         case bonjour(BonjourEndpoint)

--- a/Sources/SwiftNetwork/Endpoint/EndpointCommon.swift
+++ b/Sources/SwiftNetwork/Endpoint/EndpointCommon.swift
@@ -91,7 +91,7 @@ protocol EndpointProtocol: CustomStringConvertible {
 
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-public struct EndpointCommon: Equatable, Hashable {
+public struct EndpointCommon: Equatable, Hashable, Sendable {
     let interface: Interface?
     #if NETWORK_PRIVATE
     let commonPrivate: EndpointCommon_Private?

--- a/Sources/SwiftNetwork/Endpoint/EthernetAddress.swift
+++ b/Sources/SwiftNetwork/Endpoint/EthernetAddress.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 @available(Network 0.1.0, *)
-public struct EthernetAddress: Hashable, CustomDebugStringConvertible {
+public struct EthernetAddress: Hashable, CustomDebugStringConvertible, Sendable {
 
     public static var broadcast: EthernetAddress {
         EthernetAddress(EthernetAddressStorage(repeating: 0xff))

--- a/Sources/SwiftNetwork/Endpoint/HostEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/HostEndpoint.swift
@@ -14,7 +14,7 @@
 
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-public struct HostEndpoint: EndpointProtocol, EndpointCommonProtocol {
+public struct HostEndpoint: EndpointProtocol, EndpointCommonProtocol, Sendable {
     public var common: EndpointCommon
     public let name: String
     public let port: UInt16

--- a/Sources/SwiftNetwork/Endpoint/SRVEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/SRVEndpoint.swift
@@ -14,7 +14,7 @@
 
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-public struct SRVEndpoint: EndpointProtocol, EndpointCommonProtocol {
+public struct SRVEndpoint: EndpointProtocol, EndpointCommonProtocol, Sendable {
     public var common: EndpointCommon
     let name: String
 

--- a/Sources/SwiftNetwork/Endpoint/URLEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/URLEndpoint.swift
@@ -18,7 +18,7 @@ import Foundation
 
 @_spi(Essentials)
 @available(Network 0.1.0, *)
-public struct URLEndpoint: EndpointProtocol, EndpointCommonProtocol {
+public struct URLEndpoint: EndpointProtocol, EndpointCommonProtocol, Sendable {
     public var common: EndpointCommon
     public let url: URL
     public let schemeIsSecure: Bool


### PR DESCRIPTION
Adds Sendability conformance to `Endpoint.EndpointType` enum. This was mostly mechanical save for `BonjourEndpoint` and `ApplicationServiceEndpoint` which needed locking support to protect access to the mutable `Storage` object.