### PR TITLE
SwiftQUIC: PERF: Make knownFlows lookup cheaper

### DIFF
--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -300,7 +300,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
     // List of streams that have app input data in their reassembly queue.
     var pendingReassemblyDequeue = QUICStreamList.pendingReassemblyDequeueList()
 
-    private(set) var knownFlows = [QUICStreamID: MultiplexedFlowIdentifier]()
+    private(set) var knownFlows = [UInt64: MultiplexedFlowIdentifier]()
 
     private(set) var localCIDLength: Int = 0
     private var initialSourceConnectionID: QUICConnectionID?

--- a/Sources/SwiftNetwork/QUIC/QUICStreamID.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICStreamID.swift
@@ -326,4 +326,16 @@ extension QUICStreamID: CustomStringConvertible {
         String(value)
     }
 }
+
+@available(Network 0.1.0, *)
+extension Dictionary where Key == UInt64 {
+    subscript(streamID: QUICStreamID) -> Value? {
+        get { self[streamID.value] }
+        set { self[streamID.value] = newValue }
+    }
+    @discardableResult
+    mutating func removeValue(forKey streamID: QUICStreamID) -> Value? {
+        removeValue(forKey: streamID.value)
+    }
+}
 #endif


### PR DESCRIPTION
In `QUICConnection` we do a streamID -> flowID -> QUICStream look for each inbound stream packet and this change optimizes the key hashing for QUICStreamID to be a UInt64. This cuts the lookup CPU usage down here by 44%.

Top of tree:
```
1.39 G   QUICConnection.processStreamFrame(_:)	
172.67   specialized Dictionary.subscript.getter	
```
With this change:
```
1.31 G   QUICConnection.processStreamFrame(_:)	
77.02 M  specialized Dictionary<>.subscript.getter	
```