### PR TITLE
SwiftQUIC: PERF: Delivery data directly to the flow

### DIFF
--- a/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
@@ -1400,18 +1400,16 @@ extension ManyToManyApplicationStreamProtocol where Flow: AutomaticUpperStreamPr
         streamData: consuming FrameArray
     ) throws(NetworkError) {
         guard var flow = self.flow(for: flowID) else { throw NetworkError.posix(EINVAL) }
-        try flow.addToUpperReceiveQueue(streamData)
-        flow.serviceUpperReceiveQueue()
+        try deliverInboundStreamData(flow: &flow, streamData: streamData)
     }
 
     // Enqueue and deliver the stream data directly to the flow
     public func deliverInboundStreamData(
-        flow existingFlow: Flow?,
+        flow existingFlow: inout Flow,
         streamData: consuming FrameArray
     ) throws(NetworkError) {
-        guard var flow = existingFlow else { throw NetworkError.posix(EINVAL) }
-        try flow.addToUpperReceiveQueue(streamData)
-        flow.serviceUpperReceiveQueue()
+        try existingFlow.addToUpperReceiveQueue(streamData)
+        existingFlow.serviceUpperReceiveQueue()
     }
 }
 
@@ -1655,18 +1653,16 @@ extension HeterogeneousManyToManyProtocolHandler where SecondaryFlow: AutomaticU
         datagrams: consuming FrameArray
     ) throws(NetworkError) {
         guard var flow = self.secondaryFlow(for: flowID) else { throw NetworkError.posix(EINVAL) }
-        try flow.addToUpperReceiveQueue(datagrams)
-        flow.serviceUpperReceiveQueue()
+        try deliverInboundDatagrams(flow: &flow, datagrams: datagrams)
     }
 
     // Enqueue and deliver the datagrams directly to the flow
     public func deliverInboundDatagrams(
-        flow existingFlow: SecondaryFlow?,
+        flow existingFlow: inout SecondaryFlow,
         datagrams: consuming FrameArray
     ) throws(NetworkError) {
-        guard var flow = existingFlow else { throw NetworkError.posix(EINVAL) }
-        try flow.addToUpperReceiveQueue(datagrams)
-        flow.serviceUpperReceiveQueue()
+        try existingFlow.addToUpperReceiveQueue(datagrams)
+        existingFlow.serviceUpperReceiveQueue()
     }
 }
 

--- a/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
@@ -1403,6 +1403,16 @@ extension ManyToManyApplicationStreamProtocol where Flow: AutomaticUpperStreamPr
         try flow.addToUpperReceiveQueue(streamData)
         flow.serviceUpperReceiveQueue()
     }
+
+    // Enqueue and deliver the stream data directly to the flow
+    public func deliverInboundStreamData(
+        flow existingFlow: Flow?,
+        streamData: consuming FrameArray
+    ) throws(NetworkError) {
+        guard var flow = existingFlow else { throw NetworkError.posix(EINVAL) }
+        try flow.addToUpperReceiveQueue(streamData)
+        flow.serviceUpperReceiveQueue()
+    }
 }
 
 @_spi(ProtocolProvider)
@@ -1645,6 +1655,16 @@ extension HeterogeneousManyToManyProtocolHandler where SecondaryFlow: AutomaticU
         datagrams: consuming FrameArray
     ) throws(NetworkError) {
         guard var flow = self.secondaryFlow(for: flowID) else { throw NetworkError.posix(EINVAL) }
+        try flow.addToUpperReceiveQueue(datagrams)
+        flow.serviceUpperReceiveQueue()
+    }
+
+    // Enqueue and deliver the datagrams directly to the flow
+    public func deliverInboundDatagrams(
+        flow existingFlow: SecondaryFlow?,
+        datagrams: consuming FrameArray
+    ) throws(NetworkError) {
+        guard var flow = existingFlow else { throw NetworkError.posix(EINVAL) }
         try flow.addToUpperReceiveQueue(datagrams)
         flow.serviceUpperReceiveQueue()
     }

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -2371,13 +2371,10 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
 
         // Service streams that are pending application reads
         while let stream = pendingReassemblyDequeue.removeFirst(connection: self) {
-            let flowID = stream.identifier
             guard let frameArray = stream.dequeueReassembledData(connection: self) else {
                 continue
             }
-
-            try? deliverInboundStreamData(flow: flowID, streamData: frameArray)
-
+            try? deliverInboundStreamData(flow: stream, streamData: frameArray)
             // When the stream is already in `resetReceived` state,
             // it should be closed when we receive STOP_SENDING, so we
             // only need to handle the `dataRead` state here.

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -2370,11 +2370,11 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         }
 
         // Service streams that are pending application reads
-        while let stream = pendingReassemblyDequeue.removeFirst(connection: self) {
+        while var stream = pendingReassemblyDequeue.removeFirst(connection: self) {
             guard let frameArray = stream.dequeueReassembledData(connection: self) else {
                 continue
             }
-            try? deliverInboundStreamData(flow: stream, streamData: frameArray)
+            try? deliverInboundStreamData(flow: &stream, streamData: frameArray)
             // When the stream is already in `resetReceived` state,
             // it should be closed when we receive STOP_SENDING, so we
             // only need to handle the `dataRead` state here.


### PR DESCRIPTION
This is a minor change for overloading `deliverInboundDatagrams` and `deliverInboundStreamData` so the stack does not have to do a flow lookup twice.  Saves a minimal amount of work but in the hot path this will reduce instructions.

