### PR TITLE
Reduce Deserializer CPU Usage by almost 3x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -177,5 +177,11 @@ let package = Package(
             exclude: ["README.md"],
             swiftSettings: availabilityMacros + settings
         ),
+        .executableTarget(
+            name: "DeserializerBenchmark",
+            dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
+            path: "Sources/Tools/DeserializerBenchmark",
+            swiftSettings: availabilityMacros + settings
+        ),
     ]
 )

--- a/Sources/SwiftNetwork/Protocols/Frame.swift
+++ b/Sources/SwiftNetwork/Protocols/Frame.swift
@@ -37,7 +37,8 @@ public struct Frame: ~Copyable {
         case customFinalizer(buffer: UnsafeMutableRawBufferPointer, finalizer: (UnsafeMutableRawBufferPointer) -> Void)
     }
 
-    var _bytes: NetworkUniqueArray<UInt8> = .init()
+    @usableFromInline
+    var _bytes: UniqueArray<UInt8> = .init()
     var protocolMetadatas: NetworkUniqueDeque<FrameProtocolMetadata> = .init(minimumCapacity: 0)
     var ipPacketValues: IPPacketValues? = nil
     public var buffer: Buffer
@@ -61,10 +62,12 @@ public struct Frame: ~Copyable {
         get { Int(_endOffset) }
         set { _endOffset = UInt32(newValue) }
     }
+    @usableFromInline
     var effectiveBufferLength: Int {
         get { Int(_effectiveBufferLength) }
         set { _effectiveBufferLength = UInt32(newValue) }
     }
+    @usableFromInline
     var aggregateBufferLength: Int {
         get { Int(_aggregateBufferLength) }
         set { _aggregateBufferLength = UInt32(newValue) }
@@ -136,13 +139,15 @@ public struct Frame: ~Copyable {
 
     // MARK: - Byte access
 
-    @inline(__always)
+    @inlinable
+    @inline(always)
     public var unclaimedLength: Int {
         if effectiveBufferLength == 0 { return 0 }
         return effectiveBufferLength - (startOffset + endOffset)
     }
 
-    @inline(__always)
+    @inlinable
+    @inline(always)
     public var span: Span<UInt8>? {
         @_lifetime(borrow self)
         get {
@@ -160,7 +165,8 @@ public struct Frame: ~Copyable {
         }
     }
 
-    @inline(__always)
+    @inlinable
+    @inline(always)
     public var bytes: RawSpan? {
         @_lifetime(borrow self)
         get {
@@ -177,7 +183,8 @@ public struct Frame: ~Copyable {
         }
     }
 
-    @inline(__always)
+    @inlinable
+    @inline(always)
     public var mutableSpan: MutableSpan<UInt8>? {
         @_lifetime(&self)
         mutating get {
@@ -198,7 +205,8 @@ public struct Frame: ~Copyable {
         }
     }
 
-    @inline(__always)
+    @inlinable
+    @inline(always)
     var allBytes: RawSpan? {
         guard isValid else { return nil }
         switch buffer {
@@ -225,7 +233,8 @@ public struct Frame: ~Copyable {
     }
 
     // Only unclaimed bytes in frame, for unsafe types
-    private var unsafeUnclaimedBuffer: UnsafeMutableRawBufferPointer? {
+    @usableFromInline
+    var unsafeUnclaimedBuffer: UnsafeMutableRawBufferPointer? {
         switch buffer {
         case .empty:
             return nil
@@ -245,7 +254,8 @@ public struct Frame: ~Copyable {
     }
 
     // All bytes in frame, including claimed bytes, for unsafe types
-    private var unsafeBuffer: UnsafeMutableRawBufferPointer? {
+    @usableFromInline
+    var unsafeBuffer: UnsafeMutableRawBufferPointer? {
         switch buffer {
         case .empty:
             return nil

--- a/Sources/SwiftNetwork/QUIC/Protector.swift
+++ b/Sources/SwiftNetwork/QUIC/Protector.swift
@@ -1429,6 +1429,7 @@ struct Protector: ~Copyable, PrefixedLoggable {
 // Availability due to Swift's `RawSpan` type
 @available(macOS 10.14.4, iOS 12.2, tvOS 12.2, watchOS 5.2, *)
 extension RawSpan {
+    @usableFromInline
     subscript(index: Int) -> UInt8 {
         unsafeLoad(fromByteOffset: index, as: UInt8.self)
     }

--- a/Sources/SwiftNetwork/Utilities/Deserializer.swift
+++ b/Sources/SwiftNetwork/Utilities/Deserializer.swift
@@ -42,6 +42,7 @@ public enum DeserializationResult: CustomStringConvertible, Equatable, Sendable 
     case success(parsedBytes: Int, remainingBytes: Int)
     case error(DeserializationError)
 
+    @usableFromInline
     static let success: Self = .success(parsedBytes: 0, remainingBytes: 0)
 
     public var description: String {
@@ -75,14 +76,22 @@ public enum DeserializationResult: CustomStringConvertible, Equatable, Sendable 
 @_spi(ProtocolProvider)
 @available(Network 0.1.0, *)
 public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escapable>: ~Copyable, ~Escapable {
-    private var factory: Factory
-    private var currentSpan: RawSpan
-    private var currentSpanByteCount = 0
-    private var availableByteCount: Int
-    private var scratchSpace: [16 of UInt8]?  // Initialized lazily
-    private var cursor = 0
-    private var previousSpanAggregateByteCount = 0
-    private(set) var internalResult: DeserializationResult = .success
+    @usableFromInline
+    var factory: Factory
+    @usableFromInline
+    var currentSpan: RawSpan
+    @usableFromInline
+    var currentSpanByteCount = 0
+    @usableFromInline
+    var availableByteCount: Int
+    @usableFromInline
+    var scratchSpace: [16 of UInt8]?  // Initialized lazily
+    @usableFromInline
+    var cursor = 0
+    @usableFromInline
+    var previousSpanAggregateByteCount = 0
+    @usableFromInline
+    var internalResult: DeserializationResult = .success
 
     /// Extracts the factory from the deserializer, consuming the deserializer in the process.
     @_lifetime(copy self)
@@ -112,6 +121,8 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     ///
     /// - Returns: A Boolean value that indicates whether the factory had another span available; returns `false` when no more spans remain.
     @discardableResult
+    @inlinable
+    @inline(always)
     mutating func refill() -> Bool {
         guard let span = factory.nextSpan() else {
             return false
@@ -122,8 +133,9 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         currentSpanByteCount = currentSpan.byteCount
         return true
     }
-    @inline(__always)
-    private var remaining: Int {
+    @inlinable
+    @inline(always)
+    var remaining: Int {
         // This will never be negative since cursor is only advanced
         // by moveCursor, which checks to ensure that cursor never
         // moves beyond the remaining length
@@ -132,7 +144,8 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         #endif
         return currentSpanByteCount - cursor
     }
-    private var totalBytesParsed: Int {
+    @usableFromInline
+    var totalBytesParsed: Int {
         previousSpanAggregateByteCount + cursor
     }
     var finalResult: DeserializationResult {
@@ -150,26 +163,31 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         }
     }
 
-    @inline(__always)
-    private func hasRoom(_ length: Int) -> Bool {
+    @inlinable
+    @inline(always)
+    func hasRoom(_ length: Int) -> Bool {
         (currentSpanByteCount - cursor) >= length
     }
 
+    @inlinable
+    @inline(always)
     mutating func invalidate(_ error: DeserializationError) throws(DeserializationError) -> Never {
         internalResult = .error(error)
         throw error
     }
 
-    @inline(__always)
-    private mutating func moveCursorUnchecked(_ amount: Int) {
+    @inlinable
+    @inline(always)
+    mutating func moveCursorUnchecked(_ amount: Int) {
         // It is safe to always add the amount to the cursor, since the length
         // was already checked. So, we use &+= which skips the more expensive
         // overflow check.
         cursor &+= amount
     }
 
-    @inline(__always)
-    private mutating func moveCursor(_ amount: Int) throws(DeserializationError) {
+    @inlinable
+    @inline(always)
+    mutating func moveCursor(_ amount: Int) throws(DeserializationError) {
         guard amount <= remaining else {
             try invalidate(.bufferTooShort)
         }
@@ -179,7 +197,9 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     /// Reads a fixed-size value across span boundaries, using the stored scratch space and refilling as needed.
     ///
     /// Call this method when `hasRoom` fails but `internalResult` is still valid.
-    private mutating func readFragmented<T: BitwiseCopyable>(_ value: inout T) throws(DeserializationError) {
+    @inlinable
+    @inline(always)
+    mutating func readFragmented<T: BitwiseCopyable>(_ value: inout T) throws(DeserializationError) {
         let length = MemoryLayout<T>.size
         precondition(length <= 16)
         if scratchSpace == nil {
@@ -219,8 +239,9 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     ///
     /// Reads a fixed-size `BitwiseCopyable` value, using the fast path when the current
     /// span has enough data, or falling back to `readFragmented(_:)`.
-    @inline(__always)
-    private mutating func readFixedSize<T: BitwiseCopyable>(_ value: inout T) throws(DeserializationError) {
+    @inlinable
+    @inline(always)
+    mutating func readFixedSize<T: BitwiseCopyable>(_ value: inout T) throws(DeserializationError) {
         let length = MemoryLayout<T>.size
         guard hasRoom(length) else {
             try readFragmented(&value)
@@ -233,8 +254,9 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     /// Reads an optional fixed-size, bitwise-copyable value.
     ///
     /// Reads an optional fixed-size `BitwiseCopyable` value.
-    @inline(__always)
-    private mutating func readFixedSize<T: BitwiseCopyable & FixedWidthInteger>(
+    @inlinable
+    @inline(always)
+    mutating func readFixedSize<T: BitwiseCopyable & FixedWidthInteger>(
         _ value: inout T?
     ) throws(DeserializationError) {
         var tempValue: T = 0
@@ -243,8 +265,9 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     }
 
     /// Reads a fixed-size integer value with optional network-to-host byte order conversion.
-    @inline(__always)
-    private mutating func readFixedSize<T: BitwiseCopyable & FixedWidthInteger>(
+    @inlinable
+    @inline(always)
+    mutating func readFixedSize<T: BitwiseCopyable & FixedWidthInteger>(
         _ value: inout T,
         networkByteOrder: Bool
     ) throws(DeserializationError) {
@@ -255,8 +278,9 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     }
 
     /// Reads an optional fixed-size integer value with optional network-to-host byte order conversion.
-    @inline(__always)
-    private mutating func readFixedSize<T: BitwiseCopyable & FixedWidthInteger>(
+    @inlinable
+    @inline(always)
+    mutating func readFixedSize<T: BitwiseCopyable & FixedWidthInteger>(
         _ value: inout T?,
         networkByteOrder: Bool
     ) throws(DeserializationError) {
@@ -266,6 +290,8 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     }
 
     @_optimize(speed)
+    @inlinable
+    @inline(always)
     mutating func decodeVariableLength() throws(DeserializationError) -> (UInt64, Int) {
         // Ensure at least 1 byte is available to peek at the length prefix
         if !hasRoom(MemoryLayout<UInt8>.size) {
@@ -294,6 +320,8 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         }
     }
 
+    @inlinable
+    @inline(always)
     static func valueMatches(lhs: UnsafeRawBufferPointer, rhs: RawSpan, rhsOffset: Int, count: Int) -> Bool {
         #if !NETWORK_EMBEDDED
         return rhs.withUnsafeBytes { rhs in
@@ -312,7 +340,9 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         #endif
     }
 
-    fileprivate mutating func validateValue<T: BitwiseCopyable>(expect value: T) throws(DeserializationError) {
+    @inlinable
+    @inline(always)
+    mutating func validateValue<T: BitwiseCopyable>(expect value: T) throws(DeserializationError) {
         let length = MemoryLayout<T>.size
         guard hasRoom(length) else {
             // Read fragmented bytes into scratch space, then compare
@@ -339,114 +369,170 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         moveCursorUnchecked(length)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint8(_ value: inout UInt8) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint8(_ value: inout UInt8?) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint8(expect value: UInt8) throws(DeserializationError) {
         try validateValue(expect: value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func int8(_ value: inout Int8) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func int8(_ value: inout Int8?) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func int8(expect value: Int8) throws(DeserializationError) {
         try validateValue(expect: value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint16(_ value: inout UInt16) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint16(_ value: inout UInt16?) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint16(expect value: UInt16) throws(DeserializationError) {
         try validateValue(expect: value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func int16(_ value: inout Int16) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func int16(_ value: inout Int16?) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func int16(expect value: Int16) throws(DeserializationError) {
         try validateValue(expect: value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint32(_ value: inout UInt32) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint32(_ value: inout UInt32?) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint32(expect value: UInt32) throws(DeserializationError) {
         try validateValue(expect: value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint64(_ value: inout UInt64) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint64(_ value: inout UInt64?) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint64(expect value: UInt64) throws(DeserializationError) {
         try validateValue(expect: value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint16NetworkByteOrder(_ value: inout UInt16) throws(DeserializationError) {
         try readFixedSize(&value, networkByteOrder: true)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint16NetworkByteOrder(_ value: inout UInt16?) throws(DeserializationError) {
         try readFixedSize(&value, networkByteOrder: true)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint16NetworkByteOrder(expect value: UInt16) throws(DeserializationError) {
         try validateValue(expect: value.bigEndian)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint32NetworkByteOrder(_ value: inout UInt32) throws(DeserializationError) {
         try readFixedSize(&value, networkByteOrder: true)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint32NetworkByteOrder(_ value: inout UInt32?) throws(DeserializationError) {
         try readFixedSize(&value, networkByteOrder: true)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint32NetworkByteOrder(expect value: UInt32) throws(DeserializationError) {
         try validateValue(expect: value.bigEndian)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint64NetworkByteOrder(_ value: inout UInt64) throws(DeserializationError) {
         try readFixedSize(&value, networkByteOrder: true)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint64NetworkByteOrder(_ value: inout UInt64?) throws(DeserializationError) {
         try readFixedSize(&value, networkByteOrder: true)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uint64NetworkByteOrder(expect value: UInt64) throws(DeserializationError) {
         try validateValue(expect: value.bigEndian)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func vle<T: FixedWidthInteger>(_ value: inout T) throws(DeserializationError) {
         guard let parsedValue = T(exactly: try decodeVariableLength().0) else {
             throw .parsingFailed
@@ -454,6 +540,8 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         value = parsedValue
     }
 
+    @inlinable
+    @inline(always)
     public mutating func vle<T: FixedWidthInteger>(_ value: inout T?) throws(DeserializationError) {
         guard let parsedValue = T(exactly: try decodeVariableLength().0) else {
             throw .parsingFailed
@@ -461,14 +549,20 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         value = parsedValue
     }
 
+    @inlinable
+    @inline(always)
     public mutating func vle(_ value: inout UInt64) throws(DeserializationError) {
         value = try decodeVariableLength().0
     }
 
+    @inlinable
+    @inline(always)
     public mutating func vle(_ value: inout UInt64?) throws(DeserializationError) {
         value = try decodeVariableLength().0
     }
 
+    @inlinable
+    @inline(always)
     public mutating func vle(expect value: UInt64) throws(DeserializationError) {
         let (decoded, _) = try decodeVariableLength()
         guard decoded == value else {
@@ -476,10 +570,14 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         }
     }
 
+    @inlinable
+    @inline(always)
     public mutating func vle<T: FixedWidthInteger>(expect value: T) throws(DeserializationError) {
         try vle(expect: UInt64(value))
     }
 
+    @inlinable
+    @inline(always)
     public mutating func vleWithSize<T: FixedWidthInteger>(
         _ value: inout T,
         _ size: inout Int
@@ -489,20 +587,28 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         size = variable.1
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uuid(_ value: inout SystemUUID) throws(DeserializationError) {
         try readFixedSize(&value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uuid(_ value: inout SystemUUID?) throws(DeserializationError) {
         var tempValue = SystemUUID.empty
         try readFixedSize(&tempValue)
         value = tempValue
     }
 
+    @inlinable
+    @inline(always)
     public mutating func uuid(expect value: SystemUUID) throws(DeserializationError) {
         try validateValue(expect: value)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func fixedLengthUTF8(_ value: inout String, byteCount: Int) throws(DeserializationError) {
         guard byteCount > 0 else {
             return
@@ -560,6 +666,8 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         moveCursorUnchecked(byteCount)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func fixedLengthUTF8(_ value: inout String?, byteCount: Int) throws(DeserializationError) {
         var tempValue = ""
         try fixedLengthUTF8(&tempValue, byteCount: byteCount)
@@ -567,7 +675,8 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     }
 
     @_optimize(speed)
-    @inline(__always)
+    @inlinable
+    @inline(always)
     public mutating func buffer(_ value: inout [UInt8], length: Int) throws(DeserializationError) {
         guard length > 0 else {
             return
@@ -602,6 +711,8 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         moveCursorUnchecked(length)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func span(expect value: RawSpan) throws(DeserializationError) {
         let length = value.byteCount
         guard length > 0 else {
@@ -657,6 +768,8 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     }
 
     @_optimize(speed)
+    @inlinable
+    @inline(always)
     public mutating func span(_ value: inout MutableSpan<UInt8>, length: Int? = nil) throws(DeserializationError) {
         let lengthToCopy: Int
         if let length {
@@ -710,12 +823,16 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         moveCursorUnchecked(lengthToCopy)
     }
 
+    @inlinable
+    @inline(always)
     public mutating func string(_ value: inout String) throws(DeserializationError) {
         var byteCount: UInt16 = 0
         try self.uint16(&byteCount)
         try self.fixedLengthUTF8(&value, byteCount: Int(byteCount))
     }
 
+    @inlinable
+    @inline(always)
     public mutating func string(appendTo value: inout [String]) throws(DeserializationError) {
         var byteCount: UInt16 = 0
         try self.uint16(&byteCount)
@@ -727,7 +844,8 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     }
 
     @_optimize(speed)
-    @inline(__always)
+    @inlinable
+    @inline(always)
     public mutating func buffer(_ value: inout [UInt8]) throws(DeserializationError) {
         // Drain the current span and all subsequent spans
         repeat {
@@ -741,6 +859,8 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         } while refill()
     }
 
+    @inlinable
+    @inline(always)
     public mutating func skip(_ length: Int) throws(DeserializationError) {
         guard hasRoom(length) else {
             var skipped = 0
@@ -801,6 +921,8 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         return deserializer.finalResult
     }
 
+    @inlinable
+    @inline(always)
     public static func deserialize(
         _ buffer: Span<UInt8>,
         _ builder: (_ buffer: inout Deserializer) throws(DeserializationError) -> Void
@@ -808,6 +930,8 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         deserialize(buffer.bytes, builder)
     }
 
+    @inlinable
+    @inline(always)
     public static func deserialize(
         _ bytes: [UInt8],
         _ builder: (_ buffer: inout Deserializer) throws(DeserializationError) -> Void
@@ -815,6 +939,8 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         deserialize(bytes.span.bytes, builder)
     }
 
+    @inlinable
+    @inline(always)
     static func deserialize(
         _ bytes: inout [UInt8],
         _ builder: (_ buffer: inout Deserializer) throws(DeserializationError) -> Void
@@ -827,6 +953,8 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     }
 
     @_optimize(speed)
+    @inlinable
+    @inline(always)
     public static func deserialize(
         _ frame: inout Frame,
         claim: Bool,
@@ -846,6 +974,8 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
 
     #if !NETWORK_EMBEDDED
     @_optimize(speed)
+    @inlinable
+    @inline(always)
     public static func deserialize(
         _ frameArray: inout FrameArray,
         claim: Bool,

--- a/Sources/SwiftNetwork/Utilities/SerializationHelpers.swift
+++ b/Sources/SwiftNetwork/Utilities/SerializationHelpers.swift
@@ -100,6 +100,7 @@ public struct FrameArraySpanFactory: ~Copyable, ~Escapable, DeserializerSpanFact
     public private(set) var availableByteCount: Int
 
     /// Extracts the frame array from the factory, consuming the factory in the process.
+    @usableFromInline
     consuming func takeFrameArray() -> FrameArray {
         frameArray
     }
@@ -119,6 +120,7 @@ public struct FrameArraySpanFactory: ~Copyable, ~Escapable, DeserializerSpanFact
     // lifetime dependency. @_lifetime(immortal) is correct for a self-contained
     // ~Escapable type whose data is fully owned.
     @_lifetime(immortal)
+    @usableFromInline
     init(_ frameArray: consuming FrameArray) {
         self.spanCount = frameArray.count
         self.availableByteCount = frameArray.unclaimedLength

--- a/Sources/Tools/DeserializerBenchmark/main.swift
+++ b/Sources/Tools/DeserializerBenchmark/main.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetwork
+@_spi(Essentials) @_spi(ProtocolProvider) import SwiftNetworkBenchmarks
+
+private let testBytes: [UInt8] = [
+    0x01,  // UInt8
+    0x02, 0x03,  // UInt16 big-endian
+    0x04, 0x05, 0x06, 0x07,  // UInt32 big-endian
+    0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,  // UInt64 big-endian
+    0x10,  // UInt8
+]
+
+let iterationCount = 10_000_000
+
+@available(Network 0.1.0, *)
+func runtest() {
+    var frame = Frame(copyBuffer: testBytes)
+    defer { frame.finalize(success: false) }
+    for _ in 0..<iterationCount {
+        var f1: UInt8 = 0
+        var f2: UInt16 = 0
+        var f3: UInt32 = 0
+        var f4: UInt64 = 0
+        var f5: UInt8 = 0
+        _ = Deserializer.deserialize(&frame, claim: false) { read throws(DeserializationError) in
+            try read.uint8(&f1)
+            try read.uint16NetworkByteOrder(&f2)
+            try read.uint32NetworkByteOrder(&f3)
+            try read.uint64NetworkByteOrder(&f4)
+            try read.uint8(&f5)
+        }
+    }
+}
+if #available(macOS 26.0, *) {
+    runtest()
+}

--- a/Sources/Tools/DeserializerBenchmark/main.swift
+++ b/Sources/Tools/DeserializerBenchmark/main.swift
@@ -44,6 +44,6 @@ func runtest() {
         }
     }
 }
-if #available(macOS 26.0, *) {
+if #available(anyAppleOS 26, *) {
     runtest()
 }

--- a/Sources/Tools/QUICTransfer/main.swift
+++ b/Sources/Tools/QUICTransfer/main.swift
@@ -380,7 +380,7 @@ final class QUICTransfer {
 
 if #available(anyAppleOS 26, *) {
     // Take command line arguments
-    var iterations = 1  // 5gb total (if 500000 sendSize)
+    var iterations = 10000  // 5gb total (if 500000 sendSize)
     var loggingHandler: LoggingHandle = LoggingHandle(loggingType: .none)
     var sendSize = 500000  // 500kb
     var linkDelay = NetworkDuration.zero


### PR DESCRIPTION
Reduce the deserializer CPU usage by almost 3x.  Added a benchmark for incremental investigation.

Top of tree:
```
434.41 M 89.1%	52.65 M	      specialized static Deserializer<>.deserialize<>(_:claim:_:)	
298.24 M 61.1%	13.00 M	       static Deserializer<>.deserialize<>(_:_:)	
262.99 M 53.9%	12.00 M	        specialized static Deserializer<>.deserialize<>(_:_:)	
22.24 M  4.6%	22.24 M	        partial apply for closure #1 in runtest()	
83.53 M  17.1%	72.53 M	       Frame.bytes.getter	
11.00 M  2.3%	11.00 M	        Frame.startOffset.getter	
15.83 M  3.2%	15.83 M	      specialized static Deserializer<>.deserialize<>(_:_:)	
8.00 M   1.6%	8.00 M 	     specialized static Deserializer<>.deserialize<>(_:claim:_:)	
```
With this change:
```
154.37 M 69.8%	8.55 M 	      static Deserializer<>.deserialize<>(_:claim:_:)	
145.81 M 66.0%	34.19 M	       specialized static Deserializer<>.deserialize<>(_:_:)	
107.62 M 48.7%	9.77 M 	        partial apply for closure #1 in runtest()	
97.86 M  44.3%	-      	         closure #1 in runtest()	
43.31 M  19.6%	43.31 M	          specialized Deserializer<>.uint8(_:)	
24.36 M  11.0%	24.36 M	          specialized Deserializer<>.uint32NetworkByteOrder(_:)	
16.18 M  7.3%	16.18 M	          specialized Deserializer<>.uint64NetworkByteOrder(_:)	
14.00 M  6.3%	14.00 M	          specialized Deserializer<>.uint16NetworkByteOrder(_:)	
4.00 M   1.8%	4.00 M 	        specialized Deserializer<>.finalResult.getter	
25.28 M  11.4%	15.32 M	      static Deserializer<>.deserialize<>(_:claim:_:)	
```