### PR TITLE
SwiftQUIC: PERF: Avoid calling inboundStarting and inboundStopped when not applicable

### DIFF
--- a/Sources/SwiftNetwork/QUIC/PacketNumberSpace.swift
+++ b/Sources/SwiftNetwork/QUIC/PacketNumberSpace.swift
@@ -250,6 +250,7 @@ enum PacketNumberSpace: UInt8, Comparable, CaseIterable {
     case initial = 0
     case handshake = 1
     case applicationData = 2
+    @inline(always)
     static func fromKeyState(keyState: PacketKeyState) -> PacketNumberSpace {
         switch keyState {
         case .earlyData, .phase0, .phase1:

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -1561,9 +1561,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         // Detect if any received packet contains a QUIC Frame that unblocks
         // all streams, such as a new MAX_DATA. Includes setting
         // triggerAllStreamsUnblocked = false
-        initialPendingItems.inboundStarting()
-        handshakePendingItems.inboundStarting()
-        applicationPendingItems.inboundStarting()
+        withPendingItemsForKeyState { $0.inboundStarting() }
 
         // Tell recovery that a batch of packets is starting to be processed; suppress timer updates.
         // Ending recovery is deferred until servicing is done.
@@ -2387,10 +2385,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         }
 
         sendFrames()
-
-        initialPendingItems.inboundStopped()
-        handshakePendingItems.inboundStopped()
-        applicationPendingItems.inboundStopped()
+        withPendingItemsForKeyState { $0.inboundStopped() }
     }
 
     // Handle an outbound write to stream, queue the data for sending in the
@@ -2916,6 +2911,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
     var handshakePendingItems = PendingItems(packetNumberSpace: .handshake)
     var applicationPendingItems = PendingItems(packetNumberSpace: .applicationData)
     @discardableResult
+    @inline(always)
     func withPendingItems<T>(
         for packetNumberSpace: PacketNumberSpace,
         block: (inout PendingItems) -> T
@@ -2945,6 +2941,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         }
     }
     @discardableResult
+    @inline(always)
     func withPendingItemsForKeyState<T>(block: (inout PendingItems) -> T) -> T {
         let packetNumberSpace = PacketNumberSpace.fromKeyState(keyState: self.keyState)
         return withPendingItems(for: packetNumberSpace) { block(&$0) }

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -1557,11 +1557,11 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         // Save a timestamp to avoid calculating `now` again during processing
         currentInboundReceiveTimestamp = .now
 
-        // Start anew with pendingItems
+        // Start anew with pendingItems for applicationPendingItems
         // Detect if any received packet contains a QUIC Frame that unblocks
         // all streams, such as a new MAX_DATA. Includes setting
         // triggerAllStreamsUnblocked = false
-        withPendingItemsForKeyState { $0.inboundStarting() }
+        applicationPendingItems.triggerAllStreamsUnblocked = false
 
         // Tell recovery that a batch of packets is starting to be processed; suppress timer updates.
         // Ending recovery is deferred until servicing is done.
@@ -2385,7 +2385,6 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         }
 
         sendFrames()
-        withPendingItemsForKeyState { $0.inboundStopped() }
     }
 
     // Handle an outbound write to stream, queue the data for sending in the

--- a/Sources/SwiftNetwork/QUIC/SendItems.swift
+++ b/Sources/SwiftNetwork/QUIC/SendItems.swift
@@ -2684,18 +2684,6 @@ struct PendingItems: ~Copyable {
         self.packetNumberSpace = packetNumberSpace
     }
 
-    mutating func inboundStarting() {
-        precondition(unblockedSendStreams.isEmpty, "Something left unblocked streams in list")
-        triggerAllStreamsUnblocked = false
-    }
-
-    mutating func inboundStopped() {
-        precondition(
-            unblockedSendStreams.isEmpty,
-            "inbound stopping left unblocked streams in list"
-        )
-    }
-
     var hasPendingItems: Bool {
         simpleSendableItems.rawValue > 0
     }


### PR DESCRIPTION
This change avoids calling `inboundStarting` and `inboundStopped` for each key state every time `serviceReceivedDatagrams` and `inboundStopping` are called.  These only accumulated to around 6 megacycles in the QUICTransfer benchmark but now they are completely optimized away.