### PR TITLE
Add Sendability to various members of Parameters

### DIFF
--- a/Sources/SwiftNetwork/Parameters/Parameters.swift
+++ b/Sources/SwiftNetwork/Parameters/Parameters.swift
@@ -46,7 +46,7 @@ public struct Parameters: Hashable, CustomStringConvertible {
         }
     }
 
-    public enum MultipathServiceType: UInt8, Hashable, CustomStringConvertible {
+    public enum MultipathServiceType: UInt8, Hashable, CustomStringConvertible, Sendable {
         case disabled = 0
         case handover = 1
         case interactive = 2
@@ -66,7 +66,7 @@ public struct Parameters: Hashable, CustomStringConvertible {
         }
     }
 
-    public enum ExpiredDNSBehavior: Hashable, CustomStringConvertible {
+    public enum ExpiredDNSBehavior: Hashable, CustomStringConvertible, Sendable {
         /// Let the system determine whether or not to allow expired DNS answers
         case systemDefault
         /// Explicitly allow the use of expired DNS answers
@@ -87,7 +87,7 @@ public struct Parameters: Hashable, CustomStringConvertible {
         }
     }
 
-    public enum ServiceClass: UInt8, CustomStringConvertible {
+    public enum ServiceClass: UInt8, CustomStringConvertible, Sendable {
         /// Default priority traffic
         case bestEffort = 0
         /// Bulk traffic, or traffic that can be de-prioritized behind foreground traffic

--- a/Sources/SwiftNetwork/Parameters/PathParameters.swift
+++ b/Sources/SwiftNetwork/Parameters/PathParameters.swift
@@ -29,7 +29,7 @@ internal import os
 
 @available(Network 0.1.0, *)
 struct PathParameters: Hashable, CustomStringConvertible {
-    struct ProcessPathValue: Hashable {
+    struct ProcessPathValue: Hashable, Sendable {
         // Parameters that influence path selection for process delegation, by value, that
         // can be compared and copied.
         // These items are used for compatibility evaluation for most modes.
@@ -70,7 +70,7 @@ struct PathParameters: Hashable, CustomStringConvertible {
         #endif
     }
 
-    struct PathValue: Hashable {
+    struct PathValue: Hashable, Sendable {
         // Parameters that influence path selection, by value, that can be compared and copied
         // These items are used for compatibility evaluation
         var trafficClass: UInt32 = 0
@@ -135,7 +135,7 @@ struct PathParameters: Hashable, CustomStringConvertible {
         }
     }
 
-    struct JoinablePathValue: Hashable {
+    struct JoinablePathValue: Hashable, Sendable {
         // Parameters that influence path selection but do not influence compatibility when joining,
         // by value, that can be compared and copied
         // These items are not used for compatibility evaluation for joining protocol stacks.
@@ -229,12 +229,65 @@ struct PathParameters: Hashable, CustomStringConvertible {
             func hash(into hasher: inout Hasher) {
                 hasher.combine(storage)
             }
-        }
-        var backing: InterfacePreferenceValuesBacking?
 
-        mutating func setupBacking() {
+            init() {}
+
+            init(storage: Storage) {
+                self.storage = storage
+            }
+
+            func copy() -> InterfacePreferenceValuesBacking {
+                .init(storage: storage)
+            }
+        }
+        private var backing: InterfacePreferenceValuesBacking?
+
+        /// Guarantees a backing that this value uniquely owns, allocating one if absent and copying
+        /// it first if it is shared.
+        ///
+        /// Every mutating path must go through here. Mutating `backing` directly would let a write
+        /// land on storage another copy can see, which is what the copy-on-write is preventing.
+        private mutating func ensureUniquelyReferencedBacking() {
             if self.backing == nil {
                 self.backing = InterfacePreferenceValuesBacking()
+            } else if !isKnownUniquelyReferenced(&self.backing) {
+                self.backing = self.backing?.copy()
+            }
+        }
+
+        var requiredInterface: Interface? {
+            get { self.backing?.storage.requiredInterface }
+            set {
+                self.ensureUniquelyReferencedBacking()
+                self.backing!.storage.requiredInterface = newValue
+            }
+        }
+        var prohibitedInterfaceTypes: Deque<InterfaceType>? {
+            get { self.backing?.storage.prohibitedInterfaceTypes }
+            set {
+                self.ensureUniquelyReferencedBacking()
+                self.backing!.storage.prohibitedInterfaceTypes = newValue
+            }
+        }
+        var prohibitedInterfaceSubtypes: Deque<InterfaceSubtype>? {
+            get { self.backing?.storage.prohibitedInterfaceSubtypes }
+            set {
+                self.ensureUniquelyReferencedBacking()
+                self.backing!.storage.prohibitedInterfaceSubtypes = newValue
+            }
+        }
+        var preferredInterfaceSubtypes: Deque<InterfaceSubtype>? {
+            get { self.backing?.storage.preferredInterfaceSubtypes }
+            set {
+                self.ensureUniquelyReferencedBacking()
+                self.backing!.storage.preferredInterfaceSubtypes = newValue
+            }
+        }
+        var prohibitedInterfaces: Deque<Interface>? {
+            get { self.backing?.storage.prohibitedInterfaces }
+            set {
+                self.ensureUniquelyReferencedBacking()
+                self.backing!.storage.prohibitedInterfaces = newValue
             }
         }
 
@@ -252,38 +305,33 @@ struct PathParameters: Hashable, CustomStringConvertible {
     var interfacePreferenceValues = InterfacePreferenceValues()
 
     var requiredInterface: Interface? {
-        get { interfacePreferenceValues.backing?.storage.requiredInterface }
+        get { self.interfacePreferenceValues.requiredInterface }
         set {
-            interfacePreferenceValues.setupBacking()
-            interfacePreferenceValues.backing!.storage.requiredInterface = newValue
+            self.interfacePreferenceValues.requiredInterface = newValue
         }
     }
     var prohibitedInterfaceTypes: Deque<InterfaceType>? {
-        get { interfacePreferenceValues.backing?.storage.prohibitedInterfaceTypes }
+        get { self.interfacePreferenceValues.prohibitedInterfaceTypes }
         set {
-            interfacePreferenceValues.setupBacking()
-            interfacePreferenceValues.backing!.storage.prohibitedInterfaceTypes = newValue
+            self.interfacePreferenceValues.prohibitedInterfaceTypes = newValue
         }
     }
     var prohibitedInterfaceSubtypes: Deque<InterfaceSubtype>? {
-        get { interfacePreferenceValues.backing?.storage.prohibitedInterfaceSubtypes }
+        get { self.interfacePreferenceValues.prohibitedInterfaceSubtypes }
         set {
-            interfacePreferenceValues.setupBacking()
-            interfacePreferenceValues.backing!.storage.prohibitedInterfaceSubtypes = newValue
+            self.interfacePreferenceValues.prohibitedInterfaceSubtypes = newValue
         }
     }
     var preferredInterfaceSubtypes: Deque<InterfaceSubtype>? {
-        get { interfacePreferenceValues.backing?.storage.preferredInterfaceSubtypes }
+        get { self.interfacePreferenceValues.preferredInterfaceSubtypes }
         set {
-            interfacePreferenceValues.setupBacking()
-            interfacePreferenceValues.backing!.storage.preferredInterfaceSubtypes = newValue
+            self.interfacePreferenceValues.preferredInterfaceSubtypes = newValue
         }
     }
     var prohibitedInterfaces: Deque<Interface>? {
-        get { interfacePreferenceValues.backing?.storage.prohibitedInterfaces }
+        get { self.interfacePreferenceValues.prohibitedInterfaces }
         set {
-            interfacePreferenceValues.setupBacking()
-            interfacePreferenceValues.backing!.storage.prohibitedInterfaces = newValue
+            self.interfacePreferenceValues.prohibitedInterfaces = newValue
         }
     }
     #if NETWORK_PRIVATE || NETWORK_DRIVERKIT
@@ -366,6 +414,10 @@ struct PathParameters: Hashable, CustomStringConvertible {
 
     init() {}
 }
+
+// @unchecked Sendable because access is controlled by getters and copy-on-write setters giving this value semantics.
+@available(Network 0.1.0, *)
+extension PathParameters.InterfacePreferenceValues: @unchecked Sendable {}
 
 // MARK: - Copying and comparing
 @available(Network 0.1.0, *)

--- a/Sources/SwiftNetwork/Parameters/PathParameters.swift
+++ b/Sources/SwiftNetwork/Parameters/PathParameters.swift
@@ -239,65 +239,81 @@ struct PathParameters: Hashable, CustomStringConvertible {
             func copy() -> InterfacePreferenceValuesBacking {
                 .init(storage: storage)
             }
-        }
-        private var backing: InterfacePreferenceValuesBacking?
 
-        /// Guarantees a backing that this value uniquely owns, allocating one if absent and copying
-        /// it first if it is shared.
+            /// The default backing, shared by every value not yet written to.
+            ///
+            /// Most values never set a preference at all, so they should not pay for a heap
+            /// allocation. Sharing one instance means a value only allocates once it is written to,
+            /// and optimized builds make the shared instance immortal, so copying a default value touches
+            /// no refcount.
+            ///
+            /// It must stay a `static let` of one instance. Holding that reference forever is what
+            /// makes `isKnownUniquelyReferenced` false for it, so a first write copies rather than
+            /// mutating the default every other value reads; it is also why `nonisolated(unsafe)` is
+            /// sound, since nothing ever mutates it. A computed property would allocate one per value,
+            /// defeating the point.
+            nonisolated(unsafe) static let empty = InterfacePreferenceValuesBacking()
+        }
+        private var backing: InterfacePreferenceValuesBacking = .empty
+
+        /// Guarantees a backing that this value uniquely owns, copying it first if it is shared.
         ///
         /// Every mutating path must go through here. Mutating `backing` directly would let a write
         /// land on storage another copy can see, which is what the copy-on-write is preventing.
         private mutating func ensureUniquelyReferencedBacking() {
-            if self.backing == nil {
-                self.backing = InterfacePreferenceValuesBacking()
-            } else if !isKnownUniquelyReferenced(&self.backing) {
-                self.backing = self.backing?.copy()
+            if !isKnownUniquelyReferenced(&self.backing) {
+                self.backing = self.backing.copy()
+            }
+        }
+
+        /// The stored preferences.
+        ///
+        /// Prefer the per-field accessors on `PathParameters`.
+        var _storage: InterfacePreferenceValuesBacking.Storage {
+            get { self.backing.storage }
+            // Per-field writes come through here rather than `set`, mutating the storage where it
+            // lives instead of copying the whole struct out and back. That copy costs time in
+            // proportion to the number of fields, whether or not they hold anything.
+            _modify {
+                self.ensureUniquelyReferencedBacking()
+                yield &self.backing.storage
+            }
+            set {
+                self.ensureUniquelyReferencedBacking()
+                self.backing.storage = newValue
             }
         }
 
         var requiredInterface: Interface? {
-            get { self.backing?.storage.requiredInterface }
-            set {
-                self.ensureUniquelyReferencedBacking()
-                self.backing!.storage.requiredInterface = newValue
-            }
+            get { self._storage.requiredInterface }
+            set { self._storage.requiredInterface = newValue }
         }
         var prohibitedInterfaceTypes: Deque<InterfaceType>? {
-            get { self.backing?.storage.prohibitedInterfaceTypes }
-            set {
-                self.ensureUniquelyReferencedBacking()
-                self.backing!.storage.prohibitedInterfaceTypes = newValue
-            }
+            get { self._storage.prohibitedInterfaceTypes }
+            set { self._storage.prohibitedInterfaceTypes = newValue }
         }
         var prohibitedInterfaceSubtypes: Deque<InterfaceSubtype>? {
-            get { self.backing?.storage.prohibitedInterfaceSubtypes }
-            set {
-                self.ensureUniquelyReferencedBacking()
-                self.backing!.storage.prohibitedInterfaceSubtypes = newValue
-            }
+            get { self._storage.prohibitedInterfaceSubtypes }
+            set { self._storage.prohibitedInterfaceSubtypes = newValue }
         }
         var preferredInterfaceSubtypes: Deque<InterfaceSubtype>? {
-            get { self.backing?.storage.preferredInterfaceSubtypes }
-            set {
-                self.ensureUniquelyReferencedBacking()
-                self.backing!.storage.preferredInterfaceSubtypes = newValue
-            }
+            get { self._storage.preferredInterfaceSubtypes }
+            set { self._storage.preferredInterfaceSubtypes = newValue }
         }
         var prohibitedInterfaces: Deque<Interface>? {
-            get { self.backing?.storage.prohibitedInterfaces }
-            set {
-                self.ensureUniquelyReferencedBacking()
-                self.backing!.storage.prohibitedInterfaces = newValue
-            }
+            get { self._storage.prohibitedInterfaces }
+            set { self._storage.prohibitedInterfaces = newValue }
         }
 
         init() {}
 
         init(deepCopy other: InterfacePreferenceValues) {
-            if let existing = other.backing?.storage {
-                let newBacking = InterfacePreferenceValuesBacking()
-                newBacking.storage = existing
-                self.backing = newBacking
+            // Copying the storage struct is a full copy here: every field is a value type, so
+            // there is nothing behind it left shared. A value still on `empty` has nothing to
+            // copy, and skipping the assignment leaves this one on `empty` too rather than
+            // allocating a backing that holds nothing.
+            if other.backing !== InterfacePreferenceValuesBacking.empty {
+                self._storage = other.backing.storage
             }
         }
     }
@@ -306,33 +322,23 @@ struct PathParameters: Hashable, CustomStringConvertible {
 
     var requiredInterface: Interface? {
         get { self.interfacePreferenceValues.requiredInterface }
-        set {
-            self.interfacePreferenceValues.requiredInterface = newValue
-        }
+        set { self.interfacePreferenceValues.requiredInterface = newValue }
     }
     var prohibitedInterfaceTypes: Deque<InterfaceType>? {
         get { self.interfacePreferenceValues.prohibitedInterfaceTypes }
-        set {
-            self.interfacePreferenceValues.prohibitedInterfaceTypes = newValue
-        }
+        set { self.interfacePreferenceValues.prohibitedInterfaceTypes = newValue }
     }
     var prohibitedInterfaceSubtypes: Deque<InterfaceSubtype>? {
         get { self.interfacePreferenceValues.prohibitedInterfaceSubtypes }
-        set {
-            self.interfacePreferenceValues.prohibitedInterfaceSubtypes = newValue
-        }
+        set { self.interfacePreferenceValues.prohibitedInterfaceSubtypes = newValue }
     }
     var preferredInterfaceSubtypes: Deque<InterfaceSubtype>? {
         get { self.interfacePreferenceValues.preferredInterfaceSubtypes }
-        set {
-            self.interfacePreferenceValues.preferredInterfaceSubtypes = newValue
-        }
+        set { self.interfacePreferenceValues.preferredInterfaceSubtypes = newValue }
     }
     var prohibitedInterfaces: Deque<Interface>? {
         get { self.interfacePreferenceValues.prohibitedInterfaces }
-        set {
-            self.interfacePreferenceValues.prohibitedInterfaces = newValue
-        }
+        set { self.interfacePreferenceValues.prohibitedInterfaces = newValue }
     }
     #if NETWORK_PRIVATE || NETWORK_DRIVERKIT
     var pathParametersPrivate = PathParametersPrivate()
@@ -373,22 +379,70 @@ struct PathParameters: Hashable, CustomStringConvertible {
             func hash(into hasher: inout Hasher) {
                 hasher.combine(storage)
             }
-        }
-        var backing: ProtocolValuesBacking?
 
-        mutating func setupBacking() {
-            if self.backing == nil {
-                self.backing = ProtocolValuesBacking()
+            init() {}
+
+            init(storage: Storage) {
+                self.storage = storage
+            }
+
+            // Copy-on-write only has to unshare the storage struct; `init(deepCopy:)` is what unshares
+            // the protocol options it points at.
+            func copy() -> ProtocolValuesBacking {
+                .init(storage: storage)
+            }
+
+            /// The default backing, shared by every value not yet written to.
+            ///
+            /// Most values never set a preference at all, so they should not pay for a heap
+            /// allocation. Sharing one instance means a value only allocates once it is written to,
+            /// and optimized builds make the shared instance immortal, so copying a default value touches
+            /// no refcount.
+            ///
+            /// It must stay a `static let` of one instance. Holding that reference forever is what
+            /// makes `isKnownUniquelyReferenced` false for it, so a first write copies rather than
+            /// mutating the default every other value reads; it is also why `nonisolated(unsafe)` is
+            /// sound, since nothing ever mutates it. A computed property would allocate one per value,
+            /// defeating the point.
+            nonisolated(unsafe) static let empty = ProtocolValuesBacking()
+        }
+        private var backing: ProtocolValuesBacking = .empty
+
+        /// Guarantees a backing that this value uniquely owns, copying it first if it is shared.
+        ///
+        /// Every mutating path must go through here. Mutating `backing` directly would let a write
+        /// land on storage another copy can see, which is what the copy-on-write is preventing.
+        private mutating func ensureUniquelyReferencedBacking() {
+            if !isKnownUniquelyReferenced(&self.backing) {
+                self.backing = self.backing.copy()
+            }
+        }
+
+        /// The stored protocol values.
+        ///
+        /// Prefer the per-field accessors on `PathParameters`.
+        var _storage: ProtocolValuesBacking.Storage {
+            get { self.backing.storage }
+            // Per-field writes come through here rather than `set`, mutating the storage where it
+            // lives instead of copying the whole struct out and back. That copy costs time in
+            // proportion to the number of fields, whether or not they hold anything.
+            _modify {
+                self.ensureUniquelyReferencedBacking()
+                yield &self.backing.storage
+            }
+            set {
+                self.ensureUniquelyReferencedBacking()
+                self.backing.storage = newValue
             }
         }
 
         init() {}
 
         init(deepCopy other: ProtocolValues) {
-            if let existing = other.backing?.storage {
-                let newBacking = ProtocolValuesBacking()
-                newBacking.storage = ProtocolValuesBacking.Storage(deepCopy: existing)
-                self.backing = newBacking
+            // A value still on `empty` has nothing to copy; see the note on
+            // `InterfacePreferenceValues.init(deepCopy:)`.
+            if other.backing !== ProtocolValuesBacking.empty {
+                self._storage = ProtocolValuesBacking.Storage(deepCopy: other.backing.storage)
             }
         }
     }
@@ -396,17 +450,15 @@ struct PathParameters: Hashable, CustomStringConvertible {
     var protocolValues = ProtocolValues()
 
     var transportOptions: ProtocolStack.TransportProtocol? {
-        get { protocolValues.backing?.storage.transportOptions }
+        get { self.protocolValues._storage.transportOptions }
         set {
-            protocolValues.setupBacking()
-            protocolValues.backing!.storage.transportOptions = newValue
+            self.protocolValues._storage.transportOptions = newValue
         }
     }
     var internetOptions: ProtocolStack.InternetProtocol? {
-        get { protocolValues.backing?.storage.internetOptions }
+        get { self.protocolValues._storage.internetOptions }
         set {
-            protocolValues.setupBacking()
-            protocolValues.backing!.storage.internetOptions = newValue
+            self.protocolValues._storage.internetOptions = newValue
         }
     }
 

--- a/Tests/SwiftNetworkTests/SwiftNetworkPathParametersTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkPathParametersTests.swift
@@ -64,7 +64,7 @@ final class SwiftNetworkPathParametersTests: NetTestCase {
     // Reading must not allocate a backing. An absent backing and an allocated-but-empty one are not
     // equal, so a read that allocates would make two untouched values compare unequal.
     func testReadingAPreferenceDoesNotMakeValuesUnequal() {
-        var read = PathParameters()
+        let read = PathParameters()
         let untouched = PathParameters()
 
         XCTAssertNil(read.prohibitedInterfaceTypes)

--- a/Tests/SwiftNetworkTests/SwiftNetworkPathParametersTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkPathParametersTests.swift
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+#if canImport(SwiftNetwork)
+@_spi(Essentials) @testable import SwiftNetwork
+#endif
+
+@available(Network 0.1.0, *)
+final class SwiftNetworkPathParametersTests: NetTestCase {
+    // `PathParameters` has value semantics, so copies must be independent. Its interface preferences
+    // live behind a shared class, so without copy-on-write a write through one copy is visible
+    // through the other — callers would observe changes they never made.
+    func testWritingInterfacePreferenceDoesNotAffectACopy() {
+        var original = PathParameters()
+        original.prohibitedInterfaceTypes = [.wifi]
+
+        var copy = original
+        copy.prohibitedInterfaceTypes = [.cellular]
+
+        XCTAssertEqual(original.prohibitedInterfaceTypes, [.wifi], "original was mutated through the copy")
+        XCTAssertEqual(copy.prohibitedInterfaceTypes, [.cellular], "copy did not take the new value")
+    }
+
+    // The whole backing must be copied, not just the field being assigned; otherwise writing one
+    // field leaks every other field into the copy that shares the backing.
+    func testWritingOneFieldDoesNotLeakOthersIntoACopy() {
+        var original = PathParameters()
+        original.prohibitedInterfaceTypes = [.wifi]
+
+        var copy = original
+        copy.preferredInterfaceSubtypes = [.wifiAWDL]
+
+        XCTAssertNil(original.preferredInterfaceSubtypes, "unrelated field leaked into the original")
+        XCTAssertEqual(original.prohibitedInterfaceTypes, [.wifi], "original lost its own value")
+        XCTAssertEqual(copy.prohibitedInterfaceTypes, [.wifi], "copy did not inherit the original value")
+    }
+
+    // Mutating the original after a copy is taken must not write through to the copy either; the
+    // copy-on-write has to trigger whichever side is written first.
+    func testWritingTheOriginalDoesNotAffectAnEarlierCopy() {
+        var original = PathParameters()
+        original.prohibitedInterfaceTypes = [.wifi]
+
+        let copy = original
+        original.prohibitedInterfaceTypes = [.cellular]
+
+        XCTAssertEqual(copy.prohibitedInterfaceTypes, [.wifi], "copy was mutated through the original")
+        XCTAssertEqual(original.prohibitedInterfaceTypes, [.cellular], "original did not take the new value")
+    }
+
+    // Reading must not allocate a backing. An absent backing and an allocated-but-empty one are not
+    // equal, so a read that allocates would make two untouched values compare unequal.
+    func testReadingAPreferenceDoesNotMakeValuesUnequal() {
+        var read = PathParameters()
+        let untouched = PathParameters()
+
+        XCTAssertNil(read.prohibitedInterfaceTypes)
+        XCTAssertNil(read.requiredInterface)
+
+        XCTAssertEqual(read.interfacePreferenceValues, untouched.interfacePreferenceValues)
+    }
+}

--- a/Tests/SwiftNetworkTests/SwiftNetworkPathParametersTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkPathParametersTests.swift
@@ -14,8 +14,17 @@
 
 import XCTest
 
+// `Deque` supplies the array-literal initializer the preference fields are written with, so the
+// module declaring it has to be imported here even though nothing below names `Deque`.
+#if canImport(BasicContainers)
+import BasicContainers
+internal import DequeModule
+#endif
+
 #if canImport(SwiftNetwork)
-@_spi(Essentials) @testable import SwiftNetwork
+@_spi(Essentials) @_spi(ProtocolProvider) @testable import SwiftNetwork
+#elseif canImport(Network)
+@_spi(Essentials) @_spi(ProtocolProvider) @testable import Network
 #endif
 
 @available(Network 0.1.0, *)
@@ -61,8 +70,8 @@ final class SwiftNetworkPathParametersTests: NetTestCase {
         XCTAssertEqual(original.prohibitedInterfaceTypes, [.cellular], "original did not take the new value")
     }
 
-    // Reading must not allocate a backing. An absent backing and an allocated-but-empty one are not
-    // equal, so a read that allocates would make two untouched values compare unequal.
+    // Two freshly built values must read their defaults and compare equal; a write that landed on
+    // the shared default backing in place would break both for every value built after it.
     func testReadingAPreferenceDoesNotMakeValuesUnequal() {
         let read = PathParameters()
         let untouched = PathParameters()
@@ -71,5 +80,56 @@ final class SwiftNetworkPathParametersTests: NetTestCase {
         XCTAssertNil(read.requiredInterface)
 
         XCTAssertEqual(read.interfacePreferenceValues, untouched.interfacePreferenceValues)
+        XCTAssertEqual(read.protocolValues, untouched.protocolValues)
+    }
+
+    // A value set back to its defaults must equal one never written to, and hash the same; otherwise
+    // `NWParameters` breaks its `NSObject` hash contract, and it is reachable as an `NSDictionary` key.
+    func testPreferenceSetBackToDefaultEqualsUntouched() {
+        var reset = PathParameters()
+        reset.prohibitedInterfaceTypes = [.wifi]
+        reset.prohibitedInterfaceTypes = nil
+
+        let untouched = PathParameters()
+
+        XCTAssertEqual(reset.interfacePreferenceValues, untouched.interfacePreferenceValues)
+        XCTAssertEqual(
+            reset.interfacePreferenceValues.hashValue,
+            untouched.interfacePreferenceValues.hashValue,
+            "equal values must hash equally"
+        )
+    }
+
+    // The same for `ProtocolValues`, which is a separate class-backed store.
+    func testTransportOptionsSetBackToNilEqualsUntouched() {
+        var reset = PathParameters()
+        reset.transportOptions = .udp(
+            ProtocolOptions<UDPProtocol>(protocolIdentifier: UDPProtocol.identifier, perProtocolOptions: nil)
+        )
+        reset.transportOptions = nil
+
+        let untouched = PathParameters()
+
+        XCTAssertEqual(reset.protocolValues, untouched.protocolValues)
+        XCTAssertEqual(
+            reset.protocolValues.hashValue,
+            untouched.protocolValues.hashValue,
+            "equal values must hash equally"
+        )
+    }
+
+    // Protocol options are held by a second class-backed store, `ProtocolValues`, which needs the same
+    // copy-on-write; otherwise a copy clearing its transport options clears the original's too.
+    func testWritingTransportOptionsDoesNotAffectACopy() {
+        var original = PathParameters()
+        original.transportOptions = .udp(
+            ProtocolOptions<UDPProtocol>(protocolIdentifier: UDPProtocol.identifier, perProtocolOptions: nil)
+        )
+
+        var copy = original
+        copy.transportOptions = nil
+
+        XCTAssertNotNil(original.transportOptions, "original was cleared through the copy")
+        XCTAssertNil(copy.transportOptions, "copy did not take the new value")
     }
 }


### PR DESCRIPTION
Some of the memberso of the `Parameters` object could be marked as trivially sendable; `PathParameters` needed some more work to give it value semantics as the
class-backed-struct pattern implied.