### PR TITLE
Allow QUICTestHarness to be extended

### DIFF
--- a/Tests/SwiftNetworkTests/QUICTestHarness.swift
+++ b/Tests/SwiftNetworkTests/QUICTestHarness.swift
@@ -50,7 +50,7 @@ internal import os
 #if canImport(SwiftTLS)
 
 @available(Network 0.1.0, *)
-final class QUICTestHarness {
+class QUICTestHarness {
     // 127.0.0.1
     static let clientIPv4Address: [UInt8] = [0x7f, 0x00, 0x00, 0x01]
     static let serverIPv4Address: [UInt8] = [0x7f, 0x00, 0x00, 0x01]
@@ -89,7 +89,7 @@ final class QUICTestHarness {
         serverEndpoint = Endpoint(address: IPv4Address(QUICTestHarness.serverIPv4Address)!, port: serverPort)
     }
 
-    private func wait(for expectations: [XCTestExpectation], timeout seconds: TimeInterval, expectTimeout: Bool = false)
+    func wait(for expectations: [XCTestExpectation], timeout seconds: TimeInterval, expectTimeout: Bool = false)
     {
         let result = XCTWaiter.wait(for: expectations, timeout: seconds)
         if expectTimeout {
@@ -99,7 +99,7 @@ final class QUICTestHarness {
         }
     }
 
-    private func updateQUICOptions(
+    func updateQUICOptions(
         _ quicOptions: ProtocolOptions<QUICProtocol>,
         server: Bool = false,
         datagram: Bool = false
@@ -129,7 +129,7 @@ final class QUICTestHarness {
         }
     }
 
-    private func quicHandshake(
+    func quicHandshake(
         datagram: Bool = false,
         expectHandshakeError: NetworkError? = nil,
         clientLinkDelay: NetworkDuration = .zero,
@@ -358,7 +358,7 @@ final class QUICTestHarness {
         }
     }
 
-    private func createNewStream(
+    func createNewStream(
         identifier: String,
         quicOptions: ProtocolOptions<QUICProtocol> = QUICProtocol.options(),
         serverInitiated: Bool = false

--- a/Tests/SwiftNetworkTests/QUICTestHarness.swift
+++ b/Tests/SwiftNetworkTests/QUICTestHarness.swift
@@ -89,8 +89,7 @@ class QUICTestHarness {
         serverEndpoint = Endpoint(address: IPv4Address(QUICTestHarness.serverIPv4Address)!, port: serverPort)
     }
 
-    func wait(for expectations: [XCTestExpectation], timeout seconds: TimeInterval, expectTimeout: Bool = false)
-    {
+    func wait(for expectations: [XCTestExpectation], timeout seconds: TimeInterval, expectTimeout: Bool = false) {
         let result = XCTWaiter.wait(for: expectations, timeout: seconds)
         if expectTimeout {
             XCTAssertEqual(result, .timedOut)


### PR DESCRIPTION
Removes final from QUICTestHarness and relaxes wait() and updateQUICOptions() from private to internal access. This allows subclasses to inherit from QUICTestHarness and reuse/override these helper methods