### PR TITLE
SwiftQUIC: PERF: Reduce CPU using in processIncomingStreamData by 29%

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -147,35 +147,35 @@ let package = Package(
             dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
             path: "Sources/Tools/QUICHandshake",
             exclude: ["README.md"],
-            swiftSettings: availabilityMacros + settings + [.unsafeFlags(["-cross-module-optimization"])],
+            swiftSettings: availabilityMacros + settings
         ),
         .executableTarget(
             name: "IPUDPTransfer",
             dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
             path: "Sources/Tools/IPUDPTransfer",
             exclude: ["README.md"],
-            swiftSettings: availabilityMacros + settings + [.unsafeFlags(["-cross-module-optimization"])],
+            swiftSettings: availabilityMacros + settings
         ),
         .executableTarget(
             name: "QUICTransfer",
             dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
             path: "Sources/Tools/QUICTransfer",
             exclude: ["README.md"],
-            swiftSettings: availabilityMacros + settings + [.unsafeFlags(["-cross-module-optimization"])],
+            swiftSettings: availabilityMacros + settings
         ),
         .executableTarget(
             name: "QUICStreamLoad",
             dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
             path: "Sources/Tools/QUICStreamLoad",
             exclude: ["README.md"],
-            swiftSettings: availabilityMacros + settings + [.unsafeFlags(["-cross-module-optimization"])]
+            swiftSettings: availabilityMacros + settings
         ),
         .executableTarget(
             name: "SocketTransfer",
             dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
             path: "Sources/Tools/SocketTransfer",
             exclude: ["README.md"],
-            swiftSettings: availabilityMacros + settings + [.unsafeFlags(["-cross-module-optimization"])]
+            swiftSettings: availabilityMacros + settings
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -147,35 +147,35 @@ let package = Package(
             dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
             path: "Sources/Tools/QUICHandshake",
             exclude: ["README.md"],
-            swiftSettings: availabilityMacros + settings,
+            swiftSettings: availabilityMacros + settings + [.unsafeFlags(["-cross-module-optimization"])],
         ),
         .executableTarget(
             name: "IPUDPTransfer",
             dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
             path: "Sources/Tools/IPUDPTransfer",
             exclude: ["README.md"],
-            swiftSettings: availabilityMacros + settings
+            swiftSettings: availabilityMacros + settings + [.unsafeFlags(["-cross-module-optimization"])],
         ),
         .executableTarget(
             name: "QUICTransfer",
             dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
             path: "Sources/Tools/QUICTransfer",
             exclude: ["README.md"],
-            swiftSettings: availabilityMacros + settings
+            swiftSettings: availabilityMacros + settings + [.unsafeFlags(["-cross-module-optimization"])],
         ),
         .executableTarget(
             name: "QUICStreamLoad",
             dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
             path: "Sources/Tools/QUICStreamLoad",
             exclude: ["README.md"],
-            swiftSettings: availabilityMacros + settings
+            swiftSettings: availabilityMacros + settings + [.unsafeFlags(["-cross-module-optimization"])]
         ),
         .executableTarget(
             name: "SocketTransfer",
             dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
             path: "Sources/Tools/SocketTransfer",
             exclude: ["README.md"],
-            swiftSettings: availabilityMacros + settings
+            swiftSettings: availabilityMacros + settings + [.unsafeFlags(["-cross-module-optimization"])]
         ),
     ]
 )

--- a/Sources/SwiftNetwork/QUIC/FlowControl.swift
+++ b/Sources/SwiftNetwork/QUIC/FlowControl.swift
@@ -309,7 +309,7 @@ extension QUICConnection {
         )
     }
 
-    @inline(__always)
+    @inline(always)
     func sendInboundFlowControlCredit() {
         guard !state.isTerminal else {
             return

--- a/Sources/SwiftNetwork/QUIC/FlowControl.swift
+++ b/Sources/SwiftNetwork/QUIC/FlowControl.swift
@@ -200,6 +200,7 @@ struct FlowControlState: ~Copyable {
     }
 
     // Returns true if changed
+    @inline(always)
     fileprivate mutating func recalculateInboundMaxData() -> Bool {
         // The new inbound max data is equal the number of bytes already delivered
         // to the application, plus the number of bytes we are willing to add
@@ -308,6 +309,7 @@ extension QUICConnection {
         )
     }
 
+    @inline(__always)
     func sendInboundFlowControlCredit() {
         guard !state.isTerminal else {
             return
@@ -319,6 +321,7 @@ extension QUICConnection {
         }
     }
 
+    @inline(always)
     fileprivate func updateMaximumUnreadInboundBytesAllowed(increment: UInt64) {
         let oldValue = flowControlState.maximumUnreadInboundBytesAllowed
         flowControlState.maximumUnreadInboundBytesAllowed = min(
@@ -496,6 +499,7 @@ extension QUICStreamInstance {
         )
     }
 
+    @inline(always)
     fileprivate func sendInboundFlowControlCredit(
         connection: QUICConnection,
         sendStreamCredit: Bool,
@@ -603,6 +607,7 @@ extension QUICStreamInstance {
         return min(connectionCredit, streamCredit)
     }
 
+    @inline(always)
     func updateLastReceivedOffset(
         to newLastReceivedOffset: UInt64,
         connection: QUICConnection
@@ -638,6 +643,7 @@ extension QUICStreamInstance {
         return delta
     }
 
+    @inline(always)
     func startTrackingInboundFlowControlInterval(connection: QUICConnection) {
         // Start of a new measurement interval
         if flowControlStreamState.receiveHighWaterMarkTime == .zero {
@@ -647,6 +653,7 @@ extension QUICStreamInstance {
 
     // Updates inbound flow control credit, and recalculates
     // `maximumUnreadInboundBytesAllowed` values.
+    @inline(always)
     func updateInboundFlowControlCredit(
         dataLengthAdded: UInt64,
         connection: QUICConnection,
@@ -686,6 +693,7 @@ extension QUICStreamInstance {
     // Grow the receive buffer based on 2*BDP to ensure
     // that sender can send at full rate.
     // Returns true if maximum was updated.
+    @inline(always)
     fileprivate func updateMaximumUnreadInboundBytesAllowed(
         dataLengthAdded: UInt64,
         connection: QUICConnection
@@ -726,6 +734,7 @@ extension QUICStreamInstance {
         return false
     }
 
+    @inline(always)
     fileprivate func updateMaximumUnreadInboundBytesAllowed(increment: UInt64) {
         let oldValue = flowControlState.maximumUnreadInboundBytesAllowed
         flowControlState.maximumUnreadInboundBytesAllowed = min(
@@ -734,33 +743,34 @@ extension QUICStreamInstance {
         )
     }
 
+    @inline(always)
     fileprivate func computeReceiveHighWaterMarkIncrease(
         dataLength: UInt64,
         connection: QUICConnection,
         now: NetworkClock.Instant
     ) -> UInt64 {
-        if flowControlStreamState.receiveHighWaterMarkTime > now {
+        let receiveHighWaterMarkTime = flowControlStreamState.receiveHighWaterMarkTime
+        if receiveHighWaterMarkTime > now {
             log.fault("Timestamp should be greater than now")
             return 0
         }
 
         var increment: UInt64 = 0
-        flowControlStreamState.receiveHighWaterMarkCount += dataLength
+        let receiveHighWaterMarkCount = flowControlStreamState.receiveHighWaterMarkCount + dataLength
 
         // If one RTT has elapsed, we can stop counting the bytes.
         // Here, we estimate if the bandwidth measured in this RTT
         // is more than a certain value of the bandwidth measured
         // in the previous RTT.
         let rtt = connection.currentPath?.smoothedRTT ?? .zero
-        if now >= flowControlStreamState.receiveHighWaterMarkTime.advanced(by: rtt) {
-            if flowControlStreamState.receiveHighWaterMarkCount
-                > flowControlStreamState.receiveHighWaterMarkPreviousCount
-            {
+        if now >= receiveHighWaterMarkTime.advanced(by: rtt) {
+            let receiveHighWaterMarkPreviousCount = flowControlStreamState.receiveHighWaterMarkPreviousCount
+            var newPreviousCount = receiveHighWaterMarkPreviousCount
+            if receiveHighWaterMarkCount > receiveHighWaterMarkPreviousCount {
                 let mss = UInt64(connection.currentPath?.mss ?? 0)
                 let shift: Int
-                if flowControlStreamState.receiveHighWaterMarkCount
-                    > (flowControlStreamState.receiveHighWaterMarkPreviousCount
-                        + (flowControlStreamState.receiveHighWaterMarkPreviousCount >> 1))
+                if receiveHighWaterMarkCount
+                    > (receiveHighWaterMarkPreviousCount + (receiveHighWaterMarkPreviousCount >> 1))
                 {
 
                     // If we received more than 1.5 times
@@ -770,14 +780,13 @@ extension QUICStreamInstance {
                     shift = 1
                 }
                 log.datapath(
-                    "Estimated BDP \(flowControlStreamState.receiveHighWaterMarkCount)B, current RTT \(rtt)us, estimated bandwidth 8 * \(flowControlStreamState.receiveHighWaterMarkCount) / \(rtt) Mbps"
+                    "Estimated BDP \(receiveHighWaterMarkCount)B, current RTT \(rtt)us, estimated bandwidth 8 * \(receiveHighWaterMarkCount) / \(rtt) Mbps"
                 )
 
-                let (incr, overflow) = (flowControlStreamState.receiveHighWaterMarkCount << shift)
+                let (incr, overflow) = (receiveHighWaterMarkCount << shift)
                     .subtractingReportingOverflow(flowControlState.maximumUnreadInboundBytesAllowed)
                 if !overflow {
-                    flowControlStreamState.receiveHighWaterMarkPreviousCount =
-                        flowControlStreamState.receiveHighWaterMarkCount
+                    newPreviousCount = receiveHighWaterMarkCount
                     // Align the increase to whole segments. Increases of a fraction of an MSS isn't useful as it won't fill a whole packet.
                     if mss != 0 {
                         increment = (incr / mss) * mss
@@ -786,8 +795,11 @@ extension QUICStreamInstance {
             }
 
             // Reset the measurement
+            flowControlStreamState.receiveHighWaterMarkPreviousCount = newPreviousCount
             flowControlStreamState.receiveHighWaterMarkCount = 0
             flowControlStreamState.receiveHighWaterMarkTime = .zero
+        } else {
+            flowControlStreamState.receiveHighWaterMarkCount = receiveHighWaterMarkCount
         }
 
         return increment

--- a/Sources/SwiftNetwork/QUIC/QUICStream.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICStream.swift
@@ -328,7 +328,7 @@ struct StreamListMembership: OptionSet {
 // Also note that a flow identifier can exist in multiple lists at one time.
 @available(Network 0.1.0, *)
 struct QUICStreamList: ~Copyable {
-    private var list = Deque<MultiplexedFlowIdentifier>()
+    private var list = Deque<MultiplexedFlowIdentifier>(minimumCapacity: 1)
     private let name: StaticString
     private let listType: StreamListMembership
 
@@ -360,15 +360,9 @@ struct QUICStreamList: ~Copyable {
 
     mutating func append(_ stream: QUICStreamInstance) {
         guard !stream.listMembership.contains(listType) else {
-            stream.log.error("Stream is already in list: \(name)")
             return
         }
-        let identifier = stream.identifier
-        guard !list.contains(where: { $0 == identifier }) else {
-            stream.log.error("Stream is already on list")
-            return
-        }
-        list.append(identifier)
+        list.append(stream.identifier)
         stream.listMembership.insert(listType)
     }
 
@@ -417,27 +411,6 @@ struct QUICStreamList: ~Copyable {
                 stream.listMembership.remove(listType)
             }
         }
-    }
-
-    func streamList(
-        continueAfterStreamID: QUICStreamID?,
-        connection: QUICConnection
-    ) -> [QUICStreamInstance] {
-        var result: [QUICStreamInstance] = []
-        var foundStart = continueAfterStreamID == nil
-        for identifier in list {
-            guard let stream = connection.flow(for: identifier) else {
-                continue
-            }
-            if !foundStart {
-                if stream.streamID == continueAfterStreamID {
-                    foundStart = true
-                }
-                continue
-            }
-            result.append(stream)
-        }
-        return result
     }
 }
 
@@ -705,18 +678,19 @@ public final class QUICStreamInstance: MultiplexedStreamFlow<QUICConnection>,
     ) -> Bool {
         startTrackingInboundFlowControlInterval(connection: connection)
 
+        let maximumUnreadInboundBytesAllowed = flowControlState.maximumUnreadInboundBytesAllowed
         // NOTE: This won't work with retransmissions if we don't
         // have enough space to take the stream data
-        if frame.length > flowControlState.maximumUnreadInboundBytesAllowed {
+        if frame.length > maximumUnreadInboundBytesAllowed {
             log.error(
-                "Not enough receive buffer space \(frame.length) > \(flowControlState.maximumUnreadInboundBytesAllowed)"
+                "Not enough receive buffer space \(frame.length) > \(maximumUnreadInboundBytesAllowed)"
             )
             frame.frame.finalize(success: false)
             return false
         }
 
         let canAppendResult = reassemblyQueue.canAppendItemsForByteLimit(
-            flowControlState.maximumUnreadInboundBytesAllowed
+            maximumUnreadInboundBytesAllowed
         )
         guard canAppendResult.acceptable else {
             connection.log.error(
@@ -727,46 +701,24 @@ public final class QUICStreamInstance: MultiplexedStreamFlow<QUICConnection>,
             return false
         }
 
-        if canAppendResult == .warning {
-            // If we have a concerning number of reassembly queue items, check to see if we're at a connection-wide limit.
-            // This is a more expensive check so should be avoided in normal cases where reassembly queues aren't being
-            // potentially abused.
-            var connectionReassemblyItemCount = 0
-            connection.applyToAllFlows { otherStream in
-                connectionReassemblyItemCount += otherStream.reassemblyQueue.items.count
-            }
-            guard
-                ReassemblyQueue.canAppendItemsForByteLimit(
-                    itemCount: connectionReassemblyItemCount,
-                    byteLimit: connection.flowControlState.maximumUnreadInboundBytesAllowed
-                ).acceptable
-            else {
-                connection.log.error(
-                    "Connection stream reassembly queues have too many items, closing"
-                )
-                frame.frame.finalize(success: false)
-                connection.close(with: .internalError, "exceeded connection reassembly queue limits")
-                return false
-            }
-        }
-
         // Offset is from a VLE so should not be bigger than a 62bit value
         // so does not represent a problem in 64bit systems.
-        let sizeAdded = reassemblyQueue.append(
+        let appendResult = reassemblyQueue.append(
             frame: frame.frame,
             offset: Int(frame.offset),
             fin: frame.isFinal
         )
-        let dataAdded = sizeAdded != 0
+        let dataAdded = appendResult.sizeAdded != 0
 
-        let frameFinalSize = frame.isFinal ? frame.offset + UInt64(frame.length) : nil
+        let frameFinalSize = frame.isFinal ? frame.offset &+ UInt64(frame.length) : nil
 
-        let lastOffsetDelta = self.updateLastOffset(
-            connection: connection,
-            newLastOffset: UInt64(reassemblyQueue.lastOffset),
-            newFinalSize: frameFinalSize
-        )
-        guard let _ = lastOffsetDelta else {
+        guard
+            let _ = self.updateLastOffset(
+                connection: connection,
+                newLastOffset: UInt64(appendResult.lastOffset),
+                newFinalSize: frameFinalSize
+            )
+        else {
             log.error("final_size invariants violated")
             connection.close(with: .internalError, "final_size invariants violated")
             return false
@@ -776,24 +728,31 @@ public final class QUICStreamInstance: MultiplexedStreamFlow<QUICConnection>,
             self.receiveState.change(logIDString: logPrefix, to: .sizeKnown)
         }
 
-        if dataAdded || reassemblyQueue.hasFin {
+        if dataAdded || appendResult.hasFin {
+            #if SignpostOutput
             if let streamID {
-                QUICSignpost.dataReceived(id: connection.signpostID, streamID: streamID.value, nbytes: sizeAdded)
+                QUICSignpost.dataReceived(
+                    id: connection.signpostID,
+                    streamID: streamID.value,
+                    nbytes: appendResult.sizeAdded
+                )
             }
+            #endif
 
             updateInboundFlowControlCredit(
-                dataLengthAdded: UInt64(sizeAdded),
+                dataLengthAdded: UInt64(appendResult.sizeAdded),
                 connection: connection,
                 connectionOnly: false
             )
+            let finOffset = appendResult.finOffset
 
-            let newOffset = reassemblyQueue.currentOffset + reassemblyQueue.availableToDequeue
-            if newOffset == reassemblyQueue.finOffset {
+            let newOffset = appendResult.currentOffset &+ appendResult.availableToDequeue
+            if newOffset == finOffset {
                 receiveState.change(logIDString: logPrefix, to: .dataReceived)
             }
-            if newOffset > reassemblyQueue.finOffset {
+            if newOffset > finOffset {
                 log.error(
-                    "Bytes received \(newOffset) > fin offset \(reassemblyQueue.finOffset)"
+                    "Bytes received \(newOffset) > fin offset \(finOffset)"
                 )
                 connection.close(with: .internalError, "bytes received larger than FIN offset")
                 return false
@@ -838,6 +797,7 @@ public final class QUICStreamInstance: MultiplexedStreamFlow<QUICConnection>,
     //
     // Otherwise, the function will return the amount by which
     // the `lastOffset` was incremented.
+    @_optimize(speed)
     func updateLastOffset(
         connection: QUICConnection,
         newLastOffset: UInt64,

--- a/Sources/SwiftNetwork/QUIC/QUICStream.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICStream.swift
@@ -328,7 +328,7 @@ struct StreamListMembership: OptionSet {
 // Also note that a flow identifier can exist in multiple lists at one time.
 @available(Network 0.1.0, *)
 struct QUICStreamList: ~Copyable {
-    private var list = Deque<MultiplexedFlowIdentifier>(minimumCapacity: 1)
+    private var list = Deque<MultiplexedFlowIdentifier>(minimumCapacity: 4)
     private let name: StaticString
     private let listType: StreamListMembership
 

--- a/Sources/SwiftNetwork/QUIC/ReassemblyQueue.swift
+++ b/Sources/SwiftNetwork/QUIC/ReassemblyQueue.swift
@@ -91,13 +91,33 @@ struct ReassemblyQueue: ~Copyable {
         #endif
     }
 
-    // Append data to the reassembly queue. Returns the amount of data added.
+    struct AppendResult {
+        var sizeAdded: Int
+        var lastOffset: Int
+        var hasFin: Bool
+        var finOffset: Int
+        var currentOffset: Int
+        var availableToDequeue: Int
+    }
+
+    @inline(always)
+    private func appendResult(sizeAdded: Int) -> AppendResult {
+        AppendResult(
+            sizeAdded: sizeAdded,
+            lastOffset: lastOffset,
+            hasFin: hasFin,
+            finOffset: finOffset,
+            currentOffset: currentOffset,
+            availableToDequeue: availableToDequeue
+        )
+    }
+
     @discardableResult
     mutating func append(
         frame: consuming Frame,
         offset: Int,
         fin: Bool
-    ) -> Int {
+    ) -> AppendResult {
         var frame = frame
         var offset = offset
         let originalBufferLength = frame.unclaimedLength
@@ -111,7 +131,7 @@ struct ReassemblyQueue: ~Copyable {
                     "FIN offset already set, old \(finOffset), new \(offset + originalBufferLength)"
                 )
                 frame.finalize(success: false)
-                return 0
+                return appendResult(sizeAdded: 0)
             }
             finOffset = offset + originalBufferLength
             log.datapath("FIN offset set to \(finOffset)")
@@ -119,19 +139,19 @@ struct ReassemblyQueue: ~Copyable {
         if originalBufferLength == 0 && size != 0 {
             // We already set FIN offset, so we don't need to create a fake item to handle the FIN bit
             frame.finalize(success: false)
-            return 0
+            return appendResult(sizeAdded: 0)
         }
 
         let oldSize = size
         var newItem: ReassemblyQueueItem
         if offset < currentOffset {
-            if offset + originalBufferLength > currentOffset {
+            if offset &+ originalBufferLength > currentOffset {
                 let startingPoint = currentOffset - offset
                 log.datapath(
                     "ignoring duplicate bytes [\(offset), \(offset + startingPoint)]"
                 )
-                offset += startingPoint
-                bufferStartPoint += startingPoint
+                offset &+= startingPoint
+                bufferStartPoint &+= startingPoint
 
                 // Use a truncated buffer
                 _ = frame.claim(fromStart: bufferStartPoint)
@@ -144,14 +164,14 @@ struct ReassemblyQueue: ~Copyable {
                 log.datapath(
                     "dropping duplicate buffer [\(offset), \(offset + originalBufferLength)]"
                 )
-                return 0
+                return appendResult(sizeAdded: 0)
             }
         } else {
             // Use the whole buffer
             newItem = ReassemblyQueueItem(offset: offset, frame: frame)
         }
         lastOffset =
-            (offset == 0 && newItem.length == 0) ? 0 : max(lastOffset, offset + newItem.length - 1)
+            (offset == 0 && newItem.length == 0) ? 0 : max(lastOffset, offset &+ newItem.length - 1)
         traceDump()
         log.datapath("appending to reassq: offset \(newItem.offset) len \(newItem.length)")
         // Case 0: empty reassembly queue
@@ -165,21 +185,21 @@ struct ReassemblyQueue: ~Copyable {
             } else {
                 availableToDequeue = 0
             }
-            return size
+            return appendResult(sizeAdded: size)
         }
         // Case 1: append to the reassembly queue when in-order
         let itemCount = items.count
-        let lastItemOffset = items[itemCount - 1].offset
-        let lastItemLength = items[itemCount - 1].length
-        if newItem.offset == lastItemOffset + lastItemLength {
+        let lastItemOffset = items[itemCount &- 1].offset
+        let lastItemLength = items[itemCount &- 1].length
+        if newItem.offset == lastItemOffset &+ lastItemLength {
             let newItemLength = newItem.length
             items.append(newItem)
             // When everything is in order, we can dequeue this item
             if availableToDequeue == size {
-                availableToDequeue += newItemLength
+                availableToDequeue &+= newItemLength
             }
-            size += newItemLength
-            return newItemLength
+            size &+= newItemLength
+            return appendResult(sizeAdded: newItemLength)
         }
         // Case 2: insert somewhere else while handling overlapping data
         // This algorithm is the same used in the TCP stack
@@ -208,25 +228,25 @@ struct ReassemblyQueue: ~Copyable {
         }
 
         if let prevItemOffset, let prevItemLength {
-            let overlappedLength = prevItemOffset + prevItemLength - newItem.offset
+            let overlappedLength = prevItemOffset &+ prevItemLength &- newItem.offset
             if overlappedLength > 0 {
                 if overlappedLength >= newItem.length {
                     // The existing item already covers the same data as the new item
                     newItem.frame.finalize(success: false)
-                    return 0
+                    return appendResult(sizeAdded: 0)
                 }
                 // Advance the new entry when it overlaps with the existing one
-                bufferStartPoint += overlappedLength
-                newItem.offset += overlappedLength
+                bufferStartPoint &+= overlappedLength
+                newItem.offset &+= overlappedLength
                 _ = newItem.frame.claim(fromStart: overlappedLength)
                 // Add the overlapped adjustment
                 bytesRemoved += overlappedLength
             }
         }
         // Iterate over the existing entries trying while taking care of overlaps and entries that are completely covered by the new entry
-        iterIndex = foundInsertionPoint ? iterIndex : iterIndex + 1
+        iterIndex = foundInsertionPoint ? iterIndex : iterIndex &+ 1
         while iterIndex < items.count {
-            let overlapLength = newItem.offset + newItem.length - items[iterIndex].offset
+            let overlapLength = newItem.offset &+ newItem.length &- items[iterIndex].offset
             if overlapLength <= 0 {
                 // Terminate once we cannot adjust nor remove any more entries.
                 break
@@ -234,32 +254,32 @@ struct ReassemblyQueue: ~Copyable {
             let existingLength = items[iterIndex].length
             if overlapLength < existingLength {
                 // Adjust the current entry since it overlaps with the existing one.
-                bytesRemoved += overlapLength
-                items[iterIndex].offset += overlapLength
+                bytesRemoved &+= overlapLength
+                items[iterIndex].offset &+= overlapLength
                 _ = items[iterIndex].frame.claim(fromStart: overlapLength)
                 break
             }
             // The new entry completely covers the existing one. Give preference to the new entry.
             var oldEntry = items.remove(at: iterIndex)
             oldEntry.frame.finalize(success: false)
-            bytesRemoved += existingLength
+            bytesRemoved &+= existingLength
         }
         if let prevIndex {
-            trailingIndex = prevIndex + 2
+            trailingIndex = prevIndex &+ 2
             items.insert(newItem, at: prevIndex + 1)
         } else {
             trailingIndex = 1
             items.insert(newItem, at: 0)
         }
-        size += newItemLength - bytesRemoved
-        let newEnd = newItemOffset + newItemLength
+        size += newItemLength &- bytesRemoved
+        let newEnd = newItemOffset &+ newItemLength
         // Iterate through the remaining items from the new insertion index to calculate available dequeue items
         if newItemOffset <= contiguousEnd && newEnd > contiguousEnd {
-            availableToDequeue += (newEnd - contiguousEnd)
+            availableToDequeue += (newEnd &- contiguousEnd)
             if trailingIndex < items.count {
                 for i in trailingIndex..<items.count {
-                    if items[i].offset == currentOffset + availableToDequeue {
-                        availableToDequeue += items[i].length
+                    if items[i].offset == currentOffset &+ availableToDequeue {
+                        availableToDequeue &+= items[i].length
                     }
                 }
             }
@@ -268,9 +288,9 @@ struct ReassemblyQueue: ~Copyable {
         if _slowPath(size < oldSize) {
             traceDump()
             log.fault("Reassq length went backwards \(size) < \(oldSize)")
-            return 0
+            return appendResult(sizeAdded: 0)
         }
-        return size - oldSize
+        return appendResult(sizeAdded: size - oldSize)
     }
 
     // Dequeue an item from the reassembly queue

--- a/Sources/SwiftNetwork/QUIC/ReassemblyQueue.swift
+++ b/Sources/SwiftNetwork/QUIC/ReassemblyQueue.swift
@@ -94,10 +94,10 @@ struct ReassemblyQueue: ~Copyable {
     struct AppendResult {
         var sizeAdded: Int
         var lastOffset: Int
-        var hasFin: Bool
         var finOffset: Int
         var currentOffset: Int
         var availableToDequeue: Int
+        var hasFin: Bool
     }
 
     @inline(always)
@@ -105,10 +105,10 @@ struct ReassemblyQueue: ~Copyable {
         AppendResult(
             sizeAdded: sizeAdded,
             lastOffset: lastOffset,
-            hasFin: hasFin,
             finOffset: finOffset,
             currentOffset: currentOffset,
-            availableToDequeue: availableToDequeue
+            availableToDequeue: availableToDequeue,
+            hasFin: hasFin
         )
     }
 

--- a/Sources/Tools/QUICTransfer/main.swift
+++ b/Sources/Tools/QUICTransfer/main.swift
@@ -380,7 +380,7 @@ final class QUICTransfer {
 
 if #available(anyAppleOS 26, *) {
     // Take command line arguments
-    var iterations = 1  // 5gb total (if 500000 sendSize)
+    var iterations = 10000  // 5gb total (if 500000 sendSize)
     var loggingHandler: LoggingHandle = LoggingHandle(loggingType: .none)
     var sendSize = 500000  // 500kb
     var linkDelay = NetworkDuration.zero

--- a/Tests/QUICTests/ReassemblyQueueTests.swift
+++ b/Tests/QUICTests/ReassemblyQueueTests.swift
@@ -30,7 +30,7 @@ extension ReassemblyQueue {
         offset: Int,
         fin: Bool
     ) -> Int {
-        append(frame: .init(copyBuffer: buffer), offset: offset, fin: fin)
+        append(frame: .init(copyBuffer: buffer), offset: offset, fin: fin).sizeAdded
     }
 }
 


### PR DESCRIPTION
The stream function processIncomingStreamData is the per-packet hot-path for just about every workload we have.
There are two large sources of CPU usage in the function:

1. Processing items in the ReassemblyQueue
2. Exclusivity access from a class to a non-copyable struct (swift_beginAccess / swift_endAccess)

This change is designed to reduce exclusivity access by reducing the touch points to `FlowControl`, `QUICStreamList`, and `ReassemblyQueue`.
This change also removes some redundant code and trims down the arithmetic guards in `ReassemblyQueue`.
Overall this change results in a 29% reduction to CPU in the hot path.

Top of tree:
```
718.46 M  	 QUICStreamInstance.processIncomingStreamData(connection:frame:)	
212.03 M 	   ReassemblyQueue.append(frame:offset:fin:)	
15.00 M  	    specialized UnsafeMutablePointer<>.initialize(to:)	
5.00 M          ReassemblyQueueItem.length.getter	
129.00 M  	   QUICStreamInstance.updateInboundFlowControlCredit(dataLengthAdded:connection:connectionOnly:)	
89.58 M  	   swift_beginAccess	
64.84 M   	   <deduplicated_symbol>	
47.00 M   	   QUICStreamInstance.startTrackingInboundFlowControlInterval(connection:)	
42.00 M    	   swift_endAccess	
18.00 M  	   QUICStreamInstance.updateLastOffset(connection:newLastOffset:newFinalSize:)	
6.00 M    	   DYLD-STUB$$swift_beginAccess	
6.00 M         QUICStreamList.append(_:)	
3.00 M         QUICStreamInstance.updateLastReceivedOffset(to:connection:)	
2.00 M         DYLD-STUB$$swift_endAccess	
1.00 M         DYLD-STUB$$swift_retain	
```

With this change:
```
507.09 M 	QUICStreamInstance.processIncomingStreamData(connection:frame:)	
153.03 M 	 ReassemblyQueue.append(frame:offset:fin:)	
86.26 M  	 <deduplicated_symbol>	
58.00 M      QUICStreamInstance.updateInboundFlowControlCredit(dataLengthAdded:connection:connectionOnly:)	
56.01 M  	 <deduplicated_symbol>	
42.01 M  	 swift_beginAccess	
16.00 M 	 QUICStreamInstance.startTrackingInboundFlowControlInterval(connection:)	
9.00 M     	 QUICStreamInstance.updateLastOffset(connection:newLastOffset:newFinalSize:)	
7.00 M    	 swift_endAccess	
6.00 M     	 DYLD-STUB$$swift_endAccess	
3.00 M     	 DYLD-STUB$$swift_beginAccess	
3.00 M       QUICStreamList.append(_:)
```