### PR TITLE
Consider all unix domain socket secure

### DIFF
--- a/Sources/SwiftNetwork/Endpoint/URLEndpoint.swift
+++ b/Sources/SwiftNetwork/Endpoint/URLEndpoint.swift
@@ -185,7 +185,7 @@ public struct URLEndpoint: EndpointProtocol, EndpointCommonProtocol {
         #if !NETWORK_EMBEDDED
         let scheme = scheme.lowercased()
         #endif
-        return scheme == "https" || scheme == "https+unix" || scheme == "wss" || scheme == "wss+unix"
+        return scheme == "https" || scheme == "wss" || scheme.hasSuffix("+unix")
     }
 
     // MARK: -- Internal --


### PR DESCRIPTION
Unix domain socket is the local file system and should be considered secure for App Transport Security