### PR TITLE
Workflows: enable iOS build target.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,6 +14,9 @@ jobs:
       enable_macos_checks: true
       macos_exclude_xcode_versions: "[{\"xcode_version\": \"swift_6.1\"}, {\"xcode_version\": \"swift_6.2\"}]"
       macos_build_command: bash .github/workflows/scripts/ci-macos.sh
+      enable_ios_checks: true
+      ios_host_exclude_xcode_versions: "[{\"xcode_version\": \"swift_6.1\"}, {\"xcode_version\": \"swift_6.2\"}]"
+      ios_build_command: bash .github/workflows/scripts/ci-ios.sh
       enable_linux_checks: true
       linux_swift_versions: '["nightly-6.3", "6.3"]'
       linux_build_command: bash .github/workflows/scripts/ci-linux.sh

--- a/.github/workflows/scripts/ci-ios.sh
+++ b/.github/workflows/scripts/ci-ios.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -u
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=ci-support.sh
+. "${script_dir}/ci-support.sh"
+
+xcodebuild_step 'iOS build' 'generic/platform=ios'
+
+ci_finish

--- a/.github/workflows/scripts/ci-macos.sh
+++ b/.github/workflows/scripts/ci-macos.sh
@@ -13,8 +13,8 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-# Builds the package for every Apple platform with xcodebuild, then runs the
-# test suite on macOS.
+# Builds the package for most Apple platforms with xcodebuild, then runs the
+# test suite on macOS.  Also see ci-ios.sh.
 #
 # Usage: ci-macos.sh [swift flags...]
 #
@@ -28,16 +28,8 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=ci-support.sh
 . "${script_dir}/ci-support.sh"
 
-scheme='swift-network-evolution-Package'
-
-# xcodebuild_step <name> <destination>
-xcodebuild_step() {
-    ci_run "$1" /usr/bin/xcodebuild -quiet -scheme "${scheme}" -destination "$2" build
-}
-
 xcodebuild_step 'macOS build' 'generic/platform=macos,variant=macos'
 xcodebuild_step 'Mac Catalyst build' 'generic/platform=macos,variant=Mac Catalyst'
-xcodebuild_step 'iOS build' 'generic/platform=ios'
 xcodebuild_step 'watchOS build' 'generic/platform=watchos'
 xcodebuild_step 'tvOS build' 'generic/platform=tvos'
 xcodebuild_step 'visionOS build' 'generic/platform=visionos'

--- a/.github/workflows/scripts/ci-support.sh
+++ b/.github/workflows/scripts/ci-support.sh
@@ -64,3 +64,9 @@ ci_finish() {
 
     exit "${ci_exit_code}"
 }
+
+# xcodebuild_step <name> <destination>
+xcodebuild_step() {
+    local scheme='swift-network-evolution-Package'
+    ci_run "$1" /usr/bin/xcodebuild -quiet -scheme "${scheme}" -destination "$2" build
+}

--- a/.github/workflows/scripts/ci-support.sh
+++ b/.github/workflows/scripts/ci-support.sh
@@ -68,5 +68,5 @@ ci_finish() {
 # xcodebuild_step <name> <destination>
 xcodebuild_step() {
     local scheme='swift-network-evolution-Package'
-    ci_run "$1" /usr/bin/xcodebuild -quiet -scheme "${scheme}" -destination "$2" build
+    ci_run "$1" /usr/bin/xcodebuild -scheme "${scheme}" -destination "$2" build
 }


### PR DESCRIPTION
Separate the iOS build out of the macOS build/test target into its own iOS build target.