### PR TITLE
Allow starting standalone timers on NetworkContext

### DIFF
--- a/Sources/SwiftNetwork/Context/NetworkContext.swift
+++ b/Sources/SwiftNetwork/Context/NetworkContext.swift
@@ -40,8 +40,12 @@ public struct TimerReference: Equatable, Hashable {
 
     public init() {
         var index: UInt64 = 0
-        TimerReference.nextTimerReference.withLock { nextValue in
-            index = nextValue
+        TimerReference.nextTimerReference.withLock {
+            index = $0
+
+            // If this value wraps, it will assert, but with this being UInt64, that would
+            // take many, many years.
+            $0 += 1
         }
         self.index = index
     }

--- a/Sources/SwiftNetwork/Context/NetworkContext.swift
+++ b/Sources/SwiftNetwork/Context/NetworkContext.swift
@@ -33,7 +33,18 @@ internal import Synchronization
 @_spi(ProtocolProvider)
 @available(Network 0.1.0, *)
 public struct TimerReference: Equatable, Hashable {
-    var index: Int?
+
+    private static let nextTimerReference = NetworkMutex<UInt64>(1)
+
+    let index: UInt64
+
+    public init() {
+        var index: UInt64 = 0
+        TimerReference.nextTimerReference.withLock { nextValue in
+            index = nextValue
+        }
+        self.index = index
+    }
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(index)
@@ -403,6 +414,16 @@ extension NetworkContext {
     enum FutureTime {
         case unschedule
         case milliseconds(UInt64, () -> Void)  // Milliseconds into the future
+    }
+
+    public func scheduleTimer(duration: NetworkDuration, completion: @escaping () -> Void) -> TimerReference {
+        let newReference = TimerReference()
+        resetTimer(for: newReference, to: .milliseconds(UInt64(duration.milliseconds), completion))
+        return newReference
+    }
+
+    public func unscheduleTimer(_ timerReference: TimerReference) {
+        resetTimer(for: timerReference, to: .unschedule)
     }
 
     #if !NETWORK_PRIVATE || NETWORK_STANDALONE

--- a/Sources/SwiftNetwork/Protocols/BridgeProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/BridgeProtocol.swift
@@ -128,6 +128,8 @@ public struct BridgeDatagramProtocol: NetworkProtocol {
         public var reference: ProtocolInstanceReference { ProtocolInstanceReference(custom: self) }
         var log = NetworkLoggerState()
         public var eventManager = ProtocolEventManager()
+        public let timerReference = TimerReference()
+
         var localEndpoint: Endpoint?
         var remoteEndpoint: Endpoint?
         private var incomingFrames = FrameArray()
@@ -160,7 +162,7 @@ public struct BridgeDatagramProtocol: NetworkProtocol {
             } else {
                 guard !timerSet else { return }
                 timerSet = true
-                self.reference.scheduleWakeup(milliseconds: UInt64(linkDelay.milliseconds))
+                self.scheduleWakeup(milliseconds: UInt64(linkDelay.milliseconds))
             }
         }
 

--- a/Sources/SwiftNetwork/Protocols/ProtocolEventManager.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolEventManager.swift
@@ -785,10 +785,17 @@ extension ProtocolInstanceReference {
         }
     }
 
-    func scheduleWakeup(milliseconds: UInt64,
-                               timerReference: TimerReference) {
+    func scheduleWakeup(
+        milliseconds: UInt64,
+        timerReference: TimerReference
+    ) {
         let protocolEventStateIndex = protocolEventStateIndex()!
-        context.scheduleWakeup(index: protocolEventStateIndex, timerReference: timerReference, referenceToWakeup: self, milliseconds: milliseconds)
+        context.scheduleWakeup(
+            index: protocolEventStateIndex,
+            timerReference: timerReference,
+            referenceToWakeup: self,
+            milliseconds: milliseconds
+        )
     }
 
     func unscheduleWakeup(timerReference: TimerReference) {

--- a/Sources/SwiftNetwork/Protocols/ProtocolEventManager.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolEventManager.swift
@@ -578,12 +578,13 @@ extension NetworkContext {
 
     fileprivate func scheduleWakeup(
         index: NetworkStateIndex,
+        timerReference: TimerReference,
         referenceToWakeup: ProtocolInstanceReference,
         milliseconds: UInt64
     ) {
         self.softAssert()
         self.resetTimer(
-            for: referenceToWakeup.timerReference,
+            for: timerReference,
             to: .milliseconds(
                 milliseconds,
                 {
@@ -784,16 +785,13 @@ extension ProtocolInstanceReference {
         }
     }
 
-    var timerReference: TimerReference {
-        TimerReference(index: self._protocolEventStateIndex?.rawValue ?? 0)
-    }
-
-    public func scheduleWakeup(milliseconds: UInt64) {
+    func scheduleWakeup(milliseconds: UInt64,
+                               timerReference: TimerReference) {
         let protocolEventStateIndex = protocolEventStateIndex()!
-        context.scheduleWakeup(index: protocolEventStateIndex, referenceToWakeup: self, milliseconds: milliseconds)
+        context.scheduleWakeup(index: protocolEventStateIndex, timerReference: timerReference, referenceToWakeup: self, milliseconds: milliseconds)
     }
 
-    public func unscheduleWakeup() {
+    func unscheduleWakeup(timerReference: TimerReference) {
         context.assert()
         self.context.resetTimer(for: timerReference, to: .unschedule)
     }

--- a/Sources/SwiftNetwork/Protocols/ProtocolInstance.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolInstance.swift
@@ -83,6 +83,20 @@ extension ProtocolInstance where Self: ~Copyable {
 public protocol TimerSchedulable: ~Copyable, ProtocolInstance {
     /// Handles a wakeup from a timer.
     func wakeup()
+
+    /// A reference for a timer, which should be initialized as `TimerSchedulable()`
+    var timerReference: TimerReference { get }
+}
+
+@available(Network 0.1.0, *)
+extension TimerSchedulable {
+    public func scheduleWakeup(milliseconds: UInt64) {
+        reference.scheduleWakeup(milliseconds: milliseconds, timerReference: timerReference)
+    }
+
+    public func unscheduleWakeup() {
+        reference.unscheduleWakeup(timerReference: timerReference)
+    }
 }
 
 // MARK: Loggable Protocol

--- a/Sources/SwiftNetwork/Protocols/TCPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/TCPProtocol.swift
@@ -380,6 +380,7 @@ public struct TCPProtocol: NetworkProtocol {
         var passthroughEvents = false
         var log = NetworkLoggerState()
         var eventManager = ProtocolEventManager()
+        let timerReference = TimerReference()
         func setup(
             remote: Endpoint?,
             local: Endpoint?,

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -187,6 +187,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
     public private(set) var context: NetworkContext
 
     public var eventManager = ProtocolEventManager()
+    public let timerReference = TimerReference()
 
     public var state: QUICConnectionState = .invalid
     var flowControlState = FlowControlState(isStream: false)
@@ -424,7 +425,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
 
         self.recovery = Recovery(logPrefixer: self.logPrefixer)
         self.localTransportParameters = TransportParameters(logPrefixer: self.logPrefixer)
-        self.timer = Timer(logPrefixer: self.logPrefixer)
+        self.timer = Timer(timerReference: timerReference, logPrefixer: self.logPrefixer)
         self.ecn = ECN()
         self.stats = Statistics()
     }
@@ -445,7 +446,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         // Setup metadata callbacks
         self.setMetadataHandlers()
 
-        self.timer = Timer(reference: self.reference, logPrefixer: logPrefixer)
+        self.timer = Timer(reference: self.reference, timerReference: timerReference, logPrefixer: logPrefixer)
         let ackTimerID = timer.insert(description: "ACK") {
             self.ack.timerFired(timeNow: .now)
         }

--- a/Sources/SwiftNetwork/QUIC/Timer.swift
+++ b/Sources/SwiftNetwork/QUIC/Timer.swift
@@ -72,6 +72,7 @@ final class Timer: PrefixedLoggable {
 
     var log: LogPrefixer
     private var reference: ProtocolInstanceReference? = nil
+    private var timerReference: TimerReference
     private var nextID: TimerID = 1
     private var timerCancelled = false
     private var avoidRecalculate = false
@@ -98,13 +99,15 @@ final class Timer: PrefixedLoggable {
 
     static let timerThreshold = NetworkDuration.milliseconds(1)
 
-    init(reference: ProtocolInstanceReference, logPrefixer: LogPrefixer) {
+    init(reference: ProtocolInstanceReference, timerReference: TimerReference, logPrefixer: LogPrefixer) {
         self.log = logPrefixer
         self.reference = reference
+        self.timerReference = timerReference
     }
 
-    internal init(logPrefixer: LogPrefixer) {
+    internal init(timerReference: TimerReference, logPrefixer: LogPrefixer) {
         self.log = logPrefixer
+        self.timerReference = timerReference
     }
     func insert(
         description: String,
@@ -143,7 +146,7 @@ final class Timer: PrefixedLoggable {
             log.debug("Stopping timer")
             timerCancelled = true
             wakeup = .idle
-            reference?.unscheduleWakeup()
+            reference?.unscheduleWakeup(timerReference: timerReference)
         }
         if final {
             entries.removeAll()
@@ -215,7 +218,7 @@ final class Timer: PrefixedLoggable {
         log.datapath(
             "arming timer for the next \(delta) (now \(now)), new deadline \(nextDeadline) old deadline \(oldDeadline)"
         )
-        reference?.scheduleWakeup(milliseconds: UInt64(delta.milliseconds))
+        reference?.scheduleWakeup(milliseconds: UInt64(delta.milliseconds), timerReference: timerReference)
     }
 
     private func find(_ identifier: TimerID) -> Int? {

--- a/Tests/QUICTests/TimerTests.swift
+++ b/Tests/QUICTests/TimerTests.swift
@@ -32,7 +32,7 @@ let timerTestsLogPrefixer = LogPrefixer("[TimerTests]")
 final class TimerTests: XCTestCase {
 
     func testOneTimer() {
-        let timer = QUICTimer(logPrefixer: timerTestsLogPrefixer)
+        let timer = QUICTimer(timerReference: TimerReference(), logPrefixer: timerTestsLogPrefixer)
         let semaphore = DispatchSemaphore(value: 0)
         let oneId = timer.insert(description: "one", fromNow: .milliseconds(1000), timerNow: .zero) {
             semaphore.signal()
@@ -47,7 +47,7 @@ final class TimerTests: XCTestCase {
     }
 
     func testReschedule() {
-        let timer = QUICTimer(logPrefixer: timerTestsLogPrefixer)
+        let timer = QUICTimer(timerReference: TimerReference(), logPrefixer: timerTestsLogPrefixer)
         let semaphore = DispatchSemaphore(value: 0)
         let oneId = timer.insert(description: "one-reschedule", timerNow: .zero) {
             semaphore.signal()
@@ -64,7 +64,7 @@ final class TimerTests: XCTestCase {
     }
 
     func testTwoTimersAtSameTime() throws {
-        let timer = QUICTimer(logPrefixer: timerTestsLogPrefixer)
+        let timer = QUICTimer(timerReference: TimerReference(), logPrefixer: timerTestsLogPrefixer)
         let semaphore = DispatchSemaphore(value: 0)
         let oneId = timer.insert(description: "one", fromNow: .milliseconds(1000), timerNow: .zero) {
             semaphore.signal()
@@ -88,7 +88,7 @@ final class TimerTests: XCTestCase {
     }
 
     func testTwoTimersAtDifferentTimes() throws {
-        let timer = QUICTimer(logPrefixer: timerTestsLogPrefixer)
+        let timer = QUICTimer(timerReference: TimerReference(), logPrefixer: timerTestsLogPrefixer)
         let semaphore = DispatchSemaphore(value: 0)
         let oneId = timer.insert(description: "one", fromNow: .milliseconds(2000), timerNow: .zero) {
             semaphore.signal()
@@ -115,7 +115,7 @@ final class TimerTests: XCTestCase {
     }
 
     func testRecalculateAfterMissingTimer() throws {
-        let timer = QUICTimer(logPrefixer: timerTestsLogPrefixer)
+        let timer = QUICTimer(timerReference: TimerReference(), logPrefixer: timerTestsLogPrefixer)
         let semaphore = DispatchSemaphore(value: 0)
         let oneId = timer.insert(description: "one", fromNow: .milliseconds(1000), timerNow: .zero) {
             semaphore.signal()
@@ -144,7 +144,7 @@ final class TimerTests: XCTestCase {
 
     // Test that recalculating within 1ms for future times doesn't update the timer
     func testRecalculateWithinThreshold() throws {
-        let timer = QUICTimer(logPrefixer: timerTestsLogPrefixer)
+        let timer = QUICTimer(timerReference: TimerReference(), logPrefixer: timerTestsLogPrefixer)
         let semaphore = DispatchSemaphore(value: 0)
         let oneId = timer.insert(description: "one", fromNow: .microseconds(1_000_000), timerNow: .zero) {
             semaphore.signal()
@@ -181,7 +181,7 @@ final class TimerTests: XCTestCase {
     }
 
     func testSpuriousFireRearmsRemainingTimer() {
-        let timer = QUICTimer(logPrefixer: timerTestsLogPrefixer)
+        let timer = QUICTimer(timerReference: TimerReference(), logPrefixer: timerTestsLogPrefixer)
         let semaphore = DispatchSemaphore(value: 0)
 
         // A, in 2s
@@ -226,7 +226,7 @@ final class TimerTests: XCTestCase {
     }
 
     func testCancellationFollowedByCloseInsertRearmsTimer() {
-        let timer = QUICTimer(logPrefixer: timerTestsLogPrefixer)
+        let timer = QUICTimer(timerReference: TimerReference(), logPrefixer: timerTestsLogPrefixer)
         let semaphore = DispatchSemaphore(value: 0)
 
         let idA = timer.insert(description: "A", fromNow: .seconds(2), timerNow: .zero) {

--- a/Tests/SwiftNetworkTests/SwiftNetworkContextTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkContextTests.swift
@@ -37,13 +37,28 @@ final class SwiftNetworkContextTests: NetTestCase {
 
         let expectation = XCTestExpectation()
 
+        let timerReference = TimerReference()
+
         context.resetTimer(
-            for: TimerReference(index: 13),
+            for: timerReference,
             to: .milliseconds(2000) {
                 expectation.fulfill()
             }
         )
 
         wait(for: [expectation], timeout: 5.0)
+    }
+
+    func testContextTimerConvenience() {
+        let context = NetworkContext(identifier: "test")
+
+        let expectation = XCTestExpectation()
+
+        let timerReference = context.scheduleTimer(duration: .seconds(2)) {
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+        context.unscheduleTimer(timerReference)
     }
 }

--- a/Tests/SwiftNetworkTests/SwiftNetworkContextTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkContextTests.swift
@@ -61,4 +61,36 @@ final class SwiftNetworkContextTests: NetTestCase {
         wait(for: [expectation], timeout: 5.0)
         context.unscheduleTimer(timerReference)
     }
+
+    func testContextTimerMultipleTimers() {
+        let context = NetworkContext(identifier: "test")
+
+        let expectation = XCTestExpectation()
+
+        let timerReference1 = context.scheduleTimer(duration: .seconds(2)) {
+            expectation.fulfill()
+        }
+
+        let timerReference2 = context.scheduleTimer(duration: .seconds(1)) {
+            // Do nothing
+        }
+
+        XCTAssertNotEqual(timerReference1, timerReference2)
+
+        context.unscheduleTimer(timerReference2)
+
+        wait(for: [expectation], timeout: 5.0)
+        context.unscheduleTimer(timerReference1)
+    }
+
+    func testContextTimerReferences() {
+        // Ensure timer references are unique
+        let timerReference1 = TimerReference()
+        let timerReference2 = TimerReference()
+        let timerReference3 = TimerReference()
+
+        XCTAssertNotEqual(timerReference1, timerReference2)
+        XCTAssertNotEqual(timerReference2, timerReference3)
+        XCTAssertNotEqual(timerReference3, timerReference1)
+    }
 }


### PR DESCRIPTION
Previously, timers used the same namespace as protocol event indices (in order to always have a de-duped value available). This prevents timers from being used for other non-protocol reasons on the context.

This change:
- Makes the timer reference a locked, incrementing UInt64
- Makes protocols that allow scheduling store a timer reference
- Adds conveniences to NetworkContext to let timers be directly scheduled using a duration, and returning a reference that can be used to unschedule later 