### PR TITLE
Enable documentation checks in SwiftNetwork.

### DIFF
--- a/.licenseignore
+++ b/.licenseignore
@@ -10,6 +10,7 @@
 **/Package.resolved
 .editorconfig
 .shellcheckrc
+.spi.yml
 Package.swift
 Benchmarks/Package.swift
 Package@swift-*.swift

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [SwiftNetwork]


### PR DESCRIPTION
In order to have true documentation soundness checks, we needed an .spi.yml file.
The documentation checks pipeline was reporting green because it wasn't finding this file, but effectively it wasn't doing anything.