### PR TITLE
SwiftQUIC: PERF: Reduce exclusive access checks by 1.1 gigacycles in the send path

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -99,7 +99,7 @@ let package = Package(
             name: "DISABLE_SHIM_CRYPTO_SPAN_APIS",
             description: "Disable backwards compatible crypto shim for performance sensitive cases"
         ),
-        .default(enabledTraits: []),
+        .default(enabledTraits: ["DisableDebugLogging", "DisableErrorLogging"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),

--- a/Sources/SwiftNetwork/QUIC/PMTUD.swift
+++ b/Sources/SwiftNetwork/QUIC/PMTUD.swift
@@ -186,6 +186,14 @@ struct PMTUDState: ~Copyable {
 
     mutating func canSendProbe(on path: QUICPath) -> Bool {
         let connection = path.parentProtocol
+        let hasPendingItems = connection.withPendingItemsForKeyState { pendingItems in
+            pendingItems.hasPendingItems
+        }
+        return canSendProbe(on: path, hasPendingItems: hasPendingItems)
+    }
+
+    mutating func canSendProbe(on path: QUICPath, hasPendingItems: Bool) -> Bool {
+        let connection = path.parentProtocol
         guard enabled, canProbe, !searchCompleted else {
             path.log.datapath("Not probing PMTUD, not in correct state")
             return false
@@ -206,9 +214,6 @@ struct PMTUDState: ~Copyable {
             return false
         }
 
-        let hasPendingItems = connection.withPendingItemsForKeyState { pendingItems in
-            pendingItems.hasPendingItems
-        }
         guard !hasPendingItems else {
             path.log.datapath("Not probing PMTUD, already have pending items")
             return false
@@ -328,8 +333,17 @@ struct PMTUDState: ~Copyable {
     }
 
     mutating func sendProbe(on path: QUICPath) -> NetworkUniqueDeque<SentPacketRecord> {
+        let connection = path.parentProtocol
+        return sendProbe(on: path, applicationPendingItems: &connection.applicationPendingItems)
+    }
+
+    // Used in the send path when the caller has ownership of applicationPendingItems already
+    mutating func sendProbe(
+        on path: QUICPath,
+        applicationPendingItems: inout PendingItems
+    ) -> NetworkUniqueDeque<SentPacketRecord> {
         pendingTransmission = false
-        guard canSendProbe(on: path) else {
+        guard canSendProbe(on: path, hasPendingItems: applicationPendingItems.hasPendingItems) else {
             return .init()
         }
 
@@ -340,11 +354,9 @@ struct PMTUDState: ~Copyable {
         }
         let probeMSS = (nextProbeMTU - ipUDPHeaderSize)
 
-        connection.withPendingItemsForKeyState { pendingItems in
-            pendingItems.ping = true
-            pendingItems.pmtudProbeMSS = probeMSS
-            pendingItems.paddingApproach = .padToEnd
-        }
+        applicationPendingItems.ping = true
+        applicationPendingItems.pmtudProbeMSS = probeMSS
+        applicationPendingItems.paddingApproach = .padToEnd
 
         // The probe is queued but not sent yet. A probe can be driven by the PMTUD
         // timer rather than by an application write, in which case nothing else
@@ -354,6 +366,7 @@ struct PMTUDState: ~Copyable {
         var discardInitialRecoveryState = false
         let sentPackets = connection.sendFramesFromRecovery(
             on: path,
+            applicationPendingItems: &applicationPendingItems,
             discardInitialRecoveryState: &discardInitialRecoveryState
         )
         guard !sentPackets.isEmpty else {

--- a/Sources/SwiftNetwork/QUIC/PMTUD.swift
+++ b/Sources/SwiftNetwork/QUIC/PMTUD.swift
@@ -179,8 +179,8 @@ struct PMTUDState: ~Copyable {
         )
 
         updateProbeSize(on: path)
-        connection.recordSentPackets {
-            sendProbe(on: path)
+        connection.recordSentPackets { sentPackets in
+            sendProbe(on: path, sentPackets: &sentPackets)
         }
     }
 
@@ -254,8 +254,8 @@ struct PMTUDState: ~Copyable {
         } else if PMTUDState.minimumMTU <= nextMTU && nextMTU < currentPathMTU {
             path.log.info("Packet too big MTU < current path MTU \(currentPathMTU)")
             packetTooBigMTU = (packetTooBigMTU == 0) ? nextMTU : min(packetTooBigMTU, nextMTU)
-            path.parentProtocol.recordSentPackets {
-                enterBlackholeDetection(on: path)
+            path.parentProtocol.recordSentPackets { sentPackets in
+                enterBlackholeDetection(on: path, sentPackets: &sentPackets)
             }
         } else if currentPathMTU < nextMTU && nextMTU < probedMTU {
             path.log.info("Current path MTU < packet too big MTU size < probed MTU")
@@ -324,27 +324,39 @@ struct PMTUDState: ~Copyable {
         }
     }
 
-    mutating func ptoEvent(on path: QUICPath, ptoCount: Int) -> NetworkUniqueDeque<SentPacketRecord> {
+    mutating func ptoEvent(
+        on path: QUICPath,
+        ptoCount: Int,
+        sentPackets: inout NetworkUniqueDeque<SentPacketRecord>
+    ) {
         guard !path.isFlowControlled,
             ptoCount > PMTUDState.blackholeThreshold,
             enabled
-        else { return .init() }
-        return enterBlackholeDetection(on: path)
+        else { return }
+        enterBlackholeDetection(on: path, sentPackets: &sentPackets)
     }
 
-    mutating func sendProbe(on path: QUICPath) -> NetworkUniqueDeque<SentPacketRecord> {
+    mutating func sendProbe(on path: QUICPath, sentPackets: inout NetworkUniqueDeque<SentPacketRecord>) {
         let connection = path.parentProtocol
-        return sendProbe(on: path, applicationPendingItems: &connection.applicationPendingItems)
+        sendProbe(
+            on: path,
+            sentPackets: &sentPackets,
+            initialPendingItems: &connection.initialPendingItems,
+            handshakePendingItems: &connection.handshakePendingItems,
+            applicationPendingItems: &connection.applicationPendingItems
+        )
     }
 
-    // Used in the send path when the caller has ownership of applicationPendingItems already
     mutating func sendProbe(
         on path: QUICPath,
+        sentPackets: inout NetworkUniqueDeque<SentPacketRecord>,
+        initialPendingItems: inout PendingItems,
+        handshakePendingItems: inout PendingItems,
         applicationPendingItems: inout PendingItems
-    ) -> NetworkUniqueDeque<SentPacketRecord> {
+    ) {
         pendingTransmission = false
         guard canSendProbe(on: path, hasPendingItems: applicationPendingItems.hasPendingItems) else {
-            return .init()
+            return
         }
 
         let connection = path.parentProtocol
@@ -361,24 +373,30 @@ struct PMTUDState: ~Copyable {
         // The probe is queued but not sent yet. A probe can be driven by the PMTUD
         // timer rather than by an application write, in which case nothing else
         // reports the connection active before the packet is transmitted.
-        connection.checkConnectionIdle()
+        connection.checkConnectionIdle(
+            initialPendingItemsHasPendingItems: initialPendingItems.hasPendingItems,
+            handshakePendingItemsHasPendingItems: handshakePendingItems.hasPendingItems,
+            applicationPendingItemsHasPendingItems: applicationPendingItems.hasPendingItems
+        )
 
         var discardInitialRecoveryState = false
-        let sentPackets = connection.sendFramesFromRecovery(
+        let countBeforeSend = sentPackets.count
+        connection.sendFramesFromRecovery(
             on: path,
+            sentPackets: &sentPackets,
+            initialPendingItems: &initialPendingItems,
+            handshakePendingItems: &handshakePendingItems,
             applicationPendingItems: &applicationPendingItems,
             discardInitialRecoveryState: &discardInitialRecoveryState
         )
-        guard !sentPackets.isEmpty else {
+        guard sentPackets.count > countBeforeSend else {
             path.log.error("Failed to send PMTUD probe packet")
-            return sentPackets
+            return
         }
 
         path.log.info("Probe for MTU \(nextProbeMTU) sent")
         canProbe = false
         probedMTU = nextProbeMTU
-
-        return sentPackets
     }
 
     mutating func stop(on path: QUICPath) {
@@ -389,22 +407,25 @@ struct PMTUDState: ~Copyable {
         }
     }
 
-    mutating func tryToSend(on path: QUICPath) -> NetworkUniqueDeque<SentPacketRecord> {
-        guard pendingTransmission else { return .init() }
-        return sendProbe(on: path)
+    mutating func tryToSend(on path: QUICPath, sentPackets: inout NetworkUniqueDeque<SentPacketRecord>) {
+        guard pendingTransmission else { return }
+        sendProbe(on: path, sentPackets: &sentPackets)
     }
 
     mutating func timerFired(timeNow: NetworkClock.Instant, path: QUICPath) {
         path.log.debug("PMTUD timer fired")
         self.searchCompleted = false
         self.updateProbeSize(on: path)
-        path.parentProtocol.recordSentPackets {
-            sendProbe(on: path)
+        path.parentProtocol.recordSentPackets { sentPackets in
+            sendProbe(on: path, sentPackets: &sentPackets)
         }
     }
 
-    private mutating func enterBlackholeDetection(on path: QUICPath) -> NetworkUniqueDeque<SentPacketRecord> {
-        guard enabled else { return .init() }
+    private mutating func enterBlackholeDetection(
+        on path: QUICPath,
+        sentPackets: inout NetworkUniqueDeque<SentPacketRecord>
+    ) {
+        guard enabled else { return }
         path.log.info("Entering blackhole detection, setting path MTU to \(PMTUDState.minimumMTU)")
         currentPathMTU = PMTUDState.minimumMTU
         searchCompleted = false
@@ -419,7 +440,7 @@ struct PMTUDState: ~Copyable {
 
         // Reset probe size
         updateProbeSize(on: path)
-        return sendProbe(on: path)
+        sendProbe(on: path, sentPackets: &sentPackets)
     }
 
     private func findNextMTU(mtu: Int, findLarger: Bool) -> Int {

--- a/Sources/SwiftNetwork/QUIC/PacketBuilder.swift
+++ b/Sources/SwiftNetwork/QUIC/PacketBuilder.swift
@@ -62,7 +62,9 @@ extension Packet {
         availableCongestionWindow: UInt64,
         token: [UInt8]?,
         stats: inout Statistics,
-        version: QUICVersion
+        version: QUICVersion,
+        isServer: Bool,
+        testSendingShortPackets: Bool
     ) throws(QUICError) -> Packet {
         let longHeader = Packet.requiresLongHeader(keyState: keyState)
         guard let dcid = path.dcid else {
@@ -109,7 +111,7 @@ extension Packet {
         let lengthBeforeWritingHeader = outboundFrame.unclaimedLength
 
         var headerVersion: UInt32 = version.rawValue
-        if !connection.isServer, connection.forceUnsupportedClientVersion, keyState == .initial {
+        if !isServer, connection.forceUnsupportedClientVersion, keyState == .initial {
             // For testing support only (should only run once per test connection)
             headerVersion = QUICVersion.unsupportedVersion
             connection.forceUnsupportedClientVersion = false
@@ -159,7 +161,7 @@ extension Packet {
                 availableCongestionWindow: remainingCongestionWindow,
                 isAckEliciting: &isAckEliciting,
                 isInFlightEligible: &isInFlightEligible,
-                maximumFrameCount: connection.testSendingShortPackets && packet.longHeader ? 1 : nil,
+                maximumFrameCount: testSendingShortPackets && packet.longHeader ? 1 : nil,
                 shorthandFrames: &shorthandFrames
             )
         } catch {

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -3002,6 +3002,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             delayedACK: delayedACK,
             sentPackets: &sentPackets,
             recovery: &recovery,
+            initialPendingItems: &initialPendingItems,
+            handshakePendingItems: &handshakePendingItems,
             applicationPendingItems: &applicationPendingItems
         )
     }
@@ -3012,6 +3014,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         delayedACK: Bool = false,
         sentPackets: inout NetworkUniqueDeque<SentPacketRecord>,
         recovery: inout Recovery,
+        initialPendingItems: inout PendingItems,
+        handshakePendingItems: inout PendingItems,
         applicationPendingItems: inout PendingItems
     ) -> Bool {
         // Make sure there are packets to send
@@ -3034,7 +3038,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         }
         sentPackets.reserveCapacity(capacityForPacketNumberSpace(applicationPendingItems: &applicationPendingItems))
         let success: Bool
-        if initialKeysDiscarded && isHandshakeConfirmed {
+        var discardInitialRecoveryState = false
+        if initialKeysDiscarded && isHandshakeConfirmed && applicationPendingItems.hasPendingItems {
             // Once the handshake is complete only
             // send application data from then on out.
             success = sendApplicationFrames(
@@ -3045,7 +3050,6 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
                 applicationPendingItems: &applicationPendingItems
             )
         } else {
-            var discardInitialRecoveryState = false
             success = sendFramesInternal(
                 path: path,
                 ignoreCongestionWindow: ignoreCongestionWindow,
@@ -3056,19 +3060,26 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
                 applicationPendingItems: &applicationPendingItems,
                 discardInitialRecoveryState: &discardInitialRecoveryState
             )
-            if discardInitialRecoveryState {
-                recovery.resetPNSpace(packetNumberSpace: .initial, connection: self)
-                recovery.resetPTOCount(path: path)
-            }
         }
 
         // Trigger PMTUD if necessary.
-        var pmtudPackets = path.pmtudState.sendProbe(on: path, applicationPendingItems: &applicationPendingItems)
-        while let pmtudPacket = pmtudPackets.popFirst() {
-            sentPackets.append(pmtudPacket)
-        }
+        path.pmtudState.sendProbe(
+            on: path,
+            sentPackets: &sentPackets,
+            initialPendingItems: &initialPendingItems,
+            handshakePendingItems: &handshakePendingItems,
+            applicationPendingItems: &applicationPendingItems
+        )
+        // Record the newly-built packets (including any Initial-space packet from this same
+        // call) into recovery before discarding Initial recovery state, otherwise that packet's
+        // bytesInFlight accounting is added after the space is reset and can never be undone
+        // since Initial keys are already dropped by this point.
         recovery.recordSentPackets(&sentPackets, connection: self)
         self.shrinkSentPacketsIfNecessary(sentPackets: &sentPackets)
+        if discardInitialRecoveryState {
+            recovery.resetPNSpace(packetNumberSpace: .initial, connection: self)
+            recovery.resetPTOCount(path: path)
+        }
         return success
     }
 
@@ -3142,9 +3153,35 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         return sentPackets
     }
 
-    func recordSentPackets(_ block: () -> NetworkUniqueDeque<SentPacketRecord>) {
-        var sentPackets = block()
-        recovery.recordSentPackets(&sentPackets, connection: self)
+    // Sends with pending items attached, appending into a caller-provided buffer to avoid
+    // allocating a fresh deque per call.
+    @discardableResult
+    func sendFramesFromRecovery(
+        on path: QUICPath,
+        ignoreCongestionWindow: Bool = false,
+        retransmission: Bool = false,
+        sentPackets: inout NetworkUniqueDeque<SentPacketRecord>,
+        initialPendingItems: inout PendingItems,
+        handshakePendingItems: inout PendingItems,
+        applicationPendingItems: inout PendingItems,
+        discardInitialRecoveryState: inout Bool
+    ) -> Bool {
+        sendFramesInternal(
+            path: path,
+            ignoreCongestionWindow: ignoreCongestionWindow,
+            retransmission: retransmission,
+            sentPackets: &sentPackets,
+            initialPendingItems: &initialPendingItems,
+            handshakePendingItems: &handshakePendingItems,
+            applicationPendingItems: &applicationPendingItems,
+            discardInitialRecoveryState: &discardInitialRecoveryState
+        )
+    }
+
+    func recordSentPackets(_ block: (inout NetworkUniqueDeque<SentPacketRecord>) -> Void) {
+        block(&self.sentPackets)
+        recovery.recordSentPackets(&self.sentPackets, connection: self)
+        self.shrinkSentPacketsIfNecessary(sentPackets: &self.sentPackets)
     }
 
     public func handleOutboundRoomAvailableEvent(path pathID: MultiplexingPathIdentifier) {
@@ -3242,6 +3279,10 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         datagramBatch: inout FrameArray,
         outboundFrames: inout FrameArray,
         sentPackets: inout NetworkUniqueDeque<SentPacketRecord>,
+        protector: inout Protector,
+        ack: inout Ack,
+        stats: inout Statistics,
+        ecn: inout ECN,
         applicationPendingItems: inout PendingItems
     ) {
         var packetBurst = 0
@@ -3333,11 +3374,6 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
 
         let startSendingTimestamp = self.now
 
-        // Make sure there is something to send, do not allocate empty frame arrays if we do not have to.
-        guard applicationPendingItems.hasPendingItems else {
-            return false
-        }
-
         var datagramBatch = prepareApplicationDatagramBatch(
             path: path,
             availableCongestionWindow: availableCongestionWindow,
@@ -3368,6 +3404,10 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             datagramBatch: &datagramBatch,
             outboundFrames: &outboundFrameArray,
             sentPackets: &sentPackets,
+            protector: &protector,
+            ack: &ack,
+            stats: &stats,
+            ecn: &ecn,
             applicationPendingItems: &applicationPendingItems
         )
         if !outboundFrameArray.isEmpty {
@@ -3558,6 +3598,10 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             datagramBatch: &datagramBatch,
             outboundFrames: &outboundFrameArray,
             sentPackets: &sentPackets,
+            protector: &protector,
+            ack: &ack,
+            stats: &stats,
+            ecn: &ecn,
             applicationPendingItems: &applicationPendingItems
         )
         if !outboundFrameArray.isEmpty {
@@ -5125,7 +5169,8 @@ extension QUICConnection {
         )
 
         // Check if we need to send probes
-        var sentPackets = path.pmtudState.tryToSend(on: path)
+        var sentPackets = NetworkUniqueDeque<SentPacketRecord>()
+        path.pmtudState.tryToSend(on: path, sentPackets: &sentPackets)
         recovery.recordSentPackets(&sentPackets, connection: self)
         return true
     }
@@ -6018,14 +6063,26 @@ extension QUICConnection {
     }
 
     fileprivate var connectionIsIdleForAllStreams: Bool {
+        connectionIsIdleForAllStreams(
+            initialPendingItemsHasPendingItems: initialPendingItems.hasPendingItems,
+            handshakePendingItemsHasPendingItems: handshakePendingItems.hasPendingItems,
+            applicationPendingItemsHasPendingItems: applicationPendingItems.hasPendingItems
+        )
+    }
+
+    fileprivate func connectionIsIdleForAllStreams(
+        initialPendingItemsHasPendingItems: Bool,
+        handshakePendingItemsHasPendingItems: Bool,
+        applicationPendingItemsHasPendingItems: Bool
+    ) -> Bool {
         // Fast exit if no flow has marked idle
         guard flowsHaveEverMarkedIdle else {
             return false
         }
 
         // If there are pending send items, not idle
-        if initialPendingItems.hasPendingItems || handshakePendingItems.hasPendingItems
-            || applicationPendingItems.hasPendingItems
+        if initialPendingItemsHasPendingItems || handshakePendingItemsHasPendingItems
+            || applicationPendingItemsHasPendingItems
         {
             return false
         }
@@ -6065,7 +6122,27 @@ extension QUICConnection {
     }
 
     func checkConnectionIdle() {
-        let isIdle = connectionIsIdleForAllStreams
+        reportIdleState(isIdle: connectionIsIdleForAllStreams)
+    }
+
+    // Used in the send path when the caller already holds an `inout` on
+    // connection.{initial,handshake,application}PendingItems, to avoid
+    // re-accessing those properties on `self` while they're exclusively borrowed.
+    func checkConnectionIdle(
+        initialPendingItemsHasPendingItems: Bool,
+        handshakePendingItemsHasPendingItems: Bool,
+        applicationPendingItemsHasPendingItems: Bool
+    ) {
+        reportIdleState(
+            isIdle: connectionIsIdleForAllStreams(
+                initialPendingItemsHasPendingItems: initialPendingItemsHasPendingItems,
+                handshakePendingItemsHasPendingItems: handshakePendingItemsHasPendingItems,
+                applicationPendingItemsHasPendingItems: applicationPendingItemsHasPendingItems
+            )
+        )
+    }
+
+    private func reportIdleState(isIdle: Bool) {
         applyToAllPaths { path in
             let pathIsIdle = isIdle && !path.isProbing && !path.shouldSendPathResponses
             if pathIsIdle && !path.reportedIdleEvent {

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -2185,8 +2185,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         stats.increment(.rxPackets)
         stats.increment(.rxBytes, by: packetLength)
         withCurrentPath { (path: borrowing QUICPath) -> Void in
-            path.pathStatistics[.rxPackets] += 1
-            path.pathStatistics[.rxBytes] += Int(packetLength)
+            path.pathStatistics.increment(.rxPackets)
+            path.pathStatistics.increment(.rxBytes, by: Int(packetLength))
         }
         return true
     }
@@ -2293,8 +2293,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         stats.increment(.rxPackets)
         stats.increment(.rxBytes, by: packetLength)
         withCurrentPath { (path: borrowing QUICPath) -> Void in
-            path.pathStatistics[.rxPackets] += 1
-            path.pathStatistics[.rxBytes] += Int(packetLength)
+            path.pathStatistics.increment(.rxPackets)
+            path.pathStatistics.increment(.rxBytes, by: Int(packetLength))
         }
         self.ack.append(
             packetNumberSpace: packet.numberSpace,
@@ -3806,8 +3806,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             }
             stats.increment(.txBytes, by: totalPacketLength)
             stats.increment(.txPackets)
-            path.pathStatistics[.txPackets] += 1
-            path.pathStatistics[.txBytes] += Int(totalPacketLength)
+            path.pathStatistics.increment(.txPackets)
+            path.pathStatistics.increment(.txBytes, by: Int(totalPacketLength))
 
             // Seal packet, incidentally this also effectively takes the packet number!
             do throws(QUICError) {
@@ -4214,7 +4214,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             stats.increment(.rxReorderedPackets)
             stats.increment(.rxReorderedBytes, by: Int(packet.totalLength))
             withCurrentPath { path in
-                path.pathStatistics[.rxReorderedBytes] += Int(packet.totalLength)
+                path.pathStatistics.increment(.rxReorderedBytes, by: Int(packet.totalLength))
             }
             return true
         }

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -3352,7 +3352,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             }
         }
 
-        var outboundFrameArray = FrameArray()
+        var outboundFrameArray = FrameArray(capacity: datagramBatch.count)
         // keyState can only be .phase0 or .phase1 here: initial keys are discarded and the
         // handshake is confirmed, so .earlyData is no longer possible.
         let packetKeyState: PacketKeyState = self.keyState == .phase1 ? .phase1 : .phase0
@@ -3466,7 +3466,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             }
         }
 
-        var outboundFrameArray = FrameArray()
+        var outboundFrameArray = FrameArray(capacity: datagramBatch.count)
         if !initialKeysDiscarded {
             while initialPendingItems.hasPendingItems {
                 if initialKeysDiscarded {

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -3070,10 +3070,6 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             handshakePendingItems: &handshakePendingItems,
             applicationPendingItems: &applicationPendingItems
         )
-        // Record the newly-built packets (including any Initial-space packet from this same
-        // call) into recovery before discarding Initial recovery state, otherwise that packet's
-        // bytesInFlight accounting is added after the space is reset and can never be undone
-        // since Initial keys are already dropped by this point.
         recovery.recordSentPackets(&sentPackets, connection: self)
         self.shrinkSentPacketsIfNecessary(sentPackets: &sentPackets)
         if discardInitialRecoveryState {
@@ -3123,6 +3119,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             on: path,
             ignoreCongestionWindow: ignoreCongestionWindow,
             retransmission: retransmission,
+            initialPendingItems: &initialPendingItems,
+            handshakePendingItems: &handshakePendingItems,
             applicationPendingItems: &applicationPendingItems,
             discardInitialRecoveryState: &discardInitialRecoveryState
         )
@@ -3134,6 +3132,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         on path: QUICPath,
         ignoreCongestionWindow: Bool = false,
         retransmission: Bool = false,
+        initialPendingItems: inout PendingItems,
+        handshakePendingItems: inout PendingItems,
         applicationPendingItems: inout PendingItems,
         discardInitialRecoveryState: inout Bool
     ) -> NetworkUniqueDeque<SentPacketRecord> {
@@ -6125,9 +6125,6 @@ extension QUICConnection {
         reportIdleState(isIdle: connectionIsIdleForAllStreams)
     }
 
-    // Used in the send path when the caller already holds an `inout` on
-    // connection.{initial,handshake,application}PendingItems, to avoid
-    // re-accessing those properties on `self` while they're exclusively borrowed.
     func checkConnectionIdle(
         initialPendingItemsHasPendingItems: Bool,
         handshakePendingItemsHasPendingItems: Bool,

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -2971,7 +2971,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
     // Storage for the packets recorded by a single sendFrames() call.
     private var sentPackets = NetworkUniqueDeque<SentPacketRecord>(minimumCapacity: 10)
 
-    private func capacityForPacketNumberSpace() -> Int {
+    private func capacityForPacketNumberSpace(applicationPendingItems: inout PendingItems) -> Int {
         let packetNumberSpace = PacketNumberSpace.fromKeyState(keyState: self.keyState)
         if packetNumberSpace == .applicationData {
             if !applicationPendingItems.stream {
@@ -2984,18 +2984,36 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         }
     }
 
-    private func shrinkSentPacketsIfNecessary() {
-        assert(self.sentPackets.isEmpty)
+    private func shrinkSentPacketsIfNecessary(sentPackets: inout NetworkUniqueDeque<SentPacketRecord>) {
+        assert(sentPackets.isEmpty)
         // 'sentPackets' is held onto for the lifetime of the connection. If a send burst grows it
         // beyond a certain limit then drop the capacity. This avoids bursty traffic bloating memory
         // indefinitely.
-        if self.sentPackets.capacity > QUICPreferences.shared.maxSentPacketsCapacity {
-            self.sentPackets = NetworkUniqueDeque()
+        if sentPackets.capacity > QUICPreferences.shared.maxSentPacketsCapacity {
+            sentPackets = NetworkUniqueDeque()
         }
     }
 
+    // Adds recovery and applicationPendingItems to avoid extra begin/end acccess checking overhead
     @discardableResult
     func sendFrames(ignoreCongestionWindow: Bool = false, delayedACK: Bool = false) -> Bool {
+        sendFrames(
+            ignoreCongestionWindow: ignoreCongestionWindow,
+            delayedACK: delayedACK,
+            sentPackets: &sentPackets,
+            recovery: &recovery,
+            applicationPendingItems: &applicationPendingItems
+        )
+    }
+
+    @discardableResult
+    func sendFrames(
+        ignoreCongestionWindow: Bool = false,
+        delayedACK: Bool = false,
+        sentPackets: inout NetworkUniqueDeque<SentPacketRecord>,
+        recovery: inout Recovery,
+        applicationPendingItems: inout PendingItems
+    ) -> Bool {
         // Make sure there are packets to send
         guard
             initialPendingItems.hasPendingItems
@@ -3011,33 +3029,47 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             ack.scheduleDelayedAck()
             return false
         }
-        return withCurrentPath { path in
-            self.sentPackets.reserveCapacity(capacityForPacketNumberSpace())
-            var discardInitialRecoveryState = false
-
-            let success = sendFramesInternal(
+        guard let path = currentPath else {
+            return false
+        }
+        sentPackets.reserveCapacity(capacityForPacketNumberSpace(applicationPendingItems: &applicationPendingItems))
+        let success: Bool
+        if initialKeysDiscarded && isHandshakeConfirmed {
+            // Once the handshake is complete only
+            // send application data from then on out.
+            success = sendApplicationFrames(
                 path: path,
                 ignoreCongestionWindow: ignoreCongestionWindow,
                 retransmission: false,
-                sentPackets: &self.sentPackets,
+                sentPackets: &sentPackets,
+                applicationPendingItems: &applicationPendingItems
+            )
+        } else {
+            var discardInitialRecoveryState = false
+            success = sendFramesInternal(
+                path: path,
+                ignoreCongestionWindow: ignoreCongestionWindow,
+                retransmission: false,
+                sentPackets: &sentPackets,
+                initialPendingItems: &initialPendingItems,
+                handshakePendingItems: &handshakePendingItems,
+                applicationPendingItems: &applicationPendingItems,
                 discardInitialRecoveryState: &discardInitialRecoveryState
             )
-
-            // Trigger PMTUD if necessary
-            var pmtudPackets = path.pmtudState.sendProbe(on: path)
-            while let pmtudPacket = pmtudPackets.popFirst() {
-                self.sentPackets.append(pmtudPacket)
-            }
-            recovery.recordSentPackets(&self.sentPackets, connection: self)
-            self.shrinkSentPacketsIfNecessary()
             if discardInitialRecoveryState {
                 recovery.resetPNSpace(packetNumberSpace: .initial, connection: self)
-                withCurrentPath {
-                    recovery.resetPTOCount(path: $0)
-                }
+                recovery.resetPTOCount(path: path)
             }
-            return success
         }
+
+        // Trigger PMTUD if necessary.
+        var pmtudPackets = path.pmtudState.sendProbe(on: path, applicationPendingItems: &applicationPendingItems)
+        while let pmtudPacket = pmtudPackets.popFirst() {
+            sentPackets.append(pmtudPacket)
+        }
+        recovery.recordSentPackets(&sentPackets, connection: self)
+        self.shrinkSentPacketsIfNecessary(sentPackets: &sentPackets)
+        return success
     }
 
     @discardableResult
@@ -3046,22 +3078,25 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         ignoreCongestionWindow: Bool = false,
         retransmission: Bool = false
     ) -> Bool {
-        self.sentPackets.reserveCapacity(capacityForPacketNumberSpace())
+        self.sentPackets.reserveCapacity(
+            capacityForPacketNumberSpace(applicationPendingItems: &applicationPendingItems)
+        )
         var discardInitialRecoveryState = false
         let success = sendFramesInternal(
             path: path,
             ignoreCongestionWindow: ignoreCongestionWindow,
             retransmission: retransmission,
             sentPackets: &self.sentPackets,
+            initialPendingItems: &initialPendingItems,
+            handshakePendingItems: &handshakePendingItems,
+            applicationPendingItems: &applicationPendingItems,
             discardInitialRecoveryState: &discardInitialRecoveryState
         )
         recovery.recordSentPackets(&self.sentPackets, connection: self)
-        self.shrinkSentPacketsIfNecessary()
+        self.shrinkSentPacketsIfNecessary(sentPackets: &sentPackets)
         if discardInitialRecoveryState {
             recovery.resetPNSpace(packetNumberSpace: .initial, connection: self)
-            withCurrentPath {
-                recovery.resetPTOCount(path: $0)
-            }
+            recovery.resetPTOCount(path: path)
         }
         return success
     }
@@ -3073,12 +3108,35 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         retransmission: Bool = false,
         discardInitialRecoveryState: inout Bool
     ) -> NetworkUniqueDeque<SentPacketRecord> {
-        var sentPackets = NetworkUniqueDeque<SentPacketRecord>(minimumCapacity: capacityForPacketNumberSpace())
+        sendFramesFromRecovery(
+            on: path,
+            ignoreCongestionWindow: ignoreCongestionWindow,
+            retransmission: retransmission,
+            applicationPendingItems: &applicationPendingItems,
+            discardInitialRecoveryState: &discardInitialRecoveryState
+        )
+    }
+
+    // Sends with pending items attached
+    @discardableResult
+    func sendFramesFromRecovery(
+        on path: QUICPath,
+        ignoreCongestionWindow: Bool = false,
+        retransmission: Bool = false,
+        applicationPendingItems: inout PendingItems,
+        discardInitialRecoveryState: inout Bool
+    ) -> NetworkUniqueDeque<SentPacketRecord> {
+        var sentPackets = NetworkUniqueDeque<SentPacketRecord>(
+            minimumCapacity: capacityForPacketNumberSpace(applicationPendingItems: &applicationPendingItems)
+        )
         _ = sendFramesInternal(
             path: path,
             ignoreCongestionWindow: ignoreCongestionWindow,
             retransmission: retransmission,
             sentPackets: &sentPackets,
+            initialPendingItems: &initialPendingItems,
+            handshakePendingItems: &handshakePendingItems,
+            applicationPendingItems: &applicationPendingItems,
             discardInitialRecoveryState: &discardInitialRecoveryState
         )
         return sentPackets
@@ -3094,7 +3152,10 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         sendFrames(on: path)
     }
 
-    private func buildOutboundFrameBatch(availableCongestionWindow: UInt64) -> FrameArray {
+    private func buildOutboundFrameBatch(
+        availableCongestionWindow: UInt64,
+        applicationPendingItems: inout PendingItems
+    ) -> FrameArray {
         var outboundBatch = FrameArray()
         // If ACK is only set or the connection is blocked just send empty batch
         if applicationPendingItems.isAckSet || self.hasSentDataBlocked {
@@ -3145,12 +3206,185 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         }
     }
 
+    // Shared by sendApplicationFrames and sendFramesInternal to build the datagram batch.
+    private func prepareApplicationDatagramBatch(
+        path: QUICPath,
+        availableCongestionWindow: UInt64,
+        totalSendBytes: UInt64,
+        startSendingTimestamp: NetworkClock.Instant,
+        applicationPendingItems: inout PendingItems
+    ) -> FrameArray {
+        let datagramBatch: FrameArray
+        if self.flowControlState.pendingOutboundBytesToSend > 0 && availableCongestionWindow > 0 {
+            datagramBatch = buildOutboundFrameBatch(
+                availableCongestionWindow: (availableCongestionWindow - totalSendBytes),
+                applicationPendingItems: &applicationPendingItems
+            )
+        } else {
+            datagramBatch = FrameArray()
+        }
+
+        // Sending on the current path.
+        // Add the path frames to the items for application data
+        path.addPendingItems(&applicationPendingItems, now: startSendingTimestamp)
+        return datagramBatch
+    }
+
+    // Shared by sendApplicationFrames and sendFramesInternal.
+    private func runApplicationBurstLoop(
+        keyState: PacketKeyState,
+        path: QUICPath,
+        ignoreCongestionWindow: Bool,
+        retransmission: Bool,
+        startSendingTimestamp: NetworkClock.Instant,
+        availableCongestionWindow: inout UInt64,
+        totalSendBytes: inout UInt64,
+        datagramBatch: inout FrameArray,
+        outboundFrames: inout FrameArray,
+        sentPackets: inout NetworkUniqueDeque<SentPacketRecord>,
+        applicationPendingItems: inout PendingItems
+    ) {
+        var packetBurst = 0
+        var packetBurstTotal = 0
+        while applicationPendingItems.hasPendingItems {
+            guard
+                buildSinglePacketForKeyState(
+                    keyState,
+                    pendingItems: &applicationPendingItems,
+                    sentPackets: &sentPackets,
+                    on: path,
+                    ignoreCongestionWindow: ignoreCongestionWindow,
+                    availableCongestionWindow: &availableCongestionWindow,
+                    totalSendBytes: &totalSendBytes,
+                    retransmission: retransmission,
+                    datagramBatch: &datagramBatch,
+                    outboundFrames: &outboundFrames,
+                    protector: &protector,
+                    ack: ack,
+                    stats: &stats,
+                    ecn: &ecn
+                )
+            else {
+                break
+            }
+
+            if !ignoreCongestionWindow && totalSendBytes >= availableCongestionWindow {
+                break
+            }
+
+            var shouldEndBurst = false
+            packetBurst += 1
+            packetBurstTotal += 1
+
+            if packetBurstTotal >= Constants.maxPacketBurstCount {
+                // The maximum total packet count has been reached
+                shouldEndBurst = true
+            } else if packetBurst >= Constants.packetBurstCount {
+                // The packet burst count has been reached, check the time
+                if startSendingTimestamp.duration(to: .now) >= Constants.maxPacketBurstDuration {
+                    // The maximum burst time has been reached
+                    shouldEndBurst = true
+                } else {
+                    // Reset the local burst count and continue
+                    packetBurst = 0
+                    if datagramBatch.isEmpty {
+                        // If sending packet bursts and the original batch of prefetched datagrams is empty, fetch a new batch
+                        datagramBatch = buildOutboundFrameBatch(
+                            availableCongestionWindow: (availableCongestionWindow - totalSendBytes),
+                            applicationPendingItems: &applicationPendingItems
+                        )
+                    }
+                }
+            }
+            // If we've exceeded the send burst limit, trigger an async before servicing more data
+            if shouldEndBurst {
+                log.datapath("burst limit application data")
+                applicationPendingItems.rotateFirstStreamToService()
+                burstLimitReached()
+                break
+            }
+        }
+    }
+
+    // Used to send only application data
+    private func sendApplicationFrames(
+        path: QUICPath,
+        ignoreCongestionWindow: Bool = false,
+        retransmission: Bool = false,
+        sentPackets: inout NetworkUniqueDeque<SentPacketRecord>,
+        applicationPendingItems: inout PendingItems
+    ) -> Bool {
+        // Handle the case of having additional paths at the very beginning of the connection.
+        if path.mss == 0 {
+            setInitialMSS(on: path)
+        }
+
+        var drop = false
+        guard canSendFrames(on: path, drop: &drop) else {
+            return drop
+        }
+
+        var totalSendBytes: UInt64 = 0
+        // Ignoring is equivalent to an infinite window
+        var availableCongestionWindow = UInt64.max
+        if !ignoreCongestionWindow {
+            availableCongestionWindow = path.congestionControlAvailableCongestionWindow
+        }
+
+        let startSendingTimestamp = self.now
+
+        // Make sure there is something to send, do not allocate empty frame arrays if we do not have to.
+        guard applicationPendingItems.hasPendingItems else {
+            return false
+        }
+
+        var datagramBatch = prepareApplicationDatagramBatch(
+            path: path,
+            availableCongestionWindow: availableCongestionWindow,
+            totalSendBytes: totalSendBytes,
+            startSendingTimestamp: startSendingTimestamp,
+            applicationPendingItems: &applicationPendingItems
+        )
+
+        defer {
+            if !datagramBatch.isEmpty {
+                datagramBatch.finalizeAllFramesAsFailed()
+            }
+        }
+
+        var outboundFrameArray = FrameArray()
+        // keyState can only be .phase0 or .phase1 here: initial keys are discarded and the
+        // handshake is confirmed, so .earlyData is no longer possible.
+        let packetKeyState: PacketKeyState = self.keyState == .phase1 ? .phase1 : .phase0
+
+        runApplicationBurstLoop(
+            keyState: packetKeyState,
+            path: path,
+            ignoreCongestionWindow: ignoreCongestionWindow,
+            retransmission: retransmission,
+            startSendingTimestamp: startSendingTimestamp,
+            availableCongestionWindow: &availableCongestionWindow,
+            totalSendBytes: &totalSendBytes,
+            datagramBatch: &datagramBatch,
+            outboundFrames: &outboundFrameArray,
+            sentPackets: &sentPackets,
+            applicationPendingItems: &applicationPendingItems
+        )
+        if !outboundFrameArray.isEmpty {
+            sendOutboundFrames(outboundFrameArray, on: path)
+        }
+        return true
+    }
+
     // Don't use directly, use above sendFrames*()
     private func sendFramesInternal(
         path: QUICPath,
         ignoreCongestionWindow: Bool = false,
         retransmission: Bool = false,
         sentPackets: inout NetworkUniqueDeque<SentPacketRecord>,
+        initialPendingItems: inout PendingItems,
+        handshakePendingItems: inout PendingItems,
+        applicationPendingItems: inout PendingItems,
         discardInitialRecoveryState: inout Bool
     ) -> Bool {
         // Handle the case of having additional paths at the very beginning of the connection.
@@ -3183,7 +3417,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             var datagramBatch = FrameArray()
             if self.flowControlState.pendingOutboundBytesToSend > 0 && availableCongestionWindow > 0 {
                 datagramBatch = buildOutboundFrameBatch(
-                    availableCongestionWindow: (availableCongestionWindow - totalSendBytes)
+                    availableCongestionWindow: (availableCongestionWindow - totalSendBytes),
+                    applicationPendingItems: &applicationPendingItems
                 )
             }
             var outboundFrameArray = FrameArray()
@@ -3197,7 +3432,11 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
                 totalSendBytes: &totalSendBytes,
                 retransmission: retransmission,
                 datagramBatch: &datagramBatch,
-                outboundFrames: &outboundFrameArray
+                outboundFrames: &outboundFrameArray,
+                protector: &protector,
+                ack: ack,
+                stats: &stats,
+                ecn: &ecn
             )
             if !outboundFrameArray.isEmpty {
                 sendOutboundFrames(outboundFrameArray, on: path)
@@ -3213,20 +3452,13 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             return false
         }
 
-        var datagramBatch: FrameArray
-        if self.flowControlState.pendingOutboundBytesToSend > 0 && availableCongestionWindow > 0 {
-            datagramBatch = buildOutboundFrameBatch(
-                availableCongestionWindow: (availableCongestionWindow - totalSendBytes)
-            )
-        } else {
-            datagramBatch = FrameArray()
-        }
-
-        // Sending on the current path.
-        // Add the path frames to the items for application data
-        withPendingItems(for: .applicationData) {
-            path.addPendingItems(&$0, now: startSendingTimestamp)
-        }
+        var datagramBatch = prepareApplicationDatagramBatch(
+            path: path,
+            availableCongestionWindow: availableCongestionWindow,
+            totalSendBytes: totalSendBytes,
+            startSendingTimestamp: startSendingTimestamp,
+            applicationPendingItems: &applicationPendingItems
+        )
 
         defer {
             if !datagramBatch.isEmpty {
@@ -3253,7 +3485,11 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
                         totalSendBytes: &totalSendBytes,
                         retransmission: retransmission,
                         datagramBatch: &datagramBatch,
-                        outboundFrames: &outboundFrameArray
+                        outboundFrames: &outboundFrameArray,
+                        protector: &protector,
+                        ack: ack,
+                        stats: &stats,
+                        ecn: &ecn
                     )
                 else {
                     break
@@ -3273,7 +3509,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             // Discard keys first to make sure we have room in congestion control
             if !isServer && !initialKeysDiscarded {
                 discardInitialRecoveryState = true
-                discardKeys(keyState: .initial, discardRecoveryState: false)
+                discardKeys(keyState: .initial, pendingItems: &initialPendingItems, discardRecoveryState: false)
                 initialKeysDiscarded = true
             }
 
@@ -3288,7 +3524,11 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
                     totalSendBytes: &totalSendBytes,
                     retransmission: retransmission,
                     datagramBatch: &datagramBatch,
-                    outboundFrames: &outboundFrameArray
+                    outboundFrames: &outboundFrameArray,
+                    protector: &protector,
+                    ack: ack,
+                    stats: &stats,
+                    ecn: &ecn
                 )
             else {
                 break
@@ -3298,71 +3538,28 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             }
         }
 
-        var packetBurst = 0
-        var packetBurstTotal = 0
-        while applicationPendingItems.hasPendingItems {
-            let keyState: PacketKeyState
-            if self.keyState == .initial {
-                keyState = .earlyData
-            } else if self.keyState == .phase1 {
-                keyState = .phase1
-            } else {
-                keyState = .phase0
-            }
-
-            guard
-                buildSinglePacketForKeyState(
-                    keyState,
-                    pendingItems: &applicationPendingItems,
-                    sentPackets: &sentPackets,
-                    on: path,
-                    ignoreCongestionWindow: ignoreCongestionWindow,
-                    availableCongestionWindow: &availableCongestionWindow,
-                    totalSendBytes: &totalSendBytes,
-                    retransmission: retransmission,
-                    datagramBatch: &datagramBatch,
-                    outboundFrames: &outboundFrameArray
-                )
-            else {
-                break
-            }
-
-            if !ignoreCongestionWindow && totalSendBytes >= availableCongestionWindow {
-                break
-            }
-
-            var shouldEndBurst = false
-            packetBurst += 1
-            packetBurstTotal += 1
-
-            if packetBurstTotal >= Constants.maxPacketBurstCount {
-                // The maximum total packet count has been reached
-                shouldEndBurst = true
-            } else if packetBurst >= Constants.packetBurstCount {
-                // The packet burst count has been reached, check the time
-                if startSendingTimestamp.duration(to: .now) >= Constants.maxPacketBurstDuration {
-                    // The maximum burst time has been reached
-                    shouldEndBurst = true
-                } else {
-                    // Reset the local burst count and continue
-                    packetBurst = 0
-                    if datagramBatch.isEmpty {
-                        // If sending packet bursts and the original batch of prefetched datagrams is empty, fetch a new batch
-                        datagramBatch = buildOutboundFrameBatch(
-                            availableCongestionWindow: (availableCongestionWindow - totalSendBytes)
-                        )
-                    }
-                }
-            }
-
-            // If we've exceeded the send burst limit, trigger an async before servicing more data
-            if shouldEndBurst {
-                log.datapath("burst limit application data")
-                applicationPendingItems.rotateFirstStreamToService()
-                burstLimitReached()
-                break
-            }
+        let applicationKeyState: PacketKeyState
+        if self.keyState == .initial {
+            applicationKeyState = .earlyData
+        } else if self.keyState == .phase1 {
+            applicationKeyState = .phase1
+        } else {
+            applicationKeyState = .phase0
         }
+
+        runApplicationBurstLoop(
+            keyState: applicationKeyState,
+            path: path,
+            ignoreCongestionWindow: ignoreCongestionWindow,
+            retransmission: retransmission,
+            startSendingTimestamp: startSendingTimestamp,
+            availableCongestionWindow: &availableCongestionWindow,
+            totalSendBytes: &totalSendBytes,
+            datagramBatch: &datagramBatch,
+            outboundFrames: &outboundFrameArray,
+            sentPackets: &sentPackets,
+            applicationPendingItems: &applicationPendingItems
+        )
         if !outboundFrameArray.isEmpty {
             sendOutboundFrames(outboundFrameArray, on: path)
         }
@@ -3379,14 +3576,22 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         totalSendBytes: inout UInt64,
         retransmission: Bool,
         datagramBatch: inout FrameArray,
-        outboundFrames: inout FrameArray
+        outboundFrames: inout FrameArray,
+        protector: inout Protector,
+        ack: Ack,
+        stats: inout Statistics,
+        ecn: inout ECN
     ) -> Bool {
-        let packetNumberSpace = pendingItems.packetNumberSpace
 
         if path.isFlowControlled {
             log.datapath("Path is flow controlled")
             return false
         }
+
+        let packetNumberSpace = pendingItems.packetNumberSpace
+        let isPacing = isPacing
+        let isServer = isServer
+        let testSendingShortPackets = testSendingShortPackets
 
         // Server must not send more than 3x the number of bytes received, until
         // the client's address has been validated by receiving a handshake
@@ -3430,6 +3635,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
 
         if isPacing {
             let now = NetworkClock.Instant.now
+            let lastAckElicitingPacketSentTimestamp = lastAckElicitingPacketSentTimestamp
             // lastAckElicitingPacketSentTimestamp can be in the future for kernel packet pacing.
             if now > lastAckElicitingPacketSentTimestamp {
                 let idleTime = lastAckElicitingPacketSentTimestamp.duration(to: now)
@@ -3522,8 +3728,10 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
                     connection: self,
                     availableCongestionWindow: availableCongestionWindow,
                     token: initialToken,
-                    stats: &self.stats,
-                    version: currentVersion
+                    stats: &stats,
+                    version: currentVersion,
+                    isServer: isServer,
+                    testSendingShortPackets: testSendingShortPackets
                 )
             } catch {
                 if totalBytesWrittenInFrame > 0 {
@@ -3543,8 +3751,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             }
             let isInFlightEligible = sentPacketRecord.isInFlightEligible
             outFrame.ecnFlag = ECN.outgoingIPCodepoint(
-                ecn: self.ecn,
-                path: currentPath,
+                ecn: ecn,
+                path: path,
                 stats: &stats,
                 packet: &sentPacketRecord
             )
@@ -3598,13 +3806,12 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             }
             stats.increment(.txBytes, by: totalPacketLength)
             stats.increment(.txPackets)
-            withCurrentPath { (path: borrowing QUICPath) -> Void in
-                path.pathStatistics[.txPackets] += 1
-                path.pathStatistics[.txBytes] += Int(totalPacketLength)
-            }
+            path.pathStatistics[.txPackets] += 1
+            path.pathStatistics[.txBytes] += Int(totalPacketLength)
+
             // Seal packet, incidentally this also effectively takes the packet number!
             do throws(QUICError) {
-                try self.protector.seal(&packet, frame: &outFrame)
+                try protector.seal(&packet, frame: &outFrame)
             } catch {
                 self.log.error(
                     "Failed to seal packet: \(error.info.description), code \(error.info.code)"
@@ -4273,12 +4480,11 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         self.connectionMetadata.remoteMaxDatagramFrameSize = UInt16(truncatingIfNeeded: remoteMaxDatagramFrameSize)
     }
 
-    private func discardKeys(keyState: PacketKeyState, discardRecoveryState: Bool = true) {
-        let space = PacketNumberSpace.fromKeyState(keyState: keyState)
-
-        // Flush first so that we won't send out frames other than ACKs with older key
-        withPendingItems(for: space) { $0.flush() }
-
+    private func discardKeysInternal(
+        keyState: PacketKeyState,
+        space: PacketNumberSpace,
+        discardRecoveryState: Bool = true
+    ) {
         protector.drop(keyState: keyState)
 
         if discardRecoveryState {
@@ -4297,6 +4503,24 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         }
         #endif
         ack.flush(for: space)
+    }
+
+    private func discardKeys(
+        keyState: PacketKeyState,
+        pendingItems: inout PendingItems,
+        discardRecoveryState: Bool = true
+    ) {
+        let space = PacketNumberSpace.fromKeyState(keyState: keyState)
+        // Flush first so that we won't send out frames other than ACKs with older key
+        pendingItems.flush()
+        discardKeysInternal(keyState: keyState, space: space, discardRecoveryState: discardRecoveryState)
+    }
+
+    private func discardKeys(keyState: PacketKeyState, discardRecoveryState: Bool = true) {
+        let space = PacketNumberSpace.fromKeyState(keyState: keyState)
+        // Flush first so that we won't send out frames other than ACKs with older key
+        withPendingItems(for: space) { $0.flush() }
+        discardKeysInternal(keyState: keyState, space: space, discardRecoveryState: discardRecoveryState)
     }
 
     public func wakeup() {

--- a/Sources/SwiftNetwork/QUIC/Recovery.swift
+++ b/Sources/SwiftNetwork/QUIC/Recovery.swift
@@ -978,7 +978,8 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
 
         // We may have lost a PMTUD probe, so check if we want to resend it
         connection.withCurrentPath { path in
-            var sentPackets = path.pmtudState.tryToSend(on: path)
+            var sentPackets = NetworkUniqueDeque<SentPacketRecord>()
+            path.pmtudState.tryToSend(on: path, sentPackets: &sentPackets)
             recordSentPackets(&sentPackets, connection: connection)
             return
         }
@@ -1026,7 +1027,8 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
             // want to resend it.
             let path = path ?? connection.currentPath
             if let path {
-                var sentPackets = path.pmtudState.tryToSend(on: path)
+                var sentPackets = NetworkUniqueDeque<SentPacketRecord>()
+                path.pmtudState.tryToSend(on: path, sentPackets: &sentPackets)
                 recordSentPackets(&sentPackets, connection: connection)
             }
             connection.sendAllEnqueuedOutboundDatagrams()
@@ -1263,9 +1265,11 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
             innerState.largerPacketCount > 0
         }
         if hasLargerPacketCount {
-            var sentPackets = path.pmtudState.ptoEvent(
+            var sentPackets = NetworkUniqueDeque<SentPacketRecord>()
+            path.pmtudState.ptoEvent(
                 on: path,
-                ptoCount: path.recoveryState.PTOCount
+                ptoCount: path.recoveryState.PTOCount,
+                sentPackets: &sentPackets
             )
             recordSentPackets(&sentPackets, connection: connection)
         }

--- a/Sources/SwiftNetwork/QUIC/Statistics.swift
+++ b/Sources/SwiftNetwork/QUIC/Statistics.swift
@@ -168,6 +168,8 @@ struct Statistics: ~Copyable {
         }
     }
 
+    @inline(always)
+    @inlinable
     mutating func increment(_ key: QUICStatistic, by value: Int = 1) {
         statisticsArray[key.rawValue] &+= value
     }


### PR DESCRIPTION
Swift has something called exclusive access checks, its part of what makes Swift a memory safe language. These exclusive access checks happen when accessing properties of a class or other reference type to make sure something else is not accessing and mutating that property at the same time.  These exclusive access checks end up costing a very small amount of  CPU when a property of a reference type is used.  Well, in the data path (millions of times) these very small amounts of CPU add up to becoming a lot of CPU.  One thing you can do to avoid these costs and still keep your code safe is to hoist these properties up to the top of the call stack and pass them down through the stack.  This ends up satisfying the ownership rules and avoids redundant exclusive access checks. And that's what this change does, it rewrites the send path to reduce calling `QUICConnection` properties directly on the send path, and instead, passes these properties down through the send path.  This change reduces the CPU usage by over 1.1 gigacycles.

Top of tree:
```
4.05 G 100.0%	-	 swift_beginAccess
775.78 M 100.0%	-	 swift_endAccess
```

With this change:
```
3.16 G 99.4%	-	 swift_beginAccess	
493.56 M 99.8%	-	  swift_endAccess
```