### PR TITLE
Workflows: enable api_breakage_check.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,6 +46,5 @@ jobs:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
     with:
-      api_breakage_check_enabled: false
       license_header_check_project_name: "Swift"
       api_breakage_check_container_image: "swiftlang/swift:nightly-6.3-jammy"


### PR DESCRIPTION
Hopefully we can turn this one back on without false positives.