### PR TITLE
Add cross module optimization for benchmark targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -147,41 +147,41 @@ let package = Package(
             dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
             path: "Sources/Tools/QUICHandshake",
             exclude: ["README.md"],
-            swiftSettings: availabilityMacros + settings,
+            swiftSettings: availabilityMacros + settings + [.unsafeFlags(["-cross-module-optimization"])],
         ),
         .executableTarget(
             name: "IPUDPTransfer",
             dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
             path: "Sources/Tools/IPUDPTransfer",
             exclude: ["README.md"],
-            swiftSettings: availabilityMacros + settings
+            swiftSettings: availabilityMacros + settings + [.unsafeFlags(["-cross-module-optimization"])],
         ),
         .executableTarget(
             name: "QUICTransfer",
             dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
             path: "Sources/Tools/QUICTransfer",
             exclude: ["README.md"],
-            swiftSettings: availabilityMacros + settings
+            swiftSettings: availabilityMacros + settings + [.unsafeFlags(["-cross-module-optimization"])],
         ),
         .executableTarget(
             name: "QUICStreamLoad",
             dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
             path: "Sources/Tools/QUICStreamLoad",
             exclude: ["README.md"],
-            swiftSettings: availabilityMacros + settings
+            swiftSettings: availabilityMacros + settings + [.unsafeFlags(["-cross-module-optimization"])],
         ),
         .executableTarget(
             name: "SocketTransfer",
             dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
             path: "Sources/Tools/SocketTransfer",
             exclude: ["README.md"],
-            swiftSettings: availabilityMacros + settings
+            swiftSettings: availabilityMacros + settings + [.unsafeFlags(["-cross-module-optimization"])],
         ),
         .executableTarget(
             name: "DeserializerBenchmark",
             dependencies: ["SwiftNetwork", "SwiftNetworkBenchmarks"],
             path: "Sources/Tools/DeserializerBenchmark",
-            swiftSettings: availabilityMacros + settings
+            swiftSettings: availabilityMacros + settings + [.unsafeFlags(["-cross-module-optimization"])],
         ),
     ]
 )


### PR DESCRIPTION
Adds `-cross-module-optimization` to our benchmark executables for cross module optimizations into SwiftNetwork.