### PR TITLE
Socket test improvements

### DIFF
--- a/Tests/SwiftNetworkTests/SocketTestHarness.swift
+++ b/Tests/SwiftNetworkTests/SocketTestHarness.swift
@@ -457,7 +457,7 @@ protocol SocketTestServer: AnyObject, Sendable {
 @available(Network 0.1.0, *)
 func discoverFreeLoopbackPorts(_ count: Int) -> [UInt16] {
     var descriptors: [CInt] = []
-    defer { descriptors.forEach { close($0) } }
+    defer { for descriptor in descriptors { close(descriptor) } }
 
     for _ in 0..<count {
         #if canImport(Glibc)

--- a/Tests/SwiftNetworkTests/SocketTestHarness.swift
+++ b/Tests/SwiftNetworkTests/SocketTestHarness.swift
@@ -720,12 +720,26 @@ final class SplitSendServer: SocketTestServer, @unchecked Sendable {
 
         // First segment, then a gap so the client processes it (and, if buggy,
         // suspends its read source) before the remainder arrives.
+        //
+        // This sleep is load-bearing: the gap is the condition the test reproduces. Shrink it and
+        // the two writes may coalesce into one segment, the receive no longer spans a segment
+        // boundary, and the test passes without exercising the bug.
         sendAll(payload.prefix(firstChunk))
         Thread.sleep(forTimeInterval: gap)
         sendAll(payload.suffix(total - firstChunk))
 
-        // Hold the connection open long enough for the client to finish.
-        Thread.sleep(forTimeInterval: 1.0)
+        // Hold the connection open until the client is done, which is exactly its FIN: `read` on
+        // this blocking descriptor returns 0 then. 0 is that FIN and a negative result means the
+        // descriptor has already gone; either way there is nothing left to wait for. The client
+        // sends nothing, so a positive result is not expected but costs nothing to ignore.
+        var readBuffer = [UInt8](repeating: 0, count: 16)
+        while true {
+            let bytesRead = readBuffer.withUnsafeMutableBytes { buffer -> Int in
+                guard let base = buffer.baseAddress else { return -1 }
+                return read(connFd, base, buffer.count)
+            }
+            if bytesRead <= 0 { break }
+        }
     }
 }
 

--- a/Tests/SwiftNetworkTests/SocketTestHarness.swift
+++ b/Tests/SwiftNetworkTests/SocketTestHarness.swift
@@ -85,19 +85,18 @@ final class UDPLoopbackHarness: @unchecked Sendable {
     private let c1Cancelled = XCTestExpectation(description: "c1 cancelled")
     private let c2Cancelled = XCTestExpectation(description: "c2 cancelled")
 
-    /// Builds two peers: `c1` binds `basePort + 1` and targets `basePort`;
-    /// `c2` binds `basePort` and targets `basePort + 1`.
-    init(basePort: UInt16, ipv6: Bool = false) {
-        let portA = basePort
-        let portB = basePort + 1
+    /// Builds two cross-bound peers on kernel-assigned ports: `c1` binds one and targets the
+    /// other, `c2` the reverse.
+    init(ipv6: Bool = false) {
+        let ports = discoverFreeLoopbackPorts(2)
 
         c1 = NetworkConnection(
-            to: loopbackEndpoint(port: portA, ipv6: ipv6),
-            using: makeUDPParams(localPort: portB, ipv6: ipv6)
+            to: loopbackEndpoint(port: ports[0], ipv6: ipv6),
+            using: makeUDPParams(localPort: ports[1], ipv6: ipv6)
         )
         c2 = NetworkConnection(
-            to: loopbackEndpoint(port: portB, ipv6: ipv6),
-            using: makeUDPParams(localPort: portA, ipv6: ipv6)
+            to: loopbackEndpoint(port: ports[1], ipv6: ipv6),
+            using: makeUDPParams(localPort: ports[0], ipv6: ipv6)
         )
 
         c1.onStateUpdate { [c1Ready, c1Cancelled] _, state in
@@ -302,15 +301,19 @@ final class TCPClientHarness: @unchecked Sendable {
     private let ready = XCTestExpectation(description: "tcp ready")
     private let cancelled = XCTestExpectation(description: "tcp cancelled")
 
-    /// Creates the harness around `server` (default: a `TCPEchoServer` on `port`),
-    /// starts the server, and builds a client targeting `port`.
-    init(port: UInt16, ipv6: Bool = false, server: (any SocketTestServer)? = nil) {
-        let server = server ?? TCPEchoServer(port: port, ipv6: ipv6)
+    /// Creates the harness around `server` (default: a `TCPEchoServer`), starts the server, and
+    /// builds a client targeting whichever port the kernel gave it.
+    init(ipv6: Bool = false, server: (any SocketTestServer)? = nil) {
+        let server = server ?? TCPEchoServer(ipv6: ipv6)
         self.server = server
-        try? server.start()
+        do {
+            try server.start()
+        } catch {
+            XCTFail("test server failed to start: \(error)")
+        }
 
         conn = NetworkConnection(
-            to: loopbackEndpoint(port: port, ipv6: ipv6),
+            to: loopbackEndpoint(port: server.listeningPort, ipv6: ipv6),
             using: makeTCPParams(ipv6: ipv6)
         )
         conn.onStateUpdate { [ready, cancelled] _, state in
@@ -442,21 +445,93 @@ final class TCPClientHarness: @unchecked Sendable {
 protocol SocketTestServer: AnyObject, Sendable {
     func start() throws
     func stop()
+    /// The port the kernel assigned, valid once `start()` has returned.
+    ///
+    /// Assigned at bind rather than chosen up front, which is why the servers' dispatch queue
+    /// labels no longer carry it.
+    var listeningPort: UInt16 { get }
+}
+
+/// Discovers `count` distinct loopback port numbers that are free, by binding a socket to each and
+/// releasing them all once the kernel's choices have been read back.
+@available(Network 0.1.0, *)
+func discoverFreeLoopbackPorts(_ count: Int) -> [UInt16] {
+    var descriptors: [CInt] = []
+    defer { descriptors.forEach { close($0) } }
+
+    for _ in 0..<count {
+        #if canImport(Glibc)
+        let descriptor = socket(AF_INET, CInt(SOCK_DGRAM.rawValue), 0)
+        #else
+        let descriptor = socket(AF_INET, SOCK_DGRAM, 0)
+        #endif
+        guard descriptor >= 0 else {
+            XCTFail("could not open a socket to find a free port: errno \(errno)")
+            return Array(repeating: 0, count: count)
+        }
+        descriptors.append(descriptor)
+
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_addr = in_addr(s_addr: UInt32(0x7f00_0001).bigEndian)
+        #if canImport(Darwin)
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        #endif
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                bind(descriptor, socketAddress, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bound == 0 else {
+            XCTFail("could not bind a socket to find a free port: errno \(errno)")
+            return Array(repeating: 0, count: count)
+        }
+    }
+    return descriptors.map { boundPortOfDescriptor($0) }
+}
+
+/// Discovers one free loopback port number. See `discoverFreeLoopbackPorts(_:)`.
+@available(Network 0.1.0, *)
+func discoverFreeLoopbackPort() -> UInt16 {
+    discoverFreeLoopbackPorts(1)[0]
+}
+
+/// Reads back the port `fd` is bound to.
+@available(Network 0.1.0, *)
+func boundPortOfDescriptor(_ fd: Int32) -> UInt16 {
+    var storage = sockaddr_storage()
+    var length = socklen_t(MemoryLayout<sockaddr_storage>.size)
+    let result = withUnsafeMutablePointer(to: &storage) { ptr in
+        ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+            getsockname(fd, sa, &length)
+        }
+    }
+    guard result == 0 else {
+        XCTFail("could not read back the bound port: errno \(errno)")
+        return 0
+    }
+    if storage.ss_family == sa_family_t(AF_INET6) {
+        return withUnsafePointer(to: &storage) { ptr in
+            ptr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { UInt16(bigEndian: $0.pointee.sin6_port) }
+        }
+    }
+    return withUnsafePointer(to: &storage) { ptr in
+        ptr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { UInt16(bigEndian: $0.pointee.sin_port) }
+    }
 }
 
 // Accepts one connection and echoes everything it receives back to the sender
 // until the peer half-closes (FIN).
 @available(Network 0.1.0, *)
 final class TCPEchoServer: SocketTestServer, @unchecked Sendable {
-    private let port: UInt16
+    private(set) var listeningPort: UInt16 = 0
     private let ipv6: Bool
     private let queue: DispatchQueue
     private var listenFd: Int32 = -1
 
-    init(port: UInt16, ipv6: Bool = false) {
-        self.port = port
+    init(ipv6: Bool = false) {
         self.ipv6 = ipv6
-        self.queue = DispatchQueue(label: "tcp-echo-server-\(port)", qos: .userInitiated)
+        self.queue = DispatchQueue(label: "tcp-echo-server", qos: .userInitiated)
     }
 
     func start() throws {
@@ -477,7 +552,7 @@ final class TCPEchoServer: SocketTestServer, @unchecked Sendable {
         if ipv6 {
             var addr = sockaddr_in6()
             addr.sin6_family = sa_family_t(AF_INET6)
-            addr.sin6_port = port.bigEndian
+            addr.sin6_port = 0
             addr.sin6_addr = in6addr_loopback
             #if canImport(Darwin)
             addr.sin6_len = UInt8(MemoryLayout<sockaddr_in6>.size)
@@ -490,7 +565,7 @@ final class TCPEchoServer: SocketTestServer, @unchecked Sendable {
         } else {
             var addr = sockaddr_in()
             addr.sin_family = sa_family_t(AF_INET)
-            addr.sin_port = port.bigEndian
+            addr.sin_port = 0
             addr.sin_addr = in_addr(s_addr: UInt32(0x7f00_0001).bigEndian)
             #if canImport(Darwin)
             addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
@@ -511,6 +586,7 @@ final class TCPEchoServer: SocketTestServer, @unchecked Sendable {
             throw NetworkError.posix(errno)
         }
 
+        self.listeningPort = boundPortOfDescriptor(fd)
         self.listenFd = fd
         queue.async { [weak self] in self?.acceptLoop() }
     }
@@ -556,19 +632,18 @@ final class TCPEchoServer: SocketTestServer, @unchecked Sendable {
 // to span more than one read event.
 @available(Network 0.1.0, *)
 final class SplitSendServer: SocketTestServer, @unchecked Sendable {
-    private let port: UInt16
+    private(set) var listeningPort: UInt16 = 0
     private let firstChunk: Int
     private let total: Int
     private let gap: TimeInterval
     private let queue: DispatchQueue
     private var listenFd: Int32 = -1
 
-    init(port: UInt16, firstChunk: Int, total: Int, gap: TimeInterval) {
-        self.port = port
+    init(firstChunk: Int, total: Int, gap: TimeInterval) {
         self.firstChunk = firstChunk
         self.total = total
         self.gap = gap
-        self.queue = DispatchQueue(label: "split-send-server-\(port)", qos: .userInitiated)
+        self.queue = DispatchQueue(label: "split-send-server", qos: .userInitiated)
     }
 
     func start() throws {
@@ -585,7 +660,7 @@ final class SplitSendServer: SocketTestServer, @unchecked Sendable {
 
         var addr = sockaddr_in()
         addr.sin_family = sa_family_t(AF_INET)
-        addr.sin_port = port.bigEndian
+        addr.sin_port = 0
         addr.sin_addr = in_addr(s_addr: UInt32(0x7f00_0001).bigEndian)
         #if canImport(Darwin)
         addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
@@ -604,6 +679,7 @@ final class SplitSendServer: SocketTestServer, @unchecked Sendable {
             throw NetworkError.posix(errno)
         }
 
+        self.listeningPort = boundPortOfDescriptor(fd)
         self.listenFd = fd
         queue.async { [weak self] in self?.serve() }
     }
@@ -657,15 +733,14 @@ final class SplitSendServer: SocketTestServer, @unchecked Sendable {
 // client observes EOF. Used to exercise the bottom's end-of-stream handling.
 @available(Network 0.1.0, *)
 final class ClosingServer: SocketTestServer, @unchecked Sendable {
-    private let port: UInt16
+    private(set) var listeningPort: UInt16 = 0
     private let payload: [UInt8]
     private let queue: DispatchQueue
     private var listenFd: Int32 = -1
 
-    init(port: UInt16, payload: [UInt8]) {
-        self.port = port
+    init(payload: [UInt8]) {
         self.payload = payload
-        self.queue = DispatchQueue(label: "closing-server-\(port)", qos: .userInitiated)
+        self.queue = DispatchQueue(label: "closing-server", qos: .userInitiated)
     }
 
     func start() throws {
@@ -682,7 +757,7 @@ final class ClosingServer: SocketTestServer, @unchecked Sendable {
 
         var addr = sockaddr_in()
         addr.sin_family = sa_family_t(AF_INET)
-        addr.sin_port = port.bigEndian
+        addr.sin_port = 0
         addr.sin_addr = in_addr(s_addr: UInt32(0x7f00_0001).bigEndian)
         #if canImport(Darwin)
         addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
@@ -701,6 +776,7 @@ final class ClosingServer: SocketTestServer, @unchecked Sendable {
             throw NetworkError.posix(errno)
         }
 
+        self.listeningPort = boundPortOfDescriptor(fd)
         self.listenFd = fd
         queue.async { [weak self] in self?.serve() }
     }

--- a/Tests/SwiftNetworkTests/SwiftNetworkInterfaceTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkInterfaceTests.swift
@@ -19,7 +19,6 @@ import XCTest
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(os)
 #endif
 
 @available(Network 0.1.0, *)

--- a/Tests/SwiftNetworkTests/SwiftNetworkInterfaceTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkInterfaceTests.swift
@@ -17,12 +17,9 @@ import XCTest
 
 #if canImport(Glibc)
 import Glibc
-internal import Logging
 #elseif canImport(Musl)
 import Musl
-internal import Logging
 #elseif canImport(os)
-internal import os
 #endif
 
 @available(Network 0.1.0, *)
@@ -64,38 +61,66 @@ final class SwiftNetworkInterfaceTests: NetTestCase {
     }
 
     func testCreateInterfaceWithTooManySockets() throws {
-        // Create enough sockets to hit the fd limit so that we can't make the ioctl socket in the interface
-        var sockets: [Int32] = []
-        let fdLimit = System.getFDLimit()
-        let systemFDLimit = try XCTUnwrap(fdLimit)
-        var socketsExhausted = false
-        for _ in 0..<systemFDLimit {
-            #if !os(Linux)
-            let wastedSockFd = socket(AF_INET, SOCK_DGRAM, 0)
-            #else  //os(Linux)
-            let wastedSockFd = socket(AF_INET, Int32(SOCK_DGRAM.rawValue), 0)
-            #endif
-            if wastedSockFd < 0 {
-                Logger.proto.info("Successfully opened too many sockets")
-                socketsExhausted = true
-                break
-            }
-            sockets.append(wastedSockFd)
-        }
-        XCTAssertTrue(socketsExhausted, "Sockets were not exhausted")
-        #if !os(Linux)
-        let name = "lo0"
-        #else  //os(Linux)
-        let name = "lo"
+        // `Interface.init` needs a socket to run its ioctls against, and must report a failure to
+        // get one rather than trapping. Provoke that by lowering this process's descriptor limit to
+        // below what it is already using, so the very next `socket()` fails. The window in which
+        // this process cannot open a descriptor is microseconds, and nothing outside it is affected.
+        #if canImport(Glibc)
+        let descriptorLimit = __rlimit_resource_t(RLIMIT_NOFILE.rawValue)
+        #else
+        let descriptorLimit = RLIMIT_NOFILE
         #endif
-        // This should throw here if the file descriptor limit is reached
-        // Note that in the internal build path this will just return nil for someone tring to create an Interface.
-        // This is similar to how it previously used to work, but input or an issue, return nil
-        XCTAssertThrowsError(try Interface(index: 1, name: name))
-        // Clean up the sockets
-        for sockFd in sockets {
-            close(sockFd)
+
+        // Both of these have to stop the test rather than record and continue. A failed `getrlimit`
+        // leaves `original` zeroed, and lowering from that clamps the *hard* limit to zero, which an
+        // unprivileged process can never raise again -- every later test would fail to open a
+        // descriptor.
+        var original = rlimit()
+        guard getrlimit(descriptorLimit, &original) == 0 else {
+            XCTFail("could not read the descriptor limit: errno \(errno)")
+            return
         }
+
+        var restricted = original
+        restricted.rlim_cur = 0
+        guard setrlimit(descriptorLimit, &restricted) == 0 else {
+            XCTFail("could not lower the descriptor limit: errno \(errno)")
+            return
+        }
+
+        // Check the premise: if the limit did not take effect, `Interface` would fail or succeed for
+        // some other reason and the assertion below would prove nothing.
+        #if os(Linux)
+        let probeType = CInt(SOCK_DGRAM.rawValue)
+        #else
+        let probeType = SOCK_DGRAM
+        #endif
+        XCTAssertLessThan(socket(AF_INET, probeType, 0), 0, "the descriptor limit did not take effect")
+
+        // Restore before asserting rather than from a `defer`: XCTest opens files to report a
+        // failure, so its reporting must not run while this process cannot open a descriptor.
+        let interfaceResult: Result<Interface, any Error>
+        do {
+            interfaceResult = .success(try Interface(index: 1, name: Self.loopbackInterfaceName))
+        } catch {
+            interfaceResult = .failure(error)
+        }
+        XCTAssertEqual(setrlimit(descriptorLimit, &original), 0, "could not restore the descriptor limit")
+
+        switch interfaceResult {
+        case .success:
+            XCTFail("Interface was created despite the process being unable to open a socket")
+        case .failure(let error):
+            XCTAssertEqual(error as? NetworkError, NetworkError.posix(EINVAL))
+        }
+    }
+
+    private static var loopbackInterfaceName: String {
+        #if os(Linux)
+        "lo"
+        #else
+        "lo0"
+        #endif
     }
 
     func testCompareTwoInterfaces() throws {

--- a/Tests/SwiftNetworkTests/SwiftNetworkSocketTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkSocketTests.swift
@@ -43,8 +43,9 @@ final class SwiftNetworkSocketTests: NetTestCase {
         let ready = XCTestExpectation(description: "ready")
         let cancelled = XCTestExpectation(description: "cancelled")
 
-        let remote = Endpoint(address: IPv4Address.loopback, port: 10800)
-        let conn = NetworkConnection(to: remote, using: makeUDPParams(localPort: 10801))
+        let ports = discoverFreeLoopbackPorts(2)
+        let remote = Endpoint(address: IPv4Address.loopback, port: ports[0])
+        let conn = NetworkConnection(to: remote, using: makeUDPParams(localPort: ports[1]))
             .onStateUpdate { _, state in
                 if case .ready = state { ready.fulfill() }
                 if case .cancelled = state { cancelled.fulfill() }
@@ -60,35 +61,35 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // MARK: - Basic data path (UDP)
 
     func testRoundTripEchoIPv4() {
-        let harness = UDPLoopbackHarness(basePort: 10810)
+        let harness = UDPLoopbackHarness()
         harness.start()
         harness.expectRoundTripEcho([1, 2, 3, 4, 5])
         harness.teardown()
     }
 
     func testRoundTripEchoLargePayload() {
-        let harness = UDPLoopbackHarness(basePort: 10820)
+        let harness = UDPLoopbackHarness()
         harness.start()
         harness.expectRoundTripEcho([UInt8](repeating: 0xAB, count: 1400))
         harness.teardown()
     }
 
     func testRoundTripEchoIPv6() {
-        let harness = UDPLoopbackHarness(basePort: 10830, ipv6: true)
+        let harness = UDPLoopbackHarness(ipv6: true)
         harness.start()
         harness.expectRoundTripEcho([10, 20, 30])
         harness.teardown()
     }
 
     func testSendSingleByteDatagram() {
-        let harness = UDPLoopbackHarness(basePort: 10840)
+        let harness = UDPLoopbackHarness()
         harness.start()
         harness.expectDeliver([0xFF])
         harness.teardown()
     }
 
     func testMultipleMessagesSequentially() {
-        let harness = UDPLoopbackHarness(basePort: 10850)
+        let harness = UDPLoopbackHarness()
         harness.start()
         harness.expectSequentialDeliver([
             [1], [2, 3], [4, 5, 6], [7, 8, 9, 10], [11, 12, 13, 14, 15],
@@ -97,7 +98,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
     }
 
     func testBidirectionalSimultaneousTransfer() {
-        let harness = UDPLoopbackHarness(basePort: 10860)
+        let harness = UDPLoopbackHarness()
         harness.start()
 
         let bothDone = XCTestExpectation(description: "both received")
@@ -132,21 +133,21 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // MARK: - Volume / stress (UDP)
 
     func testRapidBurst100Sends() {
-        let harness = UDPLoopbackHarness(basePort: 10870)
+        let harness = UDPLoopbackHarness()
         harness.start()
         harness.expectBurstThenDrain((0..<100).map { [UInt8($0 % 256)] })
         harness.teardown()
     }
 
     func testHighVolumeEcho200Messages() {
-        let harness = UDPLoopbackHarness(basePort: 10880)
+        let harness = UDPLoopbackHarness()
         harness.start()
         harness.expectSequentialEcho(count: 200) { [UInt8($0 % 256)] }
         harness.teardown()
     }
 
     func testVaryingPayloadSizes() {
-        let harness = UDPLoopbackHarness(basePort: 10890)
+        let harness = UDPLoopbackHarness()
         harness.start()
         let sizes = [1, 100, 500, 1000, 1400, 10]
         harness.expectSequentialDeliver(sizes.map { [UInt8](repeating: 0xAA, count: $0) })
@@ -156,14 +157,14 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // MARK: - Backpressure (UDP)
 
     func testBurstSendsReceiveOneAtATime() {
-        let harness = UDPLoopbackHarness(basePort: 10900)
+        let harness = UDPLoopbackHarness()
         harness.start()
         harness.expectBurstThenDrain((0..<5).map { [UInt8($0)] }, timeout: 15.0)
         harness.teardown()
     }
 
     func testMultipleSendsBeforeAnyReads() {
-        let harness = UDPLoopbackHarness(basePort: 10910)
+        let harness = UDPLoopbackHarness()
         harness.start()
         // Small delay to let sends queue up before reading.
         harness.expectBurstThenDrain((0..<10).map { [UInt8($0)] }, delayBeforeDrain: 0.1, timeout: 15.0)
@@ -171,7 +172,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
     }
 
     func testDelayedConsumer() {
-        let harness = UDPLoopbackHarness(basePort: 10920)
+        let harness = UDPLoopbackHarness()
         harness.start()
 
         let allDone = XCTestExpectation(description: "delayed consumer")
@@ -201,8 +202,9 @@ final class SwiftNetworkSocketTests: NetTestCase {
     func testCancelBeforeStart() {
         let cancelled = XCTestExpectation(description: "cancelled")
 
-        let remote = Endpoint(address: IPv4Address.loopback, port: 10930)
-        let conn = NetworkConnection(to: remote, using: makeUDPParams(localPort: 10931))
+        let ports = discoverFreeLoopbackPorts(2)
+        let remote = Endpoint(address: IPv4Address.loopback, port: ports[0])
+        let conn = NetworkConnection(to: remote, using: makeUDPParams(localPort: ports[1]))
             .onStateUpdate { _, state in
                 if case .cancelled = state { cancelled.fulfill() }
             }
@@ -212,7 +214,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
     }
 
     func testStartTwoConnectionsSameContext() {
-        let harness = UDPLoopbackHarness(basePort: 10940)
+        let harness = UDPLoopbackHarness()
         harness.start()
         harness.waitBothReady()
         harness.teardown()
@@ -221,21 +223,21 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // MARK: - Edge case payloads (UDP)
 
     func testEmptyPayload() {
-        let harness = UDPLoopbackHarness(basePort: 10950)
+        let harness = UDPLoopbackHarness()
         harness.start()
         harness.expectDeliver([])
         harness.teardown()
     }
 
     func testMaxSizeDatagram() {
-        let harness = UDPLoopbackHarness(basePort: 10960)
+        let harness = UDPLoopbackHarness()
         harness.start()
         harness.expectDeliver((0..<1472).map { UInt8($0 % 256) })
         harness.teardown()
     }
 
     func testPayloadWithAllByteValues() {
-        let harness = UDPLoopbackHarness(basePort: 10970)
+        let harness = UDPLoopbackHarness()
         harness.start()
         harness.expectDeliver((0...255).map { UInt8($0) })
         harness.teardown()
@@ -244,14 +246,14 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // MARK: - Multiple sequential echoes (UDP)
 
     func testEcho10RoundTrips() {
-        let harness = UDPLoopbackHarness(basePort: 10980)
+        let harness = UDPLoopbackHarness()
         harness.start()
         harness.expectSequentialEcho(count: 10, timeout: 30.0) { [UInt8($0), UInt8($0 &* 2)] }
         harness.teardown()
     }
 
     func testEcho50RoundTripsLargePayload() {
-        let harness = UDPLoopbackHarness(basePort: 10990)
+        let harness = UDPLoopbackHarness()
         harness.start()
         harness.expectSequentialEcho(count: 50) { [UInt8](repeating: UInt8($0 % 256), count: 1000) }
         harness.teardown()
@@ -260,14 +262,14 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // MARK: - IPv6 additional tests (UDP)
 
     func testIPv6SingleByte() {
-        let harness = UDPLoopbackHarness(basePort: 11000, ipv6: true)
+        let harness = UDPLoopbackHarness(ipv6: true)
         harness.start()
         harness.expectDeliver([0x42])
         harness.teardown()
     }
 
     func testIPv6BidirectionalEcho() {
-        let harness = UDPLoopbackHarness(basePort: 11010, ipv6: true)
+        let harness = UDPLoopbackHarness(ipv6: true)
         harness.start()
 
         let bothDone = XCTestExpectation(description: "both echoed")
@@ -302,7 +304,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // MARK: - Rapid send-receive patterns (UDP)
 
     func testAlternatingSendReceive() {
-        let harness = UDPLoopbackHarness(basePort: 11020)
+        let harness = UDPLoopbackHarness()
         harness.start()
 
         let allDone = XCTestExpectation(description: "alternating")
@@ -336,14 +338,14 @@ final class SwiftNetworkSocketTests: NetTestCase {
     }
 
     func testBurst50ThenDrain() {
-        let harness = UDPLoopbackHarness(basePort: 11030)
+        let harness = UDPLoopbackHarness()
         harness.start()
         harness.expectBurstThenDrain((0..<50).map { [UInt8($0 % 256)] })
         harness.teardown()
     }
 
     func testSendReceiveWithRandomPayloadSizes() {
-        let harness = UDPLoopbackHarness(basePort: 11040)
+        let harness = UDPLoopbackHarness()
         harness.start()
         let sizes = [7, 13, 42, 100, 256, 500, 1, 1000, 3, 1400]
         harness.expectSequentialDeliver(sizes.map { (0..<$0).map { UInt8($0 % 256) } })
@@ -361,7 +363,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // MARK: - Connection lifecycle (TCP)
 
     func testTCPConnectionStateLifecycle() {
-        let harness = TCPClientHarness(port: 12000)
+        let harness = TCPClientHarness()
         harness.start()
         harness.waitReady()
         harness.teardown()
@@ -374,7 +376,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
         let ready = XCTestExpectation(description: "tcp ready")
         ready.isInverted = true
 
-        let remote = Endpoint(address: IPv4Address.loopback, port: 12001)
+        let remote = Endpoint(address: IPv4Address.loopback, port: discoverFreeLoopbackPort())
         let conn = NetworkConnection(to: remote, using: makeTCPParams())
             .onStateUpdate { _, state in
                 if case .failed = state { failed.fulfill() }
@@ -390,28 +392,28 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // MARK: - Basic data path (TCP)
 
     func testTCPRoundTripEchoIPv4() {
-        let harness = TCPClientHarness(port: 12010)
+        let harness = TCPClientHarness()
         harness.start()
         harness.expectEcho([1, 2, 3, 4, 5])
         harness.teardown()
     }
 
     func testTCPRoundTripEchoIPv6() {
-        let harness = TCPClientHarness(port: 12120, ipv6: true)
+        let harness = TCPClientHarness(ipv6: true)
         harness.start()
         harness.expectEcho([10, 20, 30])
         harness.teardown()
     }
 
     func testTCPSendSingleByte() {
-        let harness = TCPClientHarness(port: 12030)
+        let harness = TCPClientHarness()
         harness.start()
         harness.expectEcho([0xFF])
         harness.teardown()
     }
 
     func testTCPLargePayloadEcho() {
-        let harness = TCPClientHarness(port: 12040)
+        let harness = TCPClientHarness()
         harness.start()
         // Stream may deliver the echo across multiple receives — drain.
         harness.expectEcho([UInt8](repeating: 0xAB, count: 8192), drain: true)
@@ -419,7 +421,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
     }
 
     func testTCPMultipleSequentialMessages() {
-        let harness = TCPClientHarness(port: 12050)
+        let harness = TCPClientHarness()
         harness.start()
         harness.expectSequentialEcho([
             [1], [2, 3], [4, 5, 6], [7, 8, 9, 10], [11, 12, 13, 14, 15],
@@ -430,14 +432,14 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // MARK: - Volume / stress (TCP)
 
     func testTCPHighVolumeEcho100Messages() {
-        let harness = TCPClientHarness(port: 12060)
+        let harness = TCPClientHarness()
         harness.start()
         harness.expectSequentialEcho(count: 100) { [UInt8($0 % 256), UInt8(($0 + 1) % 256)] }
         harness.teardown()
     }
 
     func testTCPVaryingPayloadSizes() {
-        let harness = TCPClientHarness(port: 12070)
+        let harness = TCPClientHarness()
         harness.start()
         let sizes = [1, 100, 500, 1000, 1400, 4096, 10]
         harness.expectSequentialEcho(sizes.map { [UInt8](repeating: 0xAA, count: $0) }, drain: true)
@@ -447,7 +449,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // MARK: - Backpressure / lifecycle (TCP)
 
     func testTCPBurstSendsThenDrain() {
-        let harness = TCPClientHarness(port: 12080)
+        let harness = TCPClientHarness()
         harness.start()
         // Wait until connected before bursting: on Linux, sending on a socket
         // that is still connecting fails immediately with ENOBUFS.
@@ -489,7 +491,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
     }
 
     func testTCPDelayedConsumer() {
-        let harness = TCPClientHarness(port: 12090)
+        let harness = TCPClientHarness()
         harness.start()
         harness.waitReady()
 
@@ -516,7 +518,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
     }
 
     func testTCPPayloadWithAllByteValues() {
-        let harness = TCPClientHarness(port: 12100)
+        let harness = TCPClientHarness()
         harness.start()
         harness.expectEcho((0...255).map { UInt8($0) })
         harness.teardown()
@@ -525,7 +527,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
     func testTCPCancelBeforeStart() {
         let cancelled = XCTestExpectation(description: "tcp cancelled")
 
-        let remote = Endpoint(address: IPv4Address.loopback, port: 12110)
+        let remote = Endpoint(address: IPv4Address.loopback, port: discoverFreeLoopbackPort())
         let conn = NetworkConnection(to: remote, using: makeTCPParams())
             .onStateUpdate { _, state in
                 if case .cancelled = state { cancelled.fulfill() }
@@ -538,7 +540,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // MARK: - Echo round trips (TCP)
 
     func testTCPEcho10RoundTrips() {
-        let harness = TCPClientHarness(port: 12130)
+        let harness = TCPClientHarness()
         harness.start()
         harness.expectSequentialEcho(count: 10, timeout: 30.0) {
             [UInt8($0), UInt8($0 &* 2), UInt8($0 &* 3)]
@@ -556,7 +558,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // Verifies that a cancelled connection can be garbage-collected promptly
     // (exercises deinit / teardown paths on both concrete types).
     func testUDPTeardownIsClean() {
-        let harness = UDPLoopbackHarness(basePort: 13000)
+        let harness = UDPLoopbackHarness()
         harness.c1.start()
         harness.c1.cancel()
         // teardown() waits for both peers' cancelled state; c2 was never
@@ -570,8 +572,9 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // not crash (exercises the write-source suspend path in cancelWriteSource).
     func testUDPCancelImmediatelyAfterStart() {
         let cancelled = XCTestExpectation(description: "cancelled immediately")
-        let remote = Endpoint(address: IPv4Address.loopback, port: 13020)
-        let conn = NetworkConnection(to: remote, using: makeUDPParams(localPort: 13021))
+        let ports = discoverFreeLoopbackPorts(2)
+        let remote = Endpoint(address: IPv4Address.loopback, port: ports[0])
+        let conn = NetworkConnection(to: remote, using: makeUDPParams(localPort: ports[1]))
             .onStateUpdate { _, state in
                 if case .cancelled = state { cancelled.fulfill() }
             }
@@ -584,7 +587,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
 
     func testTCPCancelImmediatelyAfterStart() {
         let cancelled = XCTestExpectation(description: "tcp cancelled immediately")
-        let remote = Endpoint(address: IPv4Address.loopback, port: 13030)
+        let remote = Endpoint(address: IPv4Address.loopback, port: discoverFreeLoopbackPort())
         let conn = NetworkConnection(to: remote, using: makeTCPParams())
             .onStateUpdate { _, state in
                 if case .cancelled = state { cancelled.fulfill() }
@@ -601,8 +604,9 @@ final class SwiftNetworkSocketTests: NetTestCase {
 
         // An explicit localPort verifies bindSocket in the base class succeeds
         // without error.
-        let remote = Endpoint(address: IPv4Address.loopback, port: 13040)
-        let conn = NetworkConnection(to: remote, using: makeUDPParams(localPort: 13041))
+        let ports = discoverFreeLoopbackPorts(2)
+        let remote = Endpoint(address: IPv4Address.loopback, port: ports[0])
+        let conn = NetworkConnection(to: remote, using: makeUDPParams(localPort: ports[1]))
             .onStateUpdate { _, state in
                 if case .ready = state { ready.fulfill() }
                 if case .cancelled = state { cancelled.fulfill() }
@@ -616,7 +620,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // Verifies that the write-source fires and triggerOutboundRoomAvailable
     // is called after a datagram send — the upper layer gets the room event.
     func testUDPOutboundRoomAvailableAfterSend() {
-        let harness = UDPLoopbackHarness(basePort: 13050)
+        let harness = UDPLoopbackHarness()
         harness.start()
 
         let sent = XCTestExpectation(description: "sent")
@@ -630,7 +634,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
 
     // Verifies write-source / triggerOutboundRoomAvailable for TCP.
     func testTCPOutboundRoomAvailableAfterSend() {
-        let harness = TCPClientHarness(port: 13060)
+        let harness = TCPClientHarness()
         harness.start()
         harness.waitReady()
 
@@ -648,9 +652,9 @@ final class SwiftNetworkSocketTests: NetTestCase {
     func testUDPMultipleCancelCycles() {
         for cycle in 0..<3 {
             let cancelled = XCTestExpectation(description: "cycle \(cycle) cancelled")
-            let port = UInt16(13070 + cycle * 2)
-            let remote = Endpoint(address: IPv4Address.loopback, port: port)
-            let conn = NetworkConnection(to: remote, using: makeUDPParams(localPort: port + 1))
+            let ports = discoverFreeLoopbackPorts(2)
+            let remote = Endpoint(address: IPv4Address.loopback, port: ports[0])
+            let conn = NetworkConnection(to: remote, using: makeUDPParams(localPort: ports[1]))
                 .onStateUpdate { _, state in
                     if case .cancelled = state { cancelled.fulfill() }
                 }
@@ -661,9 +665,8 @@ final class SwiftNetworkSocketTests: NetTestCase {
     }
 
     func testTCPMultipleCancelCycles() {
-        for cycle in 0..<3 {
-            let port = UInt16(13080 + cycle)
-            let harness = TCPClientHarness(port: port)
+        for _ in 0..<3 {
+            let harness = TCPClientHarness()
             harness.start()
             harness.waitReady()
             harness.teardown()
@@ -684,13 +687,11 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // before the rest arrives. With a correct implementation this completes
     // promptly; with the stall it times out.
     func testTCPReceiveAtLeastSpanningTwoSegments() {
-        let port: UInt16 = 12200
         let firstChunk = 4
         let total = 16  // atLeast spans both segments
 
         let harness = TCPClientHarness(
-            port: port,
-            server: SplitSendServer(port: port, firstChunk: firstChunk, total: total, gap: 0.5)
+            server: SplitSendServer(firstChunk: firstChunk, total: total, gap: 0.5)
         )
         harness.start()
 
@@ -730,8 +731,7 @@ final class SwiftNetworkSocketTests: NetTestCase {
     // a busy-loop burns ~a full core; correct behavior consumes ~nothing.
     func testTCPNoBusyLoopAfterEOF() {
         let harness = TCPClientHarness(
-            port: 12210,
-            server: ClosingServer(port: 12210, payload: [1, 2, 3, 4])
+            server: ClosingServer(payload: [1, 2, 3, 4])
         )
         harness.start()
 

--- a/Tests/SwiftNetworkTests/SwiftNetworkSocketTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkSocketTests.swift
@@ -370,23 +370,30 @@ final class SwiftNetworkSocketTests: NetTestCase {
     }
 
     func testTCPConnectionRefusedDeliversFailure() {
-        // No listener on this port: connect should fail.
+        // Nothing is listening on this port, so connect must fail. `.ready` is asserted absent from
+        // the recorded sequence, which catches it anywhere before the failure rather than only
+        // during a fixed wait, and the sequence is dumped when it does appear.
         let failed = XCTestExpectation(description: "tcp failed")
         let cancelled = XCTestExpectation(description: "tcp cancelled")
-        let ready = XCTestExpectation(description: "tcp ready")
-        ready.isInverted = true
+        let observedStates = NetworkMutex<[NetworkConnection<TCP>.State]>([])
 
         let remote = Endpoint(address: IPv4Address.loopback, port: discoverFreeLoopbackPort())
         let conn = NetworkConnection(to: remote, using: makeTCPParams())
             .onStateUpdate { _, state in
+                observedStates.withLock { $0.append(state) }
                 if case .failed = state { failed.fulfill() }
                 if case .cancelled = state { cancelled.fulfill() }
-                if case .ready = state { ready.fulfill() }
             }
         conn.start()
-        wait(for: [failed, ready], timeout: 5.0)
+        wait(for: [failed], timeout: 5.0)
         conn.cancel()
         wait(for: [cancelled], timeout: 5.0)
+
+        let states = observedStates.withLock { $0 }
+        XCTAssertFalse(
+            states.contains(.ready),
+            "connection reported ready with nothing listening on the port: \(states)"
+        )
     }
 
     // MARK: - Basic data path (TCP)

--- a/Tests/SwiftNetworkTests/SwiftNetworkSocketTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkSocketTests.swift
@@ -753,8 +753,12 @@ final class SwiftNetworkSocketTests: NetTestCase {
         }
         wait(for: [received], timeout: 5.0)
 
-        // Give the bottom a moment to observe the peer's FIN (EOF), then sample
-        // CPU across an otherwise-idle second.
+        // Both sleeps are load-bearing. The first waits for the bottom to observe the peer's FIN,
+        // which has no observable substitute: a second `receive` never completes on it.
+        //
+        // The second *is* the measurement -- no read event firing is only observable as an absence
+        // over an interval -- and it has to stay long, because the assertion is a ratio of CPU to
+        // wall time and a short window reports one descheduling of this process as noise.
         Thread.sleep(forTimeInterval: 0.3)
         let before = Self.processCPUSeconds()
         Thread.sleep(forTimeInterval: 1.0)


### PR DESCRIPTION
This PR aims to make Socket tests faster and more stable, no source changes.

- Servers now bind port 0 and report `listeningPort`.
- Where the API doesn't expose the port a test helper is used to discover a free port and that is then used (`discoverFreeLoopbackPorts`). This is still racy, but avoids most collisions and issues when hanging tests have the port.
- `TCPClientHarness.init` reports a start failure instead of dropping it with `try?`, so a bind failure no longer surfaces later as an unexplained timeout.
- The refused-connection test asserts from its recorded state history rather than an inverted expectation, which XCTest can only satisfy by waiting out the whole timeout (locally 0.002s against 5.003s).
- The split-send server blocks on the peer's FIN instead of a one second sleep.
- The interface test which previously exhausted all FDs on the system now lowers its own `RLIMIT_NOFILE` instead of opening sockets until the kernel refuses. This was probably a cause of a reasonable amount of test flakiness and was slow. (locally 17s to under a millisecond).
- Three waits are deliberately kept, each now commented with rationale