### PR TITLE
SwiftQUIC: PERF: Avoid duplicate path lookup in handleInbound

### DIFF
--- a/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
@@ -2025,7 +2025,10 @@ extension ManyToManyOutboundDatagramProtocol where Path: AutomaticLowerDatagramP
     }
 
     public func accessReceivedDatagrams(path pathID: MultiplexingPathIdentifier, _ body: (inout FrameArray) -> Void) {
-        guard var path = self.path(for: pathID) else { return }
+        guard var path = self.path(for: pathID) else {
+            log.error("Unknown path for id: \(pathID)")
+            return
+        }
         body(&path.lowerReceiveQueue)
     }
 
@@ -2033,7 +2036,10 @@ extension ManyToManyOutboundDatagramProtocol where Path: AutomaticLowerDatagramP
         path pathID: MultiplexingPathIdentifier,
         _ body: (inout FrameArray, Path) -> Void
     ) {
-        guard var path = self.path(for: pathID) else { return }
+        guard var path = self.path(for: pathID) else {
+            log.error("Unknown path for id: \(pathID)")
+            return
+        }
         body(&path.lowerReceiveQueue, path)
     }
 

--- a/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
@@ -2029,6 +2029,14 @@ extension ManyToManyOutboundDatagramProtocol where Path: AutomaticLowerDatagramP
         body(&path.lowerReceiveQueue)
     }
 
+    public func accessReceivedDatagrams(
+        path pathID: MultiplexingPathIdentifier,
+        _ body: (inout FrameArray, Path) -> Void
+    ) {
+        guard var path = self.path(for: pathID) else { return }
+        body(&path.lowerReceiveQueue, path)
+    }
+
     public func sendAllEnqueuedOutboundDatagrams() {
         allPathIdentifiers { pathID in
             try? sendEnqueuedOutboundDatagrams(path: pathID)

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -1575,9 +1575,9 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             log.fault("Pending Reassembly Dequeue is not empty")
         }
 
-        accessReceivedDatagrams(path: pathID) { datagrams in
+        accessReceivedDatagrams(path: pathID) { (datagrams, path) in
             while let frame = datagrams.popFirst() {
-                handleInbound(frame: frame, from: pathID)
+                handleInbound(frame: frame, from: path)
             }
         }
 
@@ -1590,7 +1590,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
 
     func handleInbound(
         frame: consuming Frame,
-        from pathID: MultiplexingPathIdentifier
+        from path: QUICPath
     ) {
         deferClosing = true
         defer {
@@ -1615,11 +1615,6 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         }
 
         log.datapath("Handling inbound packet (length: \(dataLength))")
-
-        guard let path = path(for: pathID) else {
-            log.error("Dropping packet from unknown path \(pathID.description)")
-            return
-        }
 
         var unvalidatedPath = false
         // Attempt path validation if this is the first packet that we have received on this path.


### PR DESCRIPTION
For each inbound packet SwiftQUIC is looking up associated path twice.  This change avoids that and saves us ~250 megacycles for the QUICTransfer benchmark.

Top of tree:
```
37.28 G    QUICConnection.handleInbound(frame:from:)	
36.67 G     QUICConnection.handleInboundPacket(frame:path:ecnFlags:unvalidatedPath:coalesced:)	
149.16 M      specialized ManyToManyProtocolHandler.path(for:)	
140.57 M      swift_beginAccess	
```
With this change:
```
36.40 G 	QUICConnection.handleInboundPacket(frame:path:ecnFlags:unvalidatedPath:coalesced:)	
36.32 G       specialized QUICConnection.handleInboundPacket(frame:path:ecnFlags:unvalidatedPath:coalesced:)	
35.00 M       swift_beginAccess	

```