### PR TITLE
Make harness protocols available without QUIC

### DIFF
--- a/Sources/SwiftNetwork/Protocols/HarnessProtocols.swift
+++ b/Sources/SwiftNetwork/Protocols/HarnessProtocols.swift
@@ -27,7 +27,7 @@ internal import Logging
 internal import os
 #endif
 
-#if !NETWORK_NO_SWIFT_QUIC && !NETWORK_NO_TESTING_HARNESS
+#if !NETWORK_NO_TESTING_HARNESS
 
 @_spi(ProtocolProvider)
 @available(Network 0.1.0, *)
@@ -814,6 +814,7 @@ public class NewFlowHarness<LinkageType: InboundFlowLinkage, HarnessType: UpperH
     public var newOutboundCIDEventCount = 0
     public func handleNetworkProtocolEvent(_ from: ProtocolInstanceReference, event: NetworkProtocolEvent) {
         log.debug("Received network protocol event: \(event)")
+#if !NETWORK_NO_SWIFT_QUIC
         if let quicEvent = event.quicEvent {
             switch quicEvent {
             case .newInboundConnectionID: newInboundCIDEventCount += 1
@@ -821,6 +822,7 @@ public class NewFlowHarness<LinkageType: InboundFlowLinkage, HarnessType: UpperH
             default: break
             }
         }
+#endif
     }
 
     public func teardown() {

--- a/Sources/SwiftNetwork/Protocols/HarnessProtocols.swift
+++ b/Sources/SwiftNetwork/Protocols/HarnessProtocols.swift
@@ -814,7 +814,7 @@ public class NewFlowHarness<LinkageType: InboundFlowLinkage, HarnessType: UpperH
     public var newOutboundCIDEventCount = 0
     public func handleNetworkProtocolEvent(_ from: ProtocolInstanceReference, event: NetworkProtocolEvent) {
         log.debug("Received network protocol event: \(event)")
-#if !NETWORK_NO_SWIFT_QUIC
+        #if !NETWORK_NO_SWIFT_QUIC
         if let quicEvent = event.quicEvent {
             switch quicEvent {
             case .newInboundConnectionID: newInboundCIDEventCount += 1
@@ -822,7 +822,7 @@ public class NewFlowHarness<LinkageType: InboundFlowLinkage, HarnessType: UpperH
             default: break
             }
         }
-#endif
+        #endif
     }
 
     public func teardown() {

--- a/Sources/SwiftNetwork/Protocols/ProtocolControlHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolControlHandlers.swift
@@ -48,12 +48,12 @@ extension ProtocolInstanceReference {
         #if !NETWORK_NO_SWIFT_QUIC
         case .quicPath(let instance): instance.handleConnectedEvent(from)
         case .quicCrypto(let instance): instance.handleConnectedEvent(from)
+        #endif
         #if !NETWORK_NO_TESTING_HARNESS
         case .streamUpperHarness(let instance): instance.handleConnectedEvent(from)
         case .datagramUpperHarness(let instance): instance.handleConnectedEvent(from)
         case .newStreamFlowHarness(let instance): instance.handleConnectedEvent(from)
         case .newDatagramFlowHarness(let instance): instance.handleConnectedEvent(from)
-        #endif
         #endif
         #if !NETWORK_EMBEDDED
         case .custom(let container, let index):
@@ -75,12 +75,12 @@ extension ProtocolInstanceReference {
         #if !NETWORK_NO_SWIFT_QUIC
         case .quicPath(let instance): instance.handleDisconnectedEvent(from, error: error)
         case .quicCrypto(let instance): instance.handleDisconnectedEvent(from, error: error)
+        #endif
         #if !NETWORK_NO_TESTING_HARNESS
         case .streamUpperHarness(let instance): instance.handleDisconnectedEvent(from, error: error)
         case .datagramUpperHarness(let instance): instance.handleDisconnectedEvent(from, error: error)
         case .newStreamFlowHarness(let instance): instance.handleDisconnectedEvent(from, error: error)
         case .newDatagramFlowHarness(let instance): instance.handleDisconnectedEvent(from, error: error)
-        #endif
         #endif
         #if !NETWORK_EMBEDDED
         case .custom(let container, let index):
@@ -103,12 +103,12 @@ extension ProtocolInstanceReference {
         #if !NETWORK_NO_SWIFT_QUIC
         case .quicPath(var instance): instance.handleNetworkProtocolEvent(from, event: event)
         case .quicCrypto(let instance): instance.handleNetworkProtocolEvent(from, event: event)
+        #endif
         #if !NETWORK_NO_TESTING_HARNESS
         case .streamUpperHarness(let instance): instance.handleNetworkProtocolEvent(from, event: event)
         case .datagramUpperHarness(let instance): instance.handleNetworkProtocolEvent(from, event: event)
         case .newStreamFlowHarness(let instance): instance.handleNetworkProtocolEvent(from, event: event)
         case .newDatagramFlowHarness(let instance): instance.handleNetworkProtocolEvent(from, event: event)
-        #endif
         #endif
         #if !NETWORK_EMBEDDED
         case .custom(let container, let index):
@@ -165,10 +165,10 @@ extension ProtocolInstanceReference {
             case .quicStream(let instance): instance.connect(from)
             case .quicDatagram(let instance): instance.connect(from)
             case .quicCrypto(let instance): instance.connect(from)
+            #endif
             #if !NETWORK_NO_TESTING_HARNESS
             case .datagramLowerHarness(let instance): instance.connect(from)
             case .streamLowerHarness(let instance): instance.connect(from)
-            #endif
             #endif
             #if !NETWORK_EMBEDDED
             case .custom(let container, let index): return container.accessLower(at: index) { $0.connect(from) }
@@ -192,10 +192,10 @@ extension ProtocolInstanceReference {
             case .quicStream(let instance): instance.disconnect(from, error: error)
             case .quicDatagram(let instance): instance.disconnect(from, error: error)
             case .quicCrypto(let instance): instance.disconnect(from, error: error)
+            #endif
             #if !NETWORK_NO_TESTING_HARNESS
             case .datagramLowerHarness(let instance): instance.disconnect(from, error: error)
             case .streamLowerHarness(let instance): instance.disconnect(from, error: error)
-            #endif
             #endif
             #if !NETWORK_EMBEDDED
             case .custom(let container, let index):
@@ -219,10 +219,10 @@ extension ProtocolInstanceReference {
             case .quicStream(let instance): instance.handleApplicationEvent(from, event: event)
             case .quicDatagram(let instance): instance.handleApplicationEvent(from, event: event)
             case .quicCrypto(let instance): instance.handleApplicationEvent(from, event: event)
+            #endif
             #if !NETWORK_NO_TESTING_HARNESS
             case .datagramLowerHarness(let instance): instance.handleApplicationEvent(from, event: event)
             case .streamLowerHarness(let instance): instance.handleApplicationEvent(from, event: event)
-            #endif
             #endif
             #if !NETWORK_EMBEDDED
             case .custom(let container, let index):
@@ -309,6 +309,8 @@ extension ProtocolInstanceReference {
                     parameters: parameters,
                     path: path
                 )
+            #endif
+            #if !NETWORK_NO_TESTING_HARNESS
             case .datagramLowerHarness(var instance):
                 return try instance.attachUpperProtocol(
                     from,
@@ -387,6 +389,7 @@ extension ProtocolInstanceReference {
                     parameters: parameters,
                     path: path
                 )
+            #endif
             #if !NETWORK_NO_TESTING_HARNESS
             case .streamLowerHarness(var instance):
                 return try instance.attachUpperStreamProtocol(
@@ -396,7 +399,6 @@ extension ProtocolInstanceReference {
                     parameters: parameters,
                     path: path
                 )
-            #endif
             #endif
             #if !NETWORK_EMBEDDED
             case .custom(let container, let index):
@@ -450,6 +452,7 @@ extension ProtocolInstanceReference {
                     parameters: parameters,
                     path: path
                 )
+            #endif
             #if !NETWORK_NO_TESTING_HARNESS
             case .datagramLowerHarness(var instance):
                 return try instance.attachUpperDatagramProtocol(
@@ -459,7 +462,6 @@ extension ProtocolInstanceReference {
                     parameters: parameters,
                     path: path
                 )
-            #endif
             #endif
             #if !NETWORK_EMBEDDED
             case .custom(let container, let index):
@@ -562,6 +564,8 @@ extension ProtocolInstanceReference {
                     parameters: parameters,
                     path: path
                 )
+            #endif
+            #if !NETWORK_NO_TESTING_HARNESS
             case .streamUpperHarness(var instance):
                 try instance.attachLowerProtocol(
                     lowerProtocol,
@@ -662,6 +666,7 @@ extension ProtocolInstanceReference {
                     parameters: parameters,
                     path: path
                 )
+            #endif
             #if !NETWORK_NO_TESTING_HARNESS
             case .datagramUpperHarness(var instance):
                 try instance.attachLowerDatagramProtocol(
@@ -671,7 +676,6 @@ extension ProtocolInstanceReference {
                     parameters: parameters,
                     path: path
                 )
-            #endif
             #endif
             #if !NETWORK_EMBEDDED
             case .custom(let container, let index):
@@ -733,6 +737,7 @@ extension ProtocolInstanceReference {
                     parameters: parameters,
                     path: path
                 )
+            #endif
             #if !NETWORK_NO_TESTING_HARNESS
             case .streamUpperHarness(var instance):
                 try instance.attachLowerStreamProtocol(
@@ -742,7 +747,6 @@ extension ProtocolInstanceReference {
                     parameters: parameters,
                     path: path
                 )
-            #endif
             #endif
             #if !NETWORK_EMBEDDED
             case .custom(let container, let index):
@@ -878,10 +882,10 @@ extension ProtocolInstanceReference {
             case .quicStream(var instance): try instance.detach(from)
             case .quicDatagram(var instance): try instance.detach(from)
             case .quicCrypto(let instance): try instance.detach(from)
+            #endif
             #if !NETWORK_NO_TESTING_HARNESS
             case .datagramLowerHarness(var instance): try instance.detach(from)
             case .streamLowerHarness(var instance): try instance.detach(from)
-            #endif
             #endif
             #if !NETWORK_EMBEDDED
             case .custom(let container, let index):
@@ -907,10 +911,10 @@ extension ProtocolInstanceReference {
             case .quicStream(let instance): return instance.getMetadata(from)
             case .quicDatagram(let instance): return instance.getMetadata(from)
             case .quicCrypto(let instance): return instance.getMetadata(from)
+            #endif
             #if !NETWORK_NO_TESTING_HARNESS
             case .datagramLowerHarness(let instance): return instance.getMetadata(from)
             case .streamLowerHarness(let instance): return instance.getMetadata(from)
-            #endif
             #endif
             #if !NETWORK_EMBEDDED
             case .custom(let container, let index): return container.accessLower(at: index) { $0.getMetadata(from) }
@@ -941,12 +945,12 @@ extension ProtocolInstanceReference {
                 return instance.getMetrics(from, requestedNetworkMetric: requestedNetworkMetric)
             case .quicCrypto(let instance):
                 return instance.getMetrics(from, requestedNetworkMetric: requestedNetworkMetric)
+            #endif
             #if !NETWORK_NO_TESTING_HARNESS
             case .datagramLowerHarness(let instance):
                 return instance.getMetrics(from, requestedNetworkMetric: requestedNetworkMetric)
             case .streamLowerHarness(let instance):
                 return instance.getMetrics(from, requestedNetworkMetric: requestedNetworkMetric)
-            #endif
             #endif
             #if !NETWORK_EMBEDDED
             case .custom(let container, let index):

--- a/Sources/SwiftNetwork/Protocols/ProtocolDatagramHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolDatagramHandlers.swift
@@ -251,10 +251,10 @@ extension ProtocolInstanceReference {
             #if !NETWORK_NO_SWIFT_QUIC
             case .quicDatagram(var instance):
                 return try instance.receiveDatagrams(from, maximumDatagramCount: maximumDatagramCount)
+            #endif
             #if !NETWORK_NO_TESTING_HARNESS
             case .datagramLowerHarness(var instance):
                 return try instance.receiveDatagrams(from, maximumDatagramCount: maximumDatagramCount)
-            #endif
             #endif
             #if !NETWORK_EMBEDDED
             case .custom(let container, let index):
@@ -295,6 +295,7 @@ extension ProtocolInstanceReference {
                     maximumDatagramCount: maximumDatagramCount,
                     minimumDatagramSize: minimumDatagramSize
                 )
+            #endif
             #if !NETWORK_NO_TESTING_HARNESS
             case .datagramLowerHarness(var instance):
                 return try instance.getDatagramsToSend(
@@ -302,7 +303,6 @@ extension ProtocolInstanceReference {
                     maximumDatagramCount: maximumDatagramCount,
                     minimumDatagramSize: minimumDatagramSize
                 )
-            #endif
             #endif
             #if !NETWORK_EMBEDDED
             case .custom(let container, let index):
@@ -334,9 +334,9 @@ extension ProtocolInstanceReference {
             case .ip(let index): try context.ipInstances[index].sendDatagrams(from, datagrams: datagrams)
             #if !NETWORK_NO_SWIFT_QUIC
             case .quicDatagram(var instance): try instance.sendDatagrams(from, datagrams: datagrams)
+            #endif
             #if !NETWORK_NO_TESTING_HARNESS
             case .datagramLowerHarness(var instance): try instance.sendDatagrams(from, datagrams: datagrams)
-            #endif
             #endif
             #if !NETWORK_EMBEDDED
             case .custom(let container, let index):

--- a/Sources/SwiftNetwork/Protocols/ProtocolDatapathHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolDatapathHandlers.swift
@@ -34,10 +34,10 @@ extension ProtocolInstanceReference {
         #if !NETWORK_NO_SWIFT_QUIC
         case .quicPath(var instance): instance.handleInboundDataAvailableEvent(from)
         case .quicCrypto(let instance): instance.handleInboundDataAvailableEvent(from)
+        #endif
         #if !NETWORK_NO_TESTING_HARNESS
         case .streamUpperHarness(let instance): instance.handleInboundDataAvailableEvent(from)
         case .datagramUpperHarness(let instance): instance.handleInboundDataAvailableEvent(from)
-        #endif
         #endif
         #if !NETWORK_EMBEDDED
         case .custom(let container, let index):
@@ -59,10 +59,10 @@ extension ProtocolInstanceReference {
         #if !NETWORK_NO_SWIFT_QUIC
         case .quicPath(var instance): instance.handleOutboundRoomAvailableEvent(from)
         case .quicCrypto(let instance): instance.handleOutboundRoomAvailableEvent(from)
+        #endif
         #if !NETWORK_NO_TESTING_HARNESS
         case .streamUpperHarness(let instance): instance.handleOutboundRoomAvailableEvent(from)
         case .datagramUpperHarness(let instance): instance.handleOutboundRoomAvailableEvent(from)
-        #endif
         #endif
 
         #if !NETWORK_EMBEDDED

--- a/Sources/SwiftNetwork/Protocols/ProtocolInstanceReference.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolInstanceReference.swift
@@ -31,6 +31,7 @@ public struct ProtocolInstanceReference: Hashable {
         case quicDatagram(_ instance: QUICDatagramFlow)
         case quicPath(_ instance: QUICPath)
         case quicCrypto(_ instance: QUICCrypto)
+        #endif
         #if !NETWORK_NO_TESTING_HARNESS
         case streamUpperHarness(_ instance: StreamUpperHarness)
         case datagramUpperHarness(_ instance: DatagramUpperHarness)
@@ -38,7 +39,6 @@ public struct ProtocolInstanceReference: Hashable {
         case streamLowerHarness(_ instance: StreamLowerHarness)
         case newStreamFlowHarness(_ instance: NewStreamFlowHarness)
         case newDatagramFlowHarness(_ instance: NewDatagramFlowHarness)
-        #endif
         #endif
         #if !NETWORK_EMBEDDED
         case custom(container: any ProtocolInstanceContainer, index: Int?)
@@ -179,6 +179,8 @@ public struct ProtocolInstanceReference: Hashable {
         self.context = instance.context
         self._protocolEventStateIndex = instance.eventManager.register(with: self.context)
     }
+    #endif
+
     #if !NETWORK_NO_TESTING_HARNESS
     init(streamUpperHarness instance: StreamUpperHarness) {
         self.reference = .streamUpperHarness(instance)
@@ -215,7 +217,6 @@ public struct ProtocolInstanceReference: Hashable {
         self.context = instance.context
         self._protocolEventStateIndex = instance.eventManager.register(with: self.context)
     }
-    #endif
     #endif
 
     #if !NETWORK_EMBEDDED

--- a/Sources/SwiftNetwork/Protocols/ProtocolListenerHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolListenerHandlers.swift
@@ -31,7 +31,7 @@ extension ProtocolInstanceReference {
     ) {
         switch reference {
         case .none: return
-        #if !NETWORK_NO_SWIFT_QUIC && !NETWORK_NO_TESTING_HARNESS
+        #if !NETWORK_NO_TESTING_HARNESS
         case .newStreamFlowHarness(let instance):
             return instance.handleNewInboundFlowEvent(from, flowReference: flowReference, flowMetadata: flowMetadata)
         case .newDatagramFlowHarness(let instance):

--- a/Sources/SwiftNetwork/Protocols/ProtocolStreamHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolStreamHandlers.swift
@@ -303,10 +303,10 @@ extension ProtocolInstanceReference {
                 return try instance.receiveStreamData(from, minimumBytes: minimumBytes, maximumBytes: maximumBytes)
             case .quicCrypto(let instance):
                 return try instance.receiveStreamData(from, minimumBytes: minimumBytes, maximumBytes: maximumBytes)
+            #endif
             #if !NETWORK_NO_TESTING_HARNESS
             case .streamLowerHarness(var instance):
                 return try instance.receiveStreamData(from, minimumBytes: minimumBytes, maximumBytes: maximumBytes)
-            #endif
             #endif
             #if !NETWORK_EMBEDDED
             case .custom(let container, let index):
@@ -329,9 +329,9 @@ extension ProtocolInstanceReference {
             #if !NETWORK_NO_SWIFT_QUIC
             case .quicStream(let instance): return try instance.getOutboundStreamDataRoomAvailable(from)
             case .quicCrypto(let instance): return try instance.getOutboundStreamDataRoomAvailable(from)
+            #endif
             #if !NETWORK_NO_TESTING_HARNESS
             case .streamLowerHarness(var instance): return try instance.getOutboundStreamDataRoomAvailable(from)
-            #endif
             #endif
             #if !NETWORK_EMBEDDED
             case .custom(let container, let index):
@@ -360,9 +360,9 @@ extension ProtocolInstanceReference {
             #if !NETWORK_NO_SWIFT_QUIC
             case .quicStream(var instance): try instance.sendStreamData(from, streamData: streamData)
             case .quicCrypto(let instance): try instance.sendStreamData(from, streamData: streamData)
+            #endif
             #if !NETWORK_NO_TESTING_HARNESS
             case .streamLowerHarness(var instance): try instance.sendStreamData(from, streamData: streamData)
-            #endif
             #endif
             #if !NETWORK_EMBEDDED
             case .custom(let container, let index):
@@ -453,9 +453,9 @@ extension ProtocolInstanceReference {
         case .streamEndpointFlow(let instance): instance.handleInboundAbortedEvent(from, error: error)
         #if !NETWORK_NO_SWIFT_QUIC
         case .quicCrypto(let instance): instance.handleInboundAbortedEvent(from, error: error)
+        #endif
         #if !NETWORK_NO_TESTING_HARNESS
         case .streamUpperHarness(let instance): instance.handleInboundAbortedEvent(from, error: error)
-        #endif
         #endif
         #if !NETWORK_EMBEDDED
         case .custom(let container, let index):
@@ -475,9 +475,9 @@ extension ProtocolInstanceReference {
         case .streamEndpointFlow(let instance): instance.handleOutboundAbortedEvent(from, error: error)
         #if !NETWORK_NO_SWIFT_QUIC
         case .quicCrypto(let instance): instance.handleOutboundAbortedEvent(from, error: error)
+        #endif
         #if !NETWORK_NO_TESTING_HARNESS
         case .streamUpperHarness(let instance): instance.handleOutboundAbortedEvent(from, error: error)
-        #endif
         #endif
         #if !NETWORK_EMBEDDED
         case .custom(let container, let index):


### PR DESCRIPTION
Change availability of harness protocols to let them work without QUIC support