### PR TITLE
CI: extract build/test commands into shared scripts

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,62 +13,28 @@ jobs:
       swift_nightly_flags: "--build-system native -Xswiftc -warnings-as-errors"  # workaround nightly-main issue
       enable_macos_checks: true
       macos_exclude_xcode_versions: "[{\"xcode_version\": \"swift_6.1\"}, {\"xcode_version\": \"swift_6.2\"}]"
-      macos_build_command: >-
-        bash -c '
-        rc=0;
-        echo "=== xcodebuild macOS ===";
-        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=macos,variant=macos" build && macos=PASSED || { rc=1; macos=FAILED; };
-        echo "=== macOS build: $macos ===";
-        echo "=== xcodebuild Mac Catalyst ===";
-        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=macos,variant=Mac Catalyst" build && catalyst=PASSED || { rc=1; catalyst=FAILED; };
-        echo "=== Mac Catalyst build: $catalyst ===";
-        echo "=== xcodebuild iOS ===";
-        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=ios" build && ios=PASSED || { rc=1; ios=FAILED; };
-        echo "=== iOS build: $ios ===";
-        echo "=== xcodebuild watchOS ===";
-        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=watchos" build && watchos=PASSED || { rc=1; watchos=FAILED; };
-        echo "=== watchOS build: $watchos ===";
-        echo "=== xcodebuild tvOS ===";
-        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=tvos" build && tvos=PASSED || { rc=1; tvos=FAILED; };
-        echo "=== tvOS build: $tvos ===";
-        echo "=== xcodebuild visionOS ===";
-        /usr/bin/xcodebuild -quiet -scheme swift-network-evolution-Package -destination "generic/platform=visionos" build && visionos=PASSED || { rc=1; visionos=FAILED; };
-        echo "=== visionOS build: $visionos ===";
-        echo "=== xcrun swift test ===";
-        xcrun swift test --quiet -Xswiftc -DNETWORK_INTERNAL_TESTS "$@" && tests=PASSED || { rc=1; tests=FAILED; };
-        echo "=== swift test: $tests ===";
-        echo "=== Summary ===";
-        printf "%-20s %s\n" "macOS build:" "$macos";
-        printf "%-20s %s\n" "Mac Catalyst build:" "$catalyst";
-        printf "%-20s %s\n" "iOS build:" "$ios";
-        printf "%-20s %s\n" "watchOS build:" "$watchos";
-        printf "%-20s %s\n" "tvOS build:" "$tvos";
-        printf "%-20s %s\n" "visionOS build:" "$visionos";
-        printf "%-20s %s\n" "swift test:" "$tests";
-        exit $rc
-        ' bash
+      macos_build_command: bash .github/workflows/scripts/ci-macos.sh
       enable_linux_checks: true
-      linux_swift_versions: '["nightly-main", "nightly-6.3", "6.3"]'
-      linux_build_command: >-
-        bash -c '
-        set -e;
-        echo "=== Build (default traits) ===";
-        swift build --build-tests --quiet "$@";
-        echo "=== Build (default traits): PASSED ===";
-        echo "=== Build (additive traits on) ===";
-        swift build --build-tests --quiet --traits DatapathLogging,QlogOutput,SignpostOutput "$@";
-        echo "=== Build (additive traits on): PASSED ===";
-        echo "=== Build (reductive traits on) ===";
-        swift build --build-tests --quiet --traits DisableDebugLogging,DisableErrorLogging "$@";
-        echo "=== Build (reductive traits on): PASSED ===";
-        echo "=== Test (debug) ===";
-        swift test --quiet -Xswiftc -DNETWORK_INTERNAL_TESTS "$@";
-        echo "=== Test (debug): PASSED ===";
-        echo "=== Test (release) ===";
-        swift test --quiet -c release -Xswiftc -DNETWORK_INTERNAL_TESTS "$@";
-        echo "=== Test (release): PASSED ===";
-        echo "=== Summary: all builds and tests passed ==="
-        ' bash
+      linux_swift_versions: '["nightly-6.3", "6.3"]'
+      linux_build_command: bash .github/workflows/scripts/ci-linux.sh
+      enable_windows_checks: false
+      enable_android_sdk_build: false
+      enable_embedded_wasm_sdk_build: false
+      enable_linux_static_sdk_build: true
+  tests-nightly-main:
+    name: Test (nightly-main)
+    # Skipped: the nightly-main (6.5-dev) compiler cannot build this package.
+    # It crashes in the LoadableByAddress SIL pass ("Unimplemented user") on
+    # Frame.span, so every build and test configuration fails. Flip this back to
+    # true once the upstream fix lands.
+    if: false
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
+    with:
+      swift_nightly_flags: "--build-system native -Xswiftc -warnings-as-errors"  # workaround nightly-main issue
+      enable_linux_checks: true
+      linux_swift_versions: '["nightly-main"]'
+      linux_build_command: bash .github/workflows/scripts/ci-linux.sh
+      enable_macos_checks: false
       enable_windows_checks: false
       enable_android_sdk_build: false
       enable_embedded_wasm_sdk_build: false

--- a/.github/workflows/scripts/ci-linux.sh
+++ b/.github/workflows/scripts/ci-linux.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+# Builds and tests the package on Linux.
+#
+# Usage: ci-linux.sh [swift flags...]
+#
+# The flags are the ones appended by the workflow (swift_flags /
+# swift_nightly_flags).
+
+set -u
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=ci-support.sh
+. "${script_dir}/ci-support.sh"
+
+ci_run 'Build (default traits)' \
+    swift build --build-tests --quiet "$@"
+ci_run 'Build (additive traits on)' \
+    swift build --build-tests --quiet \
+    --traits DatapathLogging,QlogOutput,SignpostOutput "$@"
+ci_run 'Build (reductive traits on)' \
+    swift build --build-tests --quiet \
+    --traits DisableDebugLogging,DisableErrorLogging "$@"
+ci_run 'Test (debug)' \
+    swift test --quiet -Xswiftc -DNETWORK_INTERNAL_TESTS "$@"
+ci_run 'Test (release)' \
+    swift test --quiet -c release -Xswiftc -DNETWORK_INTERNAL_TESTS "$@"
+
+ci_finish

--- a/.github/workflows/scripts/ci-macos.sh
+++ b/.github/workflows/scripts/ci-macos.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+# Builds the package for every Apple platform with xcodebuild, then runs the
+# test suite on macOS.
+#
+# Usage: ci-macos.sh [swift flags...]
+#
+# The flags are forwarded to `swift test` only. The xcodebuild invocations take
+# their settings from the scheme, which is how this worked before the commands
+# were moved out of the workflow file.
+
+set -u
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=ci-support.sh
+. "${script_dir}/ci-support.sh"
+
+scheme='swift-network-evolution-Package'
+
+# xcodebuild_step <name> <destination>
+xcodebuild_step() {
+    ci_run "$1" /usr/bin/xcodebuild -quiet -scheme "${scheme}" -destination "$2" build
+}
+
+xcodebuild_step 'macOS build' 'generic/platform=macos,variant=macos'
+xcodebuild_step 'Mac Catalyst build' 'generic/platform=macos,variant=Mac Catalyst'
+xcodebuild_step 'iOS build' 'generic/platform=ios'
+xcodebuild_step 'watchOS build' 'generic/platform=watchos'
+xcodebuild_step 'tvOS build' 'generic/platform=tvos'
+xcodebuild_step 'visionOS build' 'generic/platform=visionos'
+
+ci_run 'swift test' xcrun swift test --quiet -Xswiftc -DNETWORK_INTERNAL_TESTS "$@"
+
+ci_finish

--- a/.github/workflows/scripts/ci-support.sh
+++ b/.github/workflows/scripts/ci-support.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+# Shared step runner for the CI scripts in this directory. Source it, call
+# ci_run once per step, then call ci_finish.
+#
+# Steps always run even if an earlier one failed, so a single broken
+# configuration does not hide the state of the others. ci_finish prints a
+# summary and exits non-zero if any step failed.
+#
+# Note: this must stay compatible with bash 3.2, which is what /bin/bash is on
+# the macOS runners.
+
+ci_exit_code=0
+ci_summary=()
+
+# ci_record <name> <result>
+ci_record() {
+    ci_summary+=("$(printf '%-30s %s' "$1:" "$2")")
+}
+
+# ci_run <name> <command>...
+ci_run() {
+    local name="$1"
+    shift
+
+    echo "=== ${name} ==="
+    if "$@"; then
+        echo "=== ${name}: PASSED ==="
+        ci_record "${name}" 'PASSED'
+    else
+        echo "=== ${name}: FAILED ==="
+        ci_exit_code=1
+        ci_record "${name}" 'FAILED'
+    fi
+}
+
+ci_finish() {
+    echo '=== Summary ==='
+    if [ "${#ci_summary[@]}" -gt 0 ]; then
+        printf '%s\n' "${ci_summary[@]}"
+    fi
+
+    # Surface the outcome on the run's summary page, not just buried in the log.
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ] && [ "${#ci_summary[@]}" -gt 0 ]; then
+        {
+            echo '```'
+            printf '%s\n' "${ci_summary[@]}"
+            echo '```'
+        } >> "${GITHUB_STEP_SUMMARY}"
+    fi
+
+    exit "${ci_exit_code}"
+}

--- a/.licenseignore
+++ b/.licenseignore
@@ -9,6 +9,7 @@
 **/*.yml
 **/Package.resolved
 .editorconfig
+.shellcheckrc
 Package.swift
 Benchmarks/Package.swift
 Package@swift-*.swift

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+external-sources=true
+source-path=SCRIPTDIR


### PR DESCRIPTION
- Move macOS and Linux build/test commands out of the workflow file into
  dedicated `ci-macos.sh` and `ci-linux.sh` scripts backed by a shared
  `ci-support.sh` step runner.
- Run all steps even when one fails, print a consolidated summary (also
  to the run summary page), and exit non-zero if any step failed.
- Split `nightly-main` into its own job, currently skipped due to a
  compiler crash in the LoadableByAddress SIL pass.