### PR TITLE
Thread 'now' through the stack

### DIFF
--- a/Sources/SwiftNetwork/Protocols/IPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/IPProtocol.swift
@@ -464,7 +464,7 @@ public struct IPProtocol: NetworkProtocol {
             mutating func appendReassembledPackets(
                 _ log: borrowing NetworkLoggerState,
                 reassembled: inout FrameArray,
-                now: NetworkClock.Instant
+                now: NetworkClock.Instant?
             ) {
                 guard let empty = reassemblyState?.inputReassemblyFrames.isEmpty, !empty else {
                     return
@@ -623,7 +623,7 @@ public struct IPProtocol: NetworkProtocol {
                     newFrame.hopLimit = ttl
                 }
                 newFrame.metadataComplete = true
-                if self.flags.calculateReceiveTime {
+                if let now {
                     newFrame.timestamp = Frame.FrameTimestamp.receiveTime(now)
                 }
                 reassembled.add(frame: newFrame)
@@ -639,7 +639,7 @@ public struct IPProtocol: NetworkProtocol {
                 ipID: UInt16,
                 reassembled: inout FrameArray,
                 forceFlush: Bool,
-                now: NetworkClock.Instant
+                now: NetworkClock.Instant?
             ) {
                 let hasAccumulatedFragments = reassemblyState?.inputReassemblyFrames.isEmpty == false
                 let isNewID = reassemblyState?.reassemblyID != ipID
@@ -676,7 +676,7 @@ public struct IPProtocol: NetworkProtocol {
             mutating func processInboundFrames(
                 _ log: borrowing NetworkLoggerState,
                 _ inboundFrames: inout FrameArray,
-                now: NetworkClock.Instant
+                now: NetworkClock.Instant?
             ) {
                 let localAddress: UInt32 = self.localAddress.addressValue
                 let remoteAddress: UInt32 = self.remoteAddress.addressValue
@@ -789,7 +789,7 @@ public struct IPProtocol: NetworkProtocol {
                         /* Do nothing */
                         break
                     }
-                    if self.flags.calculateReceiveTime {
+                    if let now {
                         frame.timestamp = Frame.FrameTimestamp.receiveTime(now)
                     }
                     if self.flags.receiveHopLimit {
@@ -1258,7 +1258,7 @@ public struct IPProtocol: NetworkProtocol {
             mutating func appendReassembledPackets(
                 _ log: borrowing NetworkLoggerState,
                 reassembled: inout FrameArray,
-                now: NetworkClock.Instant
+                now: NetworkClock.Instant?
             ) {
                 guard let empty = reassemblyState?.inputReassemblyFrames.isEmpty, !empty else {
                     return
@@ -1393,7 +1393,7 @@ public struct IPProtocol: NetworkProtocol {
                 if self.flags.receiveHopLimit {
                     newFrame.hopLimit = firstHopLimit
                 }
-                if self.flags.calculateReceiveTime {
+                if let now {
                     newFrame.timestamp = Frame.FrameTimestamp.receiveTime(now)
                 }
                 newFrame.metadataComplete = true
@@ -1410,7 +1410,7 @@ public struct IPProtocol: NetworkProtocol {
                 fragmentID: UInt32,
                 reassembled: inout FrameArray,
                 forceFlush: Bool,
-                now: NetworkClock.Instant
+                now: NetworkClock.Instant?
             ) {
                 let hasAccumulatedFragments = reassemblyState?.inputReassemblyFrames.isEmpty == false
                 let isNewID = reassemblyState?.reassemblyID != fragmentID
@@ -1443,7 +1443,7 @@ public struct IPProtocol: NetworkProtocol {
             mutating func processInboundFrames(
                 _ log: borrowing NetworkLoggerState,
                 _ inboundFrames: inout FrameArray,
-                now: NetworkClock.Instant
+                now: NetworkClock.Instant?
             ) {
 
                 let localAddress = self.localAddress.addressValue
@@ -1575,7 +1575,7 @@ public struct IPProtocol: NetworkProtocol {
                         /* Do nothing */
                         break
                     }
-                    if self.flags.calculateReceiveTime {
+                    if let now {
                         frame.timestamp = Frame.FrameTimestamp.receiveTime(now)
                     }
                     if self.flags.receiveHopLimit {
@@ -2094,7 +2094,7 @@ public struct IPProtocol: NetworkProtocol {
         ///   this instant is behind `calculateReceiveTime`, so reading the clock unconditionally
         ///   would charge a clock read to every inbound batch of a stack that never asks for
         ///   receive timestamps. Resolved once here, so the frames of a batch still share one
-        ///   instant.
+        ///   instant, and passed down as `nil` when nothing will stamp a frame.
         @inline(__always)
         private static func processInbound(
             _ instanceType: inout IPInstanceType,
@@ -2104,11 +2104,11 @@ public struct IPProtocol: NetworkProtocol {
         ) {
             switch instanceType {
             case .ipv4(var instance):
-                let receiveTime = instance.flags.calculateReceiveTime ? now() : .zero
+                let receiveTime = instance.flags.calculateReceiveTime ? now() : nil
                 instance.processInboundFrames(log, &frames, now: receiveTime)
                 instanceType = .ipv4(instance)
             case .ipv6(var instance):
-                let receiveTime = instance.flags.calculateReceiveTime ? now() : .zero
+                let receiveTime = instance.flags.calculateReceiveTime ? now() : nil
                 instance.processInboundFrames(log, &frames, now: receiveTime)
                 instanceType = .ipv6(instance)
             }

--- a/Sources/SwiftNetwork/Protocols/IPProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/IPProtocol.swift
@@ -463,7 +463,8 @@ public struct IPProtocol: NetworkProtocol {
 
             mutating func appendReassembledPackets(
                 _ log: borrowing NetworkLoggerState,
-                reassembled: inout FrameArray
+                reassembled: inout FrameArray,
+                now: NetworkClock.Instant
             ) {
                 guard let empty = reassemblyState?.inputReassemblyFrames.isEmpty, !empty else {
                     return
@@ -623,7 +624,7 @@ public struct IPProtocol: NetworkProtocol {
                 }
                 newFrame.metadataComplete = true
                 if self.flags.calculateReceiveTime {
-                    newFrame.timestamp = Frame.FrameTimestamp.receiveTime(.now)
+                    newFrame.timestamp = Frame.FrameTimestamp.receiveTime(now)
                 }
                 reassembled.add(frame: newFrame)
 
@@ -637,13 +638,14 @@ public struct IPProtocol: NetworkProtocol {
                 _ log: borrowing NetworkLoggerState,
                 ipID: UInt16,
                 reassembled: inout FrameArray,
-                forceFlush: Bool
+                forceFlush: Bool,
+                now: NetworkClock.Instant
             ) {
                 let hasAccumulatedFragments = reassemblyState?.inputReassemblyFrames.isEmpty == false
                 let isNewID = reassemblyState?.reassemblyID != ipID
 
                 if hasAccumulatedFragments && (isNewID || forceFlush) {
-                    appendReassembledPackets(log, reassembled: &reassembled)
+                    appendReassembledPackets(log, reassembled: &reassembled, now: now)
                     // Only discard buffered fragments when the IP ID changes
                     if isNewID && !forceFlush {
                         var dropped = 0
@@ -671,7 +673,11 @@ public struct IPProtocol: NetworkProtocol {
                 }
             }
 
-            mutating func processInboundFrames(_ log: borrowing NetworkLoggerState, _ inboundFrames: inout FrameArray) {
+            mutating func processInboundFrames(
+                _ log: borrowing NetworkLoggerState,
+                _ inboundFrames: inout FrameArray,
+                now: NetworkClock.Instant
+            ) {
                 let localAddress: UInt32 = self.localAddress.addressValue
                 let remoteAddress: UInt32 = self.remoteAddress.addressValue
                 let mask = (0xF000_0000 as UInt32).bigEndian
@@ -784,7 +790,7 @@ public struct IPProtocol: NetworkProtocol {
                         break
                     }
                     if self.flags.calculateReceiveTime {
-                        frame.timestamp = Frame.FrameTimestamp.receiveTime(.now)
+                        frame.timestamp = Frame.FrameTimestamp.receiveTime(now)
                     }
                     if self.flags.receiveHopLimit {
                         frame.hopLimit = ttl
@@ -842,7 +848,13 @@ public struct IPProtocol: NetworkProtocol {
                         continue
                     }
 
-                    processReassembly(log, ipID: identifier, reassembled: &reassembledFragments, forceFlush: false)
+                    processReassembly(
+                        log,
+                        ipID: identifier,
+                        reassembled: &reassembledFragments,
+                        forceFlush: false,
+                        now: now
+                    )
                     let currentFragmentCount = reassemblyState?.inputReassemblyFrames.count ?? 0
                     guard currentFragmentCount < IPMaxFragmentCount else {
                         frame.finalize(success: false)
@@ -896,7 +908,7 @@ public struct IPProtocol: NetworkProtocol {
                     }
                     self.counters.rxPackets += 1
                 }
-                processReassembly(log, ipID: 0, reassembled: &reassembledFragments, forceFlush: true)
+                processReassembly(log, ipID: 0, reassembled: &reassembledFragments, forceFlush: true, now: now)
                 processedFrames.add(frames: reassembledFragments)
                 inboundFrames.add(frames: processedFrames)
             }
@@ -1245,7 +1257,8 @@ public struct IPProtocol: NetworkProtocol {
 
             mutating func appendReassembledPackets(
                 _ log: borrowing NetworkLoggerState,
-                reassembled: inout FrameArray
+                reassembled: inout FrameArray,
+                now: NetworkClock.Instant
             ) {
                 guard let empty = reassemblyState?.inputReassemblyFrames.isEmpty, !empty else {
                     return
@@ -1381,7 +1394,7 @@ public struct IPProtocol: NetworkProtocol {
                     newFrame.hopLimit = firstHopLimit
                 }
                 if self.flags.calculateReceiveTime {
-                    newFrame.timestamp = Frame.FrameTimestamp.receiveTime(.now)
+                    newFrame.timestamp = Frame.FrameTimestamp.receiveTime(now)
                 }
                 newFrame.metadataComplete = true
                 reassembled.add(frame: newFrame)
@@ -1396,13 +1409,14 @@ public struct IPProtocol: NetworkProtocol {
                 _ log: borrowing NetworkLoggerState,
                 fragmentID: UInt32,
                 reassembled: inout FrameArray,
-                forceFlush: Bool
+                forceFlush: Bool,
+                now: NetworkClock.Instant
             ) {
                 let hasAccumulatedFragments = reassemblyState?.inputReassemblyFrames.isEmpty == false
                 let isNewID = reassemblyState?.reassemblyID != fragmentID
 
                 if hasAccumulatedFragments && (isNewID || forceFlush) {
-                    appendReassembledPackets(log, reassembled: &reassembled)
+                    appendReassembledPackets(log, reassembled: &reassembled, now: now)
                     // Only discard buffered fragments when the IP ID change
                     if isNewID && !forceFlush {
                         var dropped = 0
@@ -1426,7 +1440,11 @@ public struct IPProtocol: NetworkProtocol {
                 }
             }
 
-            mutating func processInboundFrames(_ log: borrowing NetworkLoggerState, _ inboundFrames: inout FrameArray) {
+            mutating func processInboundFrames(
+                _ log: borrowing NetworkLoggerState,
+                _ inboundFrames: inout FrameArray,
+                now: NetworkClock.Instant
+            ) {
 
                 let localAddress = self.localAddress.addressValue
                 let remoteAddress = self.remoteAddress.addressValue
@@ -1558,7 +1576,7 @@ public struct IPProtocol: NetworkProtocol {
                         break
                     }
                     if self.flags.calculateReceiveTime {
-                        frame.timestamp = Frame.FrameTimestamp.receiveTime(.now)
+                        frame.timestamp = Frame.FrameTimestamp.receiveTime(now)
                     }
                     if self.flags.receiveHopLimit {
                         frame.hopLimit = hopLimit
@@ -1639,7 +1657,8 @@ public struct IPProtocol: NetworkProtocol {
                         log,
                         fragmentID: fragmentID,
                         reassembled: &reassembledFragments,
-                        forceFlush: false
+                        forceFlush: false,
+                        now: now
                     )
 
                     let currentFragmentCount = reassemblyState?.inputReassemblyFrames.count ?? 0
@@ -1685,7 +1704,13 @@ public struct IPProtocol: NetworkProtocol {
                     }
                     self.counters.rxPackets += 1
                 }
-                processReassembly(log, fragmentID: 0, reassembled: &reassembledFragments, forceFlush: true)
+                processReassembly(
+                    log,
+                    fragmentID: 0,
+                    reassembled: &reassembledFragments,
+                    forceFlush: true,
+                    now: now
+                )
                 processedFrames.add(frames: reassembledFragments)
                 inboundFrames.add(frames: processedFrames)
             }
@@ -2015,7 +2040,12 @@ public struct IPProtocol: NetworkProtocol {
                 guard var inboundFrames, !inboundFrames.isEmpty else {
                     return nil
                 }
-                IPInstance.processInbound(&self.instanceType, log: self.log, frames: &inboundFrames)
+                IPInstance.processInbound(
+                    &self.instanceType,
+                    log: self.log,
+                    frames: &inboundFrames,
+                    now: NetworkClock.Instant.now
+                )
                 guard !inboundFrames.isEmpty else {
                     log.error("Dropped inbound packets, checking for more")
                     continue
@@ -2060,18 +2090,26 @@ public struct IPProtocol: NetworkProtocol {
             try invokeSendDatagrams(datagrams)
         }
 
+        /// - Parameter now: Read lazily, and only when something will use it. Every consumer of
+        ///   this instant is behind `calculateReceiveTime`, so reading the clock unconditionally
+        ///   would charge a clock read to every inbound batch of a stack that never asks for
+        ///   receive timestamps. Resolved once here, so the frames of a batch still share one
+        ///   instant.
         @inline(__always)
         private static func processInbound(
             _ instanceType: inout IPInstanceType,
             log: borrowing NetworkLoggerState,
-            frames: inout FrameArray
+            frames: inout FrameArray,
+            now: @autoclosure () -> NetworkClock.Instant
         ) {
             switch instanceType {
             case .ipv4(var instance):
-                instance.processInboundFrames(log, &frames)
+                let receiveTime = instance.flags.calculateReceiveTime ? now() : .zero
+                instance.processInboundFrames(log, &frames, now: receiveTime)
                 instanceType = .ipv4(instance)
             case .ipv6(var instance):
-                instance.processInboundFrames(log, &frames)
+                let receiveTime = instance.flags.calculateReceiveTime ? now() : .zero
+                instance.processInboundFrames(log, &frames, now: receiveTime)
                 instanceType = .ipv6(instance)
             }
         }

--- a/Sources/SwiftNetwork/QUIC/Ack.swift
+++ b/Sources/SwiftNetwork/QUIC/Ack.swift
@@ -232,7 +232,11 @@ struct AckSpace: ~Copyable, PrefixedLoggable {
             delay = 0
         case .applicationData:
             if delay == 0 {
-                delay = UInt64(largestTimestamp.duration(to: now).microseconds) >> delayExponent
+                // ACK Delay is an unsigned varint (RFC 9000 Section 19.3), and `UInt64` traps on a
+                // negative `Int64`. Clamp rather than widen: a delay measured as negative has no
+                // representation on the wire other than zero.
+                let elapsed = max(.zero, largestTimestamp.duration(to: now))
+                delay = UInt64(elapsed.microseconds) >> delayExponent
             }
 
         }
@@ -513,13 +517,14 @@ struct Ack: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
         }
     }
 
-    mutating func timerFired(timeNow: NetworkClock.Instant) {
+    mutating func timerFired(at timeNow: NetworkClock.Instant) {
         log.datapath("delayed ACK timer fired")
         if let connection = connection {
             if sendPending(
                 isAckSet: connection.isAckSet,
                 setAckFrame: connection.scheduleAckFrame,
-                ecn: connection.ecn
+                ecn: connection.ecn,
+                now: timeNow
             ) {
                 connection.sendFrames(delayedACK: true)
 
@@ -622,7 +627,8 @@ struct Ack: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
         delayExponent: Int,
         isAckSet: (PacketNumberSpace) -> Bool,
         setAckFrame: (PacketNumberSpace, consuming QUICFrame, Bool) -> Void,
-        ecn: borrowing ECN
+        ecn: borrowing ECN,
+        now: NetworkClock.Instant
     ) -> Bool {
         var shouldSend = false
         for packetNumberSpace in PacketNumberSpace.allCases {
@@ -649,7 +655,7 @@ struct Ack: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
                             delayExponent: delayExponent,
                             setAckFrame: setAckFrame,
                             ecnCounter: ecnCounter,
-                            now: path.parentProtocol.now
+                            now: now
                         )
                         shouldSend = shouldSend || ackSize > 0
                         ackSpace.needsTransmission = false
@@ -673,17 +679,19 @@ struct Ack: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
         on path: QUICPath,
         isAckSet: (PacketNumberSpace) -> Bool,
         setAckFrame: (PacketNumberSpace, consuming QUICFrame, Bool) -> Void,
-        ecn: borrowing ECN
+        ecn: borrowing ECN,
+        now: NetworkClock.Instant
     ) -> Bool {
         let shouldSend = assemble(
             for: path,
             delayExponent: localDelayExponent,
             isAckSet: isAckSet,
             setAckFrame: setAckFrame,
-            ecn: ecn
+            ecn: ecn,
+            now: now
         )
         if shouldSend {
-            sent(path.parentProtocol.now)
+            sent(now)
         }
         log.datapath("\(shouldSend)")
         return shouldSend
@@ -692,7 +700,8 @@ struct Ack: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
     mutating func sendPending(
         isAckSet: (PacketNumberSpace) -> Bool,
         setAckFrame: (PacketNumberSpace, consuming QUICFrame, Bool) -> Void,
-        ecn: borrowing ECN
+        ecn: borrowing ECN,
+        now: NetworkClock.Instant
     ) -> Bool {
         guard let connection else {
             return false
@@ -702,14 +711,15 @@ struct Ack: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
                 on: path,
                 isAckSet: isAckSet,
                 setAckFrame: setAckFrame,
-                ecn: ecn
+                ecn: ecn,
+                now: now
             )
         }
         if timerScheduled, let timerID = timerID {
             connection.timer.reschedule(
                 identifier: timerID,
                 fromNow: .zero,
-                timerNow: connection.now
+                timerNow: now
             )
             timerScheduled = false
         }
@@ -802,7 +812,8 @@ struct Ack: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
                 on: path,
                 isAckSet: isAckSet,
                 setAckFrame: setAckFrame,
-                ecn: ecn
+                ecn: ecn,
+                now: now
             )
         }
     }

--- a/Sources/SwiftNetwork/QUIC/Ack.swift
+++ b/Sources/SwiftNetwork/QUIC/Ack.swift
@@ -559,7 +559,7 @@ final class Ack: PrefixedLoggable, TimerUser {
     func append(
         packetNumberSpace: PacketNumberSpace,
         packetNumber: PacketNumber,
-        now: NetworkClock.Instant = .now
+        now: NetworkClock.Instant
     ) {
         withAckSpace(packetNumberSpace: packetNumberSpace) { ackSpace in
             ackSpace.append(packetNumber, packetNumberSpace: packetNumberSpace, now: now)
@@ -598,7 +598,7 @@ final class Ack: PrefixedLoggable, TimerUser {
         isAckSet: Bool,
         setAckFrame: (PacketNumberSpace, consuming QUICFrame, Bool) -> Void,
         ecnCounter: ECNCounter?,
-        now: NetworkClock.Instant = .now
+        now: NetworkClock.Instant
     ) -> Bool {
         var shouldSend = false
         if isAckSet {
@@ -1244,7 +1244,8 @@ extension Ack {
     func buildForTesting(
         for packetNumberSpace: PacketNumberSpace,
         setAckFrame: (PacketNumberSpace, consuming QUICFrame, Bool) -> Void,
-        ecnCounter: ECNCounter? = nil
+        ecnCounter: ECNCounter? = nil,
+        now: NetworkClock.Instant
     ) -> Int {
         var size = 0
         withAckSpace(packetNumberSpace: packetNumberSpace) { ackSpace in
@@ -1254,7 +1255,7 @@ extension Ack {
                 delaySize: delaySize,
                 setAckFrame: setAckFrame,
                 ecnCounter: ecnCounter,
-                now: .now
+                now: now
             )
             return true
         }

--- a/Sources/SwiftNetwork/QUIC/CongestionControl.swift
+++ b/Sources/SwiftNetwork/QUIC/CongestionControl.swift
@@ -92,18 +92,19 @@ enum CongestionControl {
         path: QUICPath?,
         mss: Int,
         packetsLost: Bool,
+        now: NetworkClock.Instant,
         qlog: QLog? = nil
     ) {
         switch self {
         case .cubic(algorithm: var cubic):
-            cubic.ackEnd(rtt: rtt, path: path, mss: mss, packetsLost: packetsLost, qlog: qlog)
+            cubic.ackEnd(rtt: rtt, path: path, mss: mss, packetsLost: packetsLost, now: now, qlog: qlog)
             self = .cubic(algorithm: cubic)
         #if !NETWORK_EMBEDDED
         case .ledbat(algorithm: var ledbat):
-            ledbat.ackEnd(rtt: rtt, path: path, mss: mss, packetsLost: packetsLost, qlog: qlog)
+            ledbat.ackEnd(rtt: rtt, path: path, mss: mss, packetsLost: packetsLost, now: now, qlog: qlog)
             self = .ledbat(algorithm: ledbat)
         case .prague(algorithm: var prague):
-            prague.ackEnd(rtt: rtt, path: path, mss: mss, packetsLost: packetsLost, qlog: qlog)
+            prague.ackEnd(rtt: rtt, path: path, mss: mss, packetsLost: packetsLost, now: now, qlog: qlog)
             self = .prague(algorithm: prague)
         #endif
         }
@@ -145,7 +146,8 @@ enum CongestionControl {
         bytesLost: Int,
         largestLostSentTime: NetworkClock.Instant,
         mss: Int,
-        smoothedRTT: NetworkDuration
+        smoothedRTT: NetworkDuration,
+        now: NetworkClock.Instant
     ) -> Bool {
         switch self {
         case .cubic(algorithm: var cubic):
@@ -153,7 +155,8 @@ enum CongestionControl {
                 bytesLost: bytesLost,
                 largestLostSentTime: largestLostSentTime,
                 mss: mss,
-                smoothedRTT: smoothedRTT
+                smoothedRTT: smoothedRTT,
+                now: now
             )
             self = .cubic(algorithm: cubic)
             return reducedCongestionWindow
@@ -163,7 +166,8 @@ enum CongestionControl {
                 bytesLost: bytesLost,
                 largestLostSentTime: largestLostSentTime,
                 mss: mss,
-                smoothedRTT: smoothedRTT
+                smoothedRTT: smoothedRTT,
+                now: now
             )
             self = .ledbat(algorithm: ledbat)
             return reducedCongestionWindow
@@ -172,7 +176,8 @@ enum CongestionControl {
                 bytesLost: bytesLost,
                 largestLostSentTime: largestLostSentTime,
                 mss: mss,
-                smoothedRTT: smoothedRTT
+                smoothedRTT: smoothedRTT,
+                now: now
             )
             self = .prague(algorithm: prague)
             return reducedCongestionWindow
@@ -329,11 +334,12 @@ protocol CongestionControlProtocol: PrefixedLoggable {
         path: QUICPath?,
         mss: Int,
         packetsLost: Bool,
+        now: NetworkClock.Instant,
         qlog: QLog?
     )
     mutating func spuriousRetransmit(qlog: QLog?)
     mutating func idleTimeout(mss: Int, qlog: QLog?)
-    mutating func enterRecovery(mss: Int, qlog: QLog?)
+    mutating func enterRecovery(mss: Int, now: NetworkClock.Instant, qlog: QLog?)
     mutating func processECN(
         path: QUICPath?,
         ceCount: Int,
@@ -343,6 +349,7 @@ protocol CongestionControlProtocol: PrefixedLoggable {
         largestAckedSentTime: NetworkClock.Instant,
         mss: Int,
         smoothedRTT: NetworkDuration,
+        now: NetworkClock.Instant,
         qlog: QLog?
     )
     mutating func packetLost(
@@ -351,9 +358,15 @@ protocol CongestionControlProtocol: PrefixedLoggable {
         largestLostSentTime: NetworkClock.Instant,
         mss: Int,
         smoothedRTT: NetworkDuration,
+        now: NetworkClock.Instant,
         qlog: QLog?
     ) -> Bool
-    mutating func linkFlowControl(largestAckSentTime: NetworkClock.Instant, mss: Int, qlog: QLog?)
+    mutating func linkFlowControl(
+        largestAckSentTime: NetworkClock.Instant,
+        mss: Int,
+        now: NetworkClock.Instant,
+        qlog: QLog?
+    )
     mutating func persistentCongestion(mss: Int, qlog: QLog?)
     mutating func mssChanged(mss: Int, qlog: QLog?)
     mutating func packetDiscarded(bytesSent: Int, qlog: QLog?)
@@ -469,22 +482,24 @@ extension CongestionControlProtocol {
     mutating func congestionEvent(
         sentTime: NetworkClock.Instant,
         mss: Int,
+        now: NetworkClock.Instant,
         qlog: QLog? = nil
     ) -> Bool {
         // If the packet was sent before recovery started, do nothing
         if packetInRecovery(sentTime: sentTime) { return false }
         // Enter recovery if the packet was sent
         // after start of the previous recovery period
-        enterRecovery(mss: mss, qlog: qlog)
+        enterRecovery(mss: mss, now: now, qlog: qlog)
         return true
     }
 
     mutating func linkFlowControl(
         largestAckSentTime: NetworkClock.Instant,
         mss: Int,
+        now: NetworkClock.Instant,
         qlog: QLog? = nil
     ) {
-        congestionEvent(sentTime: largestAckSentTime, mss: mss, qlog: qlog)
+        congestionEvent(sentTime: largestAckSentTime, mss: mss, now: now, qlog: qlog)
         log.debug(
             "Link was flow controlled, reduced congestion window is \(congestionWindow) bytes"
         )
@@ -526,8 +541,7 @@ extension CongestionControlProtocol {
         }
     }
 
-    mutating func revalidateCongestionWindow(smoothedRTT: NetworkDuration) -> Bool {
-        let now = NetworkClock.Instant.now
+    mutating func revalidateCongestionWindow(smoothedRTT: NetworkDuration, now: NetworkClock.Instant) -> Bool {
         if pipeAckSampleEnd == .zero {
             pipeAckNewRound(target: now.advanced(by: smoothedRTT))
         }

--- a/Sources/SwiftNetwork/QUIC/CongestionControl.swift
+++ b/Sources/SwiftNetwork/QUIC/CongestionControl.swift
@@ -339,6 +339,7 @@ protocol CongestionControlProtocol: PrefixedLoggable {
     )
     mutating func spuriousRetransmit(qlog: QLog?)
     mutating func idleTimeout(mss: Int, qlog: QLog?)
+    /// Opens a recovery period at `now`, the time the loss was detected.
     mutating func enterRecovery(mss: Int, now: NetworkClock.Instant, qlog: QLog?)
     mutating func processECN(
         path: QUICPath?,
@@ -478,6 +479,7 @@ extension CongestionControlProtocol {
         sentTime <= recoveryStartTime
     }
 
+    /// `sentTime` is when the packet went out, `now` when its loss was detected.
     @discardableResult
     mutating func congestionEvent(
         sentTime: NetworkClock.Instant,

--- a/Sources/SwiftNetwork/QUIC/Cubic.swift
+++ b/Sources/SwiftNetwork/QUIC/Cubic.swift
@@ -141,8 +141,7 @@ struct Cubic: CongestionControlProtocol, CubicLikeProtocol {
         #endif
     }
 
-    private mutating func getTarget(mss: Int, smoothedRTT: NetworkDuration) -> UInt64 {
-        let now = NetworkClock.Instant.now
+    private mutating func getTarget(mss: Int, smoothedRTT: NetworkDuration, now: NetworkClock.Instant) -> UInt64 {
         if epochStart == .zero {
             // If we exit slow start without any packet
             // loss, CUBIC switches to CA where t is the elapsed
@@ -189,11 +188,12 @@ struct Cubic: CongestionControlProtocol, CubicLikeProtocol {
     private mutating func processAckCongestionAvoidance(
         bytesAcked: UInt64,
         smoothedRTT: NetworkDuration,
-        mss: Int
+        mss: Int,
+        now: NetworkClock.Instant
     ) {
         totalAcked += bytesAcked
         // compute W(t+RTT)
-        let WCubicNext = getTarget(mss: mss, smoothedRTT: smoothedRTT)
+        let WCubicNext = getTarget(mss: mss, smoothedRTT: smoothedRTT, now: now)
         updateTCPWindow(bytesAcked: bytesAcked, mss: mss)
         if congestionWindow < WCubicNext {
             // Either concave or convex region
@@ -245,22 +245,23 @@ struct Cubic: CongestionControlProtocol, CubicLikeProtocol {
         largestLostSentTime: NetworkClock.Instant,
         mss: Int,
         smoothedRTT: NetworkDuration,
+        now: NetworkClock.Instant,
         qlog: QLog? = nil
     ) -> Bool {
         decrementBytesInFlight(UInt64(bytesLost))
         let reducedCongestionWindow = congestionEvent(
             sentTime: largestLostSentTime,
             mss: mss,
+            now: now,
             qlog: qlog
         )
         updatePacerState(path: path, smoothedRTT: smoothedRTT)
         return reducedCongestionWindow
     }
 
-    mutating func enterRecovery(mss: Int, qlog: QLog? = nil) {
+    mutating func enterRecovery(mss: Int, now: NetworkClock.Instant, qlog: QLog? = nil) {
         log.datapath("Entering Recovery: current cwin=\(congestionWindow)")
-        let timeNow = NetworkClock.Instant.now
-        recoveryStartTime = timeNow
+        recoveryStartTime = now
         lastMaxCongestionWindow = maxCongestionWindow
         maxCongestionWindow = congestionWindow
         congestionWindow = UInt64(Double(lossFlightSize) * Cubic.beta)
@@ -284,7 +285,7 @@ struct Cubic: CongestionControlProtocol, CubicLikeProtocol {
         // Note that K = 0 if we enter congestion avoidance without loss.
         setK(mss: mss)
         // Set the start of current congestion avoidance and the origin point
-        epochStart = timeNow
+        epochStart = now
         originPoint = maxCongestionWindow
         // Reset tcpCongestionWindow to be in sync with cubic
         tcpCongestionWindow = congestionWindow
@@ -300,6 +301,7 @@ struct Cubic: CongestionControlProtocol, CubicLikeProtocol {
         path: QUICPath? = nil,
         mss: Int,
         packetsLost: Bool,
+        now: NetworkClock.Instant,
         qlog: QLog? = nil
     ) {
         if packetsLost {
@@ -312,7 +314,7 @@ struct Cubic: CongestionControlProtocol, CubicLikeProtocol {
             return
         }
         let smoothedRTT = rtt.smoothedRTT
-        if !revalidateCongestionWindow(smoothedRTT: smoothedRTT) {
+        if !revalidateCongestionWindow(smoothedRTT: smoothedRTT, now: now) {
             bytesAcked = 0
             return
         }
@@ -325,7 +327,8 @@ struct Cubic: CongestionControlProtocol, CubicLikeProtocol {
             processAckCongestionAvoidance(
                 bytesAcked: bytesAcked,
                 smoothedRTT: smoothedRTT,
-                mss: mss
+                mss: mss,
+                now: now
             )
         }
         // Should be a minimum of 2*MSS
@@ -345,6 +348,7 @@ struct Cubic: CongestionControlProtocol, CubicLikeProtocol {
         largestAckedSentTime: NetworkClock.Instant,
         mss: Int,
         smoothedRTT: NetworkDuration,
+        now: NetworkClock.Instant,
         qlog: QLog? = nil
     ) {
         if _slowPath(ceCount < ecnCECounter) {
@@ -381,7 +385,7 @@ struct Cubic: CongestionControlProtocol, CubicLikeProtocol {
             // Haven't elapsed one RTT yet from last CWR
             return
         }
-        congestionEvent(sentTime: largestAckedSentTime, mss: mss, qlog: qlog)
+        congestionEvent(sentTime: largestAckedSentTime, mss: mss, now: now, qlog: qlog)
         // Update pacer state as congestionWindow has changed
         updatePacerState(path: path, smoothedRTT: smoothedRTT)
         // Start new round for CWR

--- a/Sources/SwiftNetwork/QUIC/Ledbat.swift
+++ b/Sources/SwiftNetwork/QUIC/Ledbat.swift
@@ -87,19 +87,21 @@ struct Ledbat: CongestionControlProtocol, CubicLikeProtocol {
         largestLostSentTime: NetworkClock.Instant,
         mss: Int,
         smoothedRTT: NetworkDuration,
+        now: NetworkClock.Instant,
         qlog: QLog? = nil
     ) -> Bool {
         decrementBytesInFlight(UInt64(bytesLost))
         let reducedCongestionWindow = congestionEvent(
             sentTime: largestLostSentTime,
             mss: mss,
+            now: now,
             qlog: qlog
         )
         return reducedCongestionWindow
     }
 
-    mutating func enterRecovery(mss: Int, qlog: QLog? = nil) {
-        recoveryStartTime = .now
+    mutating func enterRecovery(mss: Int, now: NetworkClock.Instant, qlog: QLog? = nil) {
+        recoveryStartTime = now
         prevCongestionWindow = congestionWindow
         congestionWindow = UInt64(Double(lossFlightSize) * Ledbat.beta)
         if _slowPath(congestionWindow < Ledbat.minCongestionWindow(mss)) {
@@ -117,6 +119,7 @@ struct Ledbat: CongestionControlProtocol, CubicLikeProtocol {
         path: QUICPath? = nil,
         mss: Int,
         packetsLost: Bool,
+        now: NetworkClock.Instant,
         qlog: QLog? = nil
     ) {
         guard packetsLost == false else {
@@ -129,7 +132,7 @@ struct Ledbat: CongestionControlProtocol, CubicLikeProtocol {
             return
         }
         let smoothedRTT = rtt.smoothedRTT
-        if !revalidateCongestionWindow(smoothedRTT: smoothedRTT) {
+        if !revalidateCongestionWindow(smoothedRTT: smoothedRTT, now: now) {
             bytesAcked = 0
             return
         }
@@ -140,7 +143,6 @@ struct Ledbat: CongestionControlProtocol, CubicLikeProtocol {
             return
         }
         let qDelay = currentRTT - baseRTT
-        let now = NetworkClock.Instant.now
         // Slowdown period - first slowdown
         // is 2RTT after we exit initial slow start.
         // Subsequent slowdowns are after 9 times the
@@ -238,6 +240,7 @@ struct Ledbat: CongestionControlProtocol, CubicLikeProtocol {
         largestAckedSentTime: NetworkClock.Instant,
         mss: Int,
         smoothedRTT: NetworkDuration,
+        now: NetworkClock.Instant,
         qlog: QLog? = nil
     ) {
         if _slowPath(ceCount < ecnCECounter) {
@@ -269,7 +272,7 @@ struct Ledbat: CongestionControlProtocol, CubicLikeProtocol {
             /* Haven't elapsed one RTT yet from last CWR */
             return
         }
-        congestionEvent(sentTime: largestAckedSentTime, mss: mss)
+        congestionEvent(sentTime: largestAckedSentTime, mss: mss, now: now)
 
         // Start new round for CWR
         self.largestSentPN = largestSentPN

--- a/Sources/SwiftNetwork/QUIC/Migration.swift
+++ b/Sources/SwiftNetwork/QUIC/Migration.swift
@@ -30,7 +30,7 @@ struct Migration: ~Copyable {
 
     private func sendPendingChallenges(
         connection: QUICConnection,
-        now: NetworkClock.Instant = NetworkClock.Instant.now
+        now: NetworkClock.Instant
     ) {
         connection.applyToAllPaths { path in
             if path.hasPendingItems(now: now) {
@@ -45,7 +45,7 @@ struct Migration: ~Copyable {
             return
         }
 
-        let now = NetworkClock.Instant.now
+        let now = connection.now
         sendPendingChallenges(connection: connection, now: now)
 
         var firstChallengeTime: NetworkClock.Instant?
@@ -92,7 +92,7 @@ struct Migration: ~Copyable {
     func timerFired(connection: QUICConnection) {
         connection.log.debug("Migration timer fired")
 
-        sendPendingChallenges(connection: connection)
+        sendPendingChallenges(connection: connection, now: connection.now)
     }
 
     func migrate(to path: QUICPath, connection: QUICConnection) {

--- a/Sources/SwiftNetwork/QUIC/Migration.swift
+++ b/Sources/SwiftNetwork/QUIC/Migration.swift
@@ -39,13 +39,12 @@ struct Migration: ~Copyable {
         }
     }
 
-    func resetTimer(connection: QUICConnection) {
+    func resetTimer(now: NetworkClock.Instant, connection: QUICConnection) {
         guard let timerID else {
             connection.log.fault("Attempt to arm the migration timer when timer ID is unset")
             return
         }
 
-        let now = connection.now
         sendPendingChallenges(connection: connection, now: now)
 
         var firstChallengeTime: NetworkClock.Instant?
@@ -72,7 +71,7 @@ struct Migration: ~Copyable {
             connection.timer.reschedule(
                 identifier: timerID,
                 fromNow: .zero,
-                timerNow: connection.now
+                timerNow: now
             )
             return
         }
@@ -85,14 +84,17 @@ struct Migration: ~Copyable {
         connection.timer.reschedule(
             identifier: timerID,
             fromNow: duration,
-            timerNow: connection.now
+            timerNow: now
         )
     }
 
-    func timerFired(connection: QUICConnection) {
+    func timerFired(at firedAt: NetworkClock.Instant, connection: QUICConnection) {
         connection.log.debug("Migration timer fired")
 
-        sendPendingChallenges(connection: connection, now: connection.now)
+        // The timer must be re-armed even when no challenge is due: `Timer` fires up to
+        // `Timer.timerThreshold` early and has already disabled the entry, so an early wakeup would
+        // otherwise stall probing. `resetTimer` sends whatever is due before arming.
+        resetTimer(now: firedAt, connection: connection)
     }
 
     func migrate(to path: QUICPath, connection: QUICConnection) {
@@ -110,7 +112,7 @@ struct Migration: ~Copyable {
         connection.log.notice("Migrating to path \(path.identifier)")
         connection.currentPath = path
         path.spinValue = connection.initialSpinValue
-        connection.recovery.resetTimer(connection: connection)
+        connection.recovery.resetTimer(now: connection.now, connection: connection)
         path.resetPacer()
         path.pmtudState.start(on: path)
         connection.applyToAllPaths { otherPath in
@@ -202,7 +204,7 @@ extension QUICConnection {
             if isServer, path != currentPath, !path.isValidated {
                 path.beginValidation()
                 sendFrames(on: path)
-                migration.resetTimer(connection: self)
+                migration.resetTimer(now: self.now, connection: self)
             }
             break
         case .unavailable:

--- a/Sources/SwiftNetwork/QUIC/PMTUD.swift
+++ b/Sources/SwiftNetwork/QUIC/PMTUD.swift
@@ -131,7 +131,7 @@ struct PMTUDState: ~Copyable {
 
         if timerID == nil {
             let pathID = path.identifier
-            timerID = connection.timer.insert(description: "PMTUD") {
+            timerID = connection.timer.insert(description: "PMTUD", timerNow: connection.now) {
                 let innerPath = connection.path(for: pathID)
                 guard let innerPath else { return }
                 innerPath.pmtudState.timerFired(timeNow: connection.now, path: innerPath)

--- a/Sources/SwiftNetwork/QUIC/PMTUD.swift
+++ b/Sources/SwiftNetwork/QUIC/PMTUD.swift
@@ -131,10 +131,10 @@ struct PMTUDState: ~Copyable {
 
         if timerID == nil {
             let pathID = path.identifier
-            timerID = connection.timer.insert(description: "PMTUD", timerNow: connection.now) {
+            timerID = connection.timer.insert(description: "PMTUD", timerNow: connection.now) { firedAt in
                 let innerPath = connection.path(for: pathID)
                 guard let innerPath else { return }
-                innerPath.pmtudState.timerFired(timeNow: connection.now, path: innerPath)
+                innerPath.pmtudState.timerFired(timeNow: firedAt, path: innerPath)
             }
         }
 

--- a/Sources/SwiftNetwork/QUIC/PMTUD.swift
+++ b/Sources/SwiftNetwork/QUIC/PMTUD.swift
@@ -134,7 +134,7 @@ struct PMTUDState: ~Copyable {
             timerID = connection.timer.insert(description: "PMTUD", timerNow: connection.now) { firedAt in
                 let innerPath = connection.path(for: pathID)
                 guard let innerPath else { return }
-                innerPath.pmtudState.timerFired(timeNow: firedAt, path: innerPath)
+                innerPath.pmtudState.timerFired(at: firedAt, path: innerPath)
             }
         }
 
@@ -381,7 +381,7 @@ struct PMTUDState: ~Copyable {
         return sendProbe(on: path)
     }
 
-    mutating func timerFired(timeNow: NetworkClock.Instant, path: QUICPath) {
+    mutating func timerFired(at timeNow: NetworkClock.Instant, path: QUICPath) {
         path.log.debug("PMTUD timer fired")
         self.searchCompleted = false
         self.updateProbeSize(on: path)

--- a/Sources/SwiftNetwork/QUIC/Prague.swift
+++ b/Sources/SwiftNetwork/QUIC/Prague.swift
@@ -161,8 +161,11 @@ struct Prague: CongestionControlProtocol, CubicLikeProtocol {
         cubicK = K
     }
 
-    private mutating func getCubicTarget(mss: Int, smoothedRTT: NetworkDuration) -> UInt64 {
-        let now = NetworkClock.Instant.now
+    private mutating func getCubicTarget(
+        mss: Int,
+        smoothedRTT: NetworkDuration,
+        now: NetworkClock.Instant
+    ) -> UInt64 {
         if cubicEpochStart == .zero {
             // If we exit slow start without any packet loss, CUBIC switches to CA
             // where t is the elapsed time since the beginning of the current CA.
@@ -211,12 +214,13 @@ struct Prague: CongestionControlProtocol, CubicLikeProtocol {
     private mutating func cubicProcessAckCA(
         bytesAcked: UInt64,
         smoothedRTT: NetworkDuration,
-        mss: Int
+        mss: Int,
+        now: NetworkClock.Instant
     ) {
         cubicAcked += bytesAcked
 
         // compute W(t+RTT)
-        let wCubicNext = getCubicTarget(mss: mss, smoothedRTT: smoothedRTT)
+        let wCubicNext = getCubicTarget(mss: mss, smoothedRTT: smoothedRTT, now: now)
 
         updateRenoCongestionWindow(bytesAcked: bytesAcked, mss: mss)
 
@@ -323,10 +327,9 @@ struct Prague: CongestionControlProtocol, CubicLikeProtocol {
         sentTime <= recoveryStartTime
     }
 
-    mutating func enterRecovery(mss: Int, qlog: QLog? = nil) {
+    mutating func enterRecovery(mss: Int, now: NetworkClock.Instant, qlog: QLog? = nil) {
         log.datapath("Entering Recovery: current cwin=\(congestionWindow)")
-        let timeNow = NetworkClock.Instant.now
-        recoveryStartTime = timeNow
+        recoveryStartTime = now
         cubicLastMaxCongestionWindow = cubicMaxCongestionWindow
         cubicMaxCongestionWindow = congestionWindow
 
@@ -354,7 +357,7 @@ struct Prague: CongestionControlProtocol, CubicLikeProtocol {
         // Note that K = 0 if we enter CA without loss.
         setCubicK(mss: mss)
         // Set the start of current CA and the origin point
-        cubicEpochStart = timeNow
+        cubicEpochStart = now
         cubicOriginPoint = cubicMaxCongestionWindow
         // Reset renoCongestionWindow to be in sync with Prague
         renoCongestionWindow = congestionWindow
@@ -462,6 +465,7 @@ struct Prague: CongestionControlProtocol, CubicLikeProtocol {
     private mutating func pragueCongestionEvent(
         sentTime: NetworkClock.Instant,
         mss: Int,
+        now: NetworkClock.Instant,
         qlog: QLog? = nil
     ) -> Bool {
         // If the packet was sent before recovery started, do nothing
@@ -469,7 +473,7 @@ struct Prague: CongestionControlProtocol, CubicLikeProtocol {
             return false
         }
 
-        enterRecovery(mss: mss, qlog: qlog)
+        enterRecovery(mss: mss, now: now, qlog: qlog)
         return true
     }
 
@@ -480,12 +484,14 @@ struct Prague: CongestionControlProtocol, CubicLikeProtocol {
         largestLostSentTime: NetworkClock.Instant,
         mss: Int,
         smoothedRTT: NetworkDuration,
+        now: NetworkClock.Instant,
         qlog: QLog? = nil
     ) -> Bool {
         decrementBytesInFlight(UInt64(bytesLost))
         let reducedCongestionWindow = pragueCongestionEvent(
             sentTime: largestLostSentTime,
             mss: mss,
+            now: now,
             qlog: qlog
         )
         updatePacerState(path: path, smoothedRTT: smoothedRTT)
@@ -497,6 +503,7 @@ struct Prague: CongestionControlProtocol, CubicLikeProtocol {
         path: QUICPath? = nil,
         mss: Int,
         packetsLost: Bool,
+        now: NetworkClock.Instant,
         qlog: QLog? = nil
     ) {
         if packetsLost {
@@ -511,7 +518,7 @@ struct Prague: CongestionControlProtocol, CubicLikeProtocol {
         }
 
         let smoothedRTT = rtt.smoothedRTT
-        if !revalidateCongestionWindow(smoothedRTT: smoothedRTT) {
+        if !revalidateCongestionWindow(smoothedRTT: smoothedRTT, now: now) {
             bytesAcked = 0
             return
         }
@@ -522,7 +529,7 @@ struct Prague: CongestionControlProtocol, CubicLikeProtocol {
             if reducedDueToCE {
                 pragueCAAfterCE(bytesAcked: bytesAcked, mss: mss)
             } else {
-                cubicProcessAckCA(bytesAcked: bytesAcked, smoothedRTT: smoothedRTT, mss: mss)
+                cubicProcessAckCA(bytesAcked: bytesAcked, smoothedRTT: smoothedRTT, mss: mss, now: now)
             }
         }
 
@@ -543,6 +550,7 @@ struct Prague: CongestionControlProtocol, CubicLikeProtocol {
         largestAckedSentTime: NetworkClock.Instant,
         mss: Int,
         smoothedRTT: NetworkDuration,
+        now: NetworkClock.Instant,
         qlog: QLog? = nil
     ) {
         if _slowPath(ceCount < ecnCECounter) {

--- a/Sources/SwiftNetwork/QUIC/QLog.swift
+++ b/Sources/SwiftNetwork/QUIC/QLog.swift
@@ -633,7 +633,7 @@ final class QLog {
         }
     }
 
-    func packetSent(_ packet: borrowing Packet, timestamp: NetworkClock.Instant = .now) {
+    func packetSent(_ packet: borrowing Packet, timestamp: NetworkClock.Instant) {
         let packetType = PacketType(packet: packet)
         let packetHeader = PacketHeader(packet: packet)
         let frameList = EventFrames(packet: packet)
@@ -651,7 +651,7 @@ final class QLog {
     func packetReceived(
         _ packet: borrowing Packet,
         coalesced isCoalesced: Bool,
-        timestamp: NetworkClock.Instant = .now
+        timestamp: NetworkClock.Instant
     ) {
         let packetEvent = EventPacket(
             packetType: PacketType(packet: packet),
@@ -667,7 +667,7 @@ final class QLog {
     func packetLost(
         _ packet: borrowing SentPacketRecord,
         trigger: QLogPacketLostTrigger?,
-        timestamp: NetworkClock.Instant = .now
+        timestamp: NetworkClock.Instant
     ) {
         let packetEvent = EventPacket(
             packetType: PacketType(packet: packet),
@@ -691,7 +691,7 @@ final class QLog {
         slowStartThresh: UInt64 = UInt64.max,
         packetsInFlight: UInt64 = UInt64.max,
         inRecovery: Bool?,
-        timestamp: NetworkClock.Instant = .now
+        timestamp: NetworkClock.Instant
     ) {
         let metricEvent = EventMetrics(
             minRTT: minRTT,
@@ -712,7 +712,7 @@ final class QLog {
     public func recoveryUpdated(
         ptoCount: UInt64,
         inRecovery: Bool?,
-        timestamp: NetworkClock.Instant = .now
+        timestamp: NetworkClock.Instant
     ) {
         metricsUpdated(
             minRTT: .zero,
@@ -756,7 +756,7 @@ final class QLog {
         smoothedRTT: NetworkDuration,
         latestRTT: NetworkDuration,
         rttVariance: NetworkDuration,
-        timestamp: NetworkClock.Instant = .now
+        timestamp: NetworkClock.Instant
     ) {
         metricsUpdated(
             minRTT: minRTT,
@@ -778,7 +778,7 @@ final class QLog {
         oldStreamState: QLogStreamState,
         newStreamState: QLogStreamState,
         streamSide: QLogStreamSide?,
-        timestamp: NetworkClock.Instant = .now
+        timestamp: NetworkClock.Instant
     ) {
         if let streamID = stream.streamID, let streamType = stream.streamType {
             let streamEvent = StreamEvent(
@@ -819,7 +819,7 @@ final class QLog {
         owner: QLogOwner?,
         oldStreamType: QUICStreamType,
         newStreamType: QUICStreamType,
-        timestamp: NetworkClock.Instant = .now
+        timestamp: NetworkClock.Instant
     ) {
         let streamTypeSetEvent = StreamTypeSetEvent(
             streamID: streamID,
@@ -855,7 +855,7 @@ final class QLog {
         initialMaxStreamsBidirectional: Int?,
         initialMaxStreamsUnidirectional: Int?,
         preferredAddress: PreferredAddress?,
-        timestamp: NetworkClock.Instant = .now
+        timestamp: NetworkClock.Instant
     ) {
         let parametersEvent = EventParametersSet(
             owner: owner,
@@ -885,7 +885,8 @@ final class QLog {
 
     public func parametersSet(
         owner: QLogOwner?,
-        transportParameters: TransportParameters
+        transportParameters: TransportParameters,
+        timestamp: NetworkClock.Instant
     ) {
         parametersSet(
             owner: owner,
@@ -923,7 +924,8 @@ final class QLog {
                 TransportParameterTypes.initialMaxStreamsUnidirectional
             ]?.value,
             preferredAddress: transportParameters[TransportParameterTypes.preferredAddress]?
-                .preferredAddress
+                .preferredAddress,
+            timestamp: timestamp
         )
     }
 

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -1135,7 +1135,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         if let qLog {
             qLog.parametersSet(
                 owner: owner,
-                transportParameters: transportParameters
+                transportParameters: transportParameters,
+                timestamp: self.now
             )
         }
         #endif
@@ -3763,9 +3764,9 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         #if QlogOutput
         if let qLog {
             if outbound {
-                qLog.packetSent(packet)
+                qLog.packetSent(packet, timestamp: self.now)
             } else {
-                qLog.packetReceived(packet, coalesced: coalesced)
+                qLog.packetReceived(packet, coalesced: coalesced, timestamp: self.now)
             }
         }
         #endif
@@ -4294,7 +4295,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         if let qLog {
             qLog.recoveryUpdated(
                 ptoCount: 0,
-                inRecovery: nil
+                inRecovery: nil,
+                timestamp: self.now
             )
         }
         #endif

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -448,12 +448,12 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
 
         self.timer = Timer(reference: self.reference, timerReference: timerReference, logPrefixer: logPrefixer)
         let ackTimerID = timer.insert(description: "ACK", timerNow: self.now) { firedAt in
-            self.ack.timerFired(timeNow: firedAt)
+            self.ack.timerFired(at: firedAt)
         }
         self.ack = Ack(connection: self, timerID: ackTimerID, logPrefixer: logPrefixer)
 
         let recoveryTimerID = timer.insert(description: "Recovery", timerNow: self.now) { firedAt in
-            self.recovery.timerFired(timeNow: firedAt)
+            self.recovery.timerFired(at: firedAt)
         }
         self.recovery = Recovery(
             connection: self,
@@ -461,8 +461,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             logPrefixer: logPrefixer
         )
 
-        migration.timerID = timer.insert(description: "Migration", timerNow: self.now) { _ in
-            self.migration.timerFired(connection: self)
+        migration.timerID = timer.insert(description: "Migration", timerNow: self.now) { firedAt in
+            self.migration.timerFired(at: firedAt, connection: self)
         }
 
         if let remote, case .address(let remoteAddress) = remote.type,
@@ -1369,8 +1369,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             description: "Idle timeout",
             fromNow: idleTimeout,
             timerNow: self.now
-        ) { _ in
-            self.idleTimeoutFired()
+        ) { firedAt in
+            self.idleTimeoutFired(firedAt: firedAt)
         }
 
         guard let idleTimerID else {
@@ -1406,13 +1406,12 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         }
     }
 
-    func idleTimeoutFired() {
+    func idleTimeoutFired(firedAt now: NetworkClock.Instant) {
         // Assumption: Timer will not be active unless:
         //   - server: initial packet received
         //   - client: initial packet sent
 
         // Check when the last activity was recorded
-        let now = self.now
         guard now >= lastPacketReceivedTimestamp else {
             log.fault("Now should not be less than lastPacketReceivedTimestamp")
             return
@@ -1429,7 +1428,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
                     timer.reschedule(
                         identifier: idleTimerID,
                         fromNow: sleepDuration,
-                        timerNow: self.now
+                        timerNow: now
                     )
                 }
                 return
@@ -2795,7 +2794,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         writeQLog()
     }
 
-    func keepaliveSendPingFrame(timeSinceLastReceived: NetworkDuration) {
+    func keepaliveSendPingFrame(timeSinceLastReceived: NetworkDuration, now: NetworkClock.Instant) {
         // N.B.: allow 1ms of leeway.
         if timeSinceLastReceived + .milliseconds(1) >= keepaliveDuration {
             if maxKeepaliveCount > 0 && unackedKeepaliveCount >= maxKeepaliveCount {
@@ -2824,7 +2823,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
                 timer.reschedule(
                     identifier: keepaliveTimerID,
                     fromNow: keepaliveDuration,
-                    timerNow: self.now
+                    timerNow: now
                 )
             }
             // Keepalive packets ignore the congestion window.
@@ -2833,11 +2832,10 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         }
     }
 
-    func keepaliveHandler() {
+    func keepaliveHandler(firedAt now: NetworkClock.Instant) {
         // We try to delay the keep-alive by some delta amount
         // depending on when we last received a valid packet
         // from the remote side.
-        let now = self.now
         if _slowPath(now < lastPacketReceivedTimestamp) {
             log.fault("Bogus lastPacketReceivedTimestamp")
             return
@@ -2848,7 +2846,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             "Keepalive: now: \(now), last packet: \(self.lastPacketReceivedTimestamp) timeSinceLastReceived: \(timeSinceLastReceived), interval: \(self.keepaliveDuration)"
         )
 
-        keepaliveSendPingFrame(timeSinceLastReceived: timeSinceLastReceived)
+        keepaliveSendPingFrame(timeSinceLastReceived: timeSinceLastReceived, now: now)
     }
 
     func keepaliveConfigure(duration: NetworkDuration) {
@@ -2877,8 +2875,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             minIdleTime = .milliseconds(min(idleTimeoutLocal, idleTimeoutRemote))
         }
         if keepaliveTimerID == nil {
-            keepaliveTimerID = timer.insert(description: "keepalive", timerNow: self.now) { _ in
-                self.keepaliveHandler()
+            keepaliveTimerID = timer.insert(description: "keepalive", timerNow: self.now) { firedAt in
+                self.keepaliveHandler(firedAt: firedAt)
             }
         }
         // If connection has a non-zero timeout, keep-alive has to be less
@@ -3343,6 +3341,10 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
                 shouldEndBurst = true
             } else if packetBurst >= Constants.packetBurstCount {
                 // The packet burst count has been reached, check the time
+                //
+                // Deliberately the live clock rather than `self.now`: under a batch `self.now` is
+                // pinned, and `startSendingTimestamp` came from it, so comparing the two would
+                // always give zero and the cap could never be reached.
                 if startSendingTimestamp.duration(to: .now) >= Constants.maxPacketBurstDuration {
                     // The maximum burst time has been reached
                     shouldEndBurst = true
@@ -4304,7 +4306,9 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
     }
 
     public func wakeup() {
-        self.timer.timerFired(timeNow: self.now)
+        // Outside a batch neither timestamp cache is set, so `self.now` falls through to a clock
+        // read.
+        self.timer.timerFired(at: self.now)
     }
 
     func setupStreamID(isUnidirectional: Bool, isServer: Bool) -> QUICStreamID? {

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -447,13 +447,13 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         self.setMetadataHandlers()
 
         self.timer = Timer(reference: self.reference, timerReference: timerReference, logPrefixer: logPrefixer)
-        let ackTimerID = timer.insert(description: "ACK") {
-            self.ack.timerFired(timeNow: .now)
+        let ackTimerID = timer.insert(description: "ACK", timerNow: self.now) {
+            self.ack.timerFired(timeNow: self.now)
         }
         self.ack = Ack(connection: self, timerID: ackTimerID, logPrefixer: logPrefixer)
 
-        let recoveryTimerID = timer.insert(description: "Recovery") {
-            self.recovery.timerFired(timeNow: .now)
+        let recoveryTimerID = timer.insert(description: "Recovery", timerNow: self.now) {
+            self.recovery.timerFired(timeNow: self.now)
         }
         self.recovery = Recovery(
             connection: self,
@@ -461,7 +461,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             logPrefixer: logPrefixer
         )
 
-        migration.timerID = timer.insert(description: "Migration") {
+        migration.timerID = timer.insert(description: "Migration", timerNow: self.now) {
             self.migration.timerFired(connection: self)
         }
 
@@ -1313,7 +1313,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         } else {
             if state == .idle {
                 // Record handshake start time start
-                handshakeStartTime = .now
+                handshakeStartTime = self.now
 
                 // Start idle timer to terminate unresponded to connection
                 guard clientStartIdleTimer() else {
@@ -1366,7 +1366,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
 
         idleTimerID = timer.insert(
             description: "Idle timeout",
-            fromNow: idleTimeout
+            fromNow: idleTimeout,
+            timerNow: self.now
         ) {
             self.idleTimeoutFired()
         }
@@ -1410,7 +1411,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         //   - client: initial packet sent
 
         // Check when the last activity was recorded
-        let now = NetworkClock.Instant.now
+        let now = self.now
         guard now >= lastPacketReceivedTimestamp else {
             log.fault("Now should not be less than lastPacketReceivedTimestamp")
             return
@@ -2753,7 +2754,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             withCurrentPath { path in
                 _ = timer.insert(
                     description: "draining",
-                    fromNow: path.recoveryState.getMaxPTODrainTime(idleTimeout: self.idleTimeout)
+                    fromNow: path.recoveryState.getMaxPTODrainTime(idleTimeout: self.idleTimeout),
+                    timerNow: self.now
                 ) {
                     self.drain()
                 }
@@ -2834,7 +2836,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         // We try to delay the keep-alive by some delta amount
         // depending on when we last received a valid packet
         // from the remote side.
-        let now = NetworkClock.Instant.now
+        let now = self.now
         if _slowPath(now < lastPacketReceivedTimestamp) {
             log.fault("Bogus lastPacketReceivedTimestamp")
             return
@@ -2874,7 +2876,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             minIdleTime = .milliseconds(min(idleTimeoutLocal, idleTimeoutRemote))
         }
         if keepaliveTimerID == nil {
-            keepaliveTimerID = timer.insert(description: "keepalive") {
+            keepaliveTimerID = timer.insert(description: "keepalive", timerNow: self.now) {
                 self.keepaliveHandler()
             }
         }
@@ -3429,7 +3431,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         let tagSize = protector.getTagSize(for: keyState)
 
         if isPacing {
-            let now = NetworkClock.Instant.now
+            let now = self.now
             // lastAckElicitingPacketSentTimestamp can be in the future for kernel packet pacing.
             if now > lastAckElicitingPacketSentTimestamp {
                 let idleTime = lastAckElicitingPacketSentTimestamp.duration(to: now)
@@ -3742,7 +3744,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
     private func log(packet: inout Packet, coalesced: Bool = false, outbound: Bool) {
         #if !NETWORK_EMBEDDED
         if Logger.swiftNetworkDatapathLoggingEnabled {
-            let now = NetworkClock.Instant.now
+            let now = self.now
             var delta: NetworkDuration = .milliseconds(0)
             if lastShorthandTimestamp != .zero {
                 delta = lastShorthandTimestamp.duration(to: now)
@@ -4172,7 +4174,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             }
         }
 
-        handshakeDuration = handshakeStartTime.duration(to: .now)
+        handshakeDuration = handshakeStartTime.duration(to: self.now)
         var currentRTT: NetworkDuration = .milliseconds(0)
         if let currentPath = currentPath {
             currentRTT = currentPath.rtt.smoothedRTT
@@ -4300,7 +4302,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
     }
 
     public func wakeup() {
-        self.timer.timerFired()
+        self.timer.timerFired(timeNow: self.now)
     }
 
     func setupStreamID(isUnidirectional: Bool, isServer: Bool) -> QUICStreamID? {

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -447,13 +447,13 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         self.setMetadataHandlers()
 
         self.timer = Timer(reference: self.reference, timerReference: timerReference, logPrefixer: logPrefixer)
-        let ackTimerID = timer.insert(description: "ACK", timerNow: self.now) {
-            self.ack.timerFired(timeNow: self.now)
+        let ackTimerID = timer.insert(description: "ACK", timerNow: self.now) { firedAt in
+            self.ack.timerFired(timeNow: firedAt)
         }
         self.ack = Ack(connection: self, timerID: ackTimerID, logPrefixer: logPrefixer)
 
-        let recoveryTimerID = timer.insert(description: "Recovery", timerNow: self.now) {
-            self.recovery.timerFired(timeNow: self.now)
+        let recoveryTimerID = timer.insert(description: "Recovery", timerNow: self.now) { firedAt in
+            self.recovery.timerFired(timeNow: firedAt)
         }
         self.recovery = Recovery(
             connection: self,
@@ -461,7 +461,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             logPrefixer: logPrefixer
         )
 
-        migration.timerID = timer.insert(description: "Migration", timerNow: self.now) {
+        migration.timerID = timer.insert(description: "Migration", timerNow: self.now) { _ in
             self.migration.timerFired(connection: self)
         }
 
@@ -1369,7 +1369,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             description: "Idle timeout",
             fromNow: idleTimeout,
             timerNow: self.now
-        ) {
+        ) { _ in
             self.idleTimeoutFired()
         }
 
@@ -2757,7 +2757,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
                     description: "draining",
                     fromNow: path.recoveryState.getMaxPTODrainTime(idleTimeout: self.idleTimeout),
                     timerNow: self.now
-                ) {
+                ) { _ in
                     self.drain()
                 }
             }
@@ -2877,7 +2877,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             minIdleTime = .milliseconds(min(idleTimeoutLocal, idleTimeoutRemote))
         }
         if keepaliveTimerID == nil {
-            keepaliveTimerID = timer.insert(description: "keepalive", timerNow: self.now) {
+            keepaliveTimerID = timer.insert(description: "keepalive", timerNow: self.now) { _ in
                 self.keepaliveHandler()
             }
         }

--- a/Sources/SwiftNetwork/QUIC/QUICPath.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICPath.swift
@@ -601,7 +601,7 @@ public final class QUICPath: MultiplexingDatagramPath<QUICConnection>, Equatable
         }
         challengesSent += 1
 
-        parentProtocol.migration.resetTimer(connection: parentProtocol)
+        parentProtocol.migration.resetTimer(now: now, connection: parentProtocol)
     }
 
     func addPendingItems(_ pendingItems: inout PendingItems, now: NetworkClock.Instant, ) {
@@ -634,7 +634,7 @@ public final class QUICPath: MultiplexingDatagramPath<QUICConnection>, Equatable
         changeState(to: .validated)
         // Initialize RTT based on the PATH_RESPONSE duration so that we have a proper RTT estimate when we reset the timers.
         rtt.processNewSample(ackDuration: responseDuration, packetAckedTime: now, ackDelay: .zero)
-        parentProtocol.migration.resetTimer(connection: parentProtocol)
+        parentProtocol.migration.resetTimer(now: now, connection: parentProtocol)
         // Notify the stack about the path becoming validated
         if let localEndpoint, let remoteEndpoint,
             case .address(let localAddress) = localEndpoint.type,

--- a/Sources/SwiftNetwork/QUIC/QUICPath.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICPath.swift
@@ -363,7 +363,7 @@ public final class QUICPath: MultiplexingDatagramPath<QUICConnection>, Equatable
         )
     }
 
-    func updateBDP(length: Int, now: NetworkClock.Instant = NetworkClock.Instant.now) {
+    func updateBDP(length: Int, now: NetworkClock.Instant) {
         if bdp.timestamp == .zero {
             bdp.timestamp = now
         }
@@ -610,7 +610,7 @@ public final class QUICPath: MultiplexingDatagramPath<QUICConnection>, Equatable
             return
         }
         log.debug("Valid path challenge response received: \(data)")
-        let now = NetworkClock.Instant.now
+        let now = parentProtocol.now
         let responseDuration = pendingOutboundChallenge.sentTime.duration(to: now)
         pendingOutboundChallenges.removeAll()
         challengesSent = 0
@@ -655,7 +655,14 @@ extension QUICPath {
 
     @inline(__always)
     func congestionControlAckEnd(rtt: borrowing RTT, path: QUICPath?, mss: Int, packetsLost: Bool, qlog: QLog? = nil) {
-        congestionControl?.ackEnd(rtt: rtt, path: self, mss: mss, packetsLost: packetsLost, qlog: qlog)
+        congestionControl?.ackEnd(
+            rtt: rtt,
+            path: self,
+            mss: mss,
+            packetsLost: packetsLost,
+            now: parentProtocol.now,
+            qlog: qlog
+        )
     }
 
     @inline(__always)
@@ -679,7 +686,8 @@ extension QUICPath {
             bytesLost: bytesLost,
             largestLostSentTime: largestLostSentTime,
             mss: mss,
-            smoothedRTT: smoothedRTT
+            smoothedRTT: smoothedRTT,
+            now: parentProtocol.now
         ) ?? false
     }
 
@@ -740,6 +748,7 @@ extension QUICPath {
                 largestAckedSentTime: largestAckedSentTime,
                 mss: mss,
                 smoothedRTT: smoothedRTT,
+                now: parentProtocol.now,
                 qlog: qlog
             )
         #if !NETWORK_EMBEDDED
@@ -752,6 +761,7 @@ extension QUICPath {
                 largestAckedSentTime: largestAckedSentTime,
                 mss: mss,
                 smoothedRTT: smoothedRTT,
+                now: parentProtocol.now,
                 qlog: qlog
             )
         case .prague(var prague):
@@ -763,6 +773,7 @@ extension QUICPath {
                 largestAckedSentTime: largestAckedSentTime,
                 mss: mss,
                 smoothedRTT: smoothedRTT,
+                now: parentProtocol.now,
                 qlog: qlog
             )
         #endif

--- a/Sources/SwiftNetwork/QUIC/Recovery.swift
+++ b/Sources/SwiftNetwork/QUIC/Recovery.swift
@@ -988,7 +988,7 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
     mutating func findLostPacket(
         pnSpace: PacketNumberSpace? = nil,
         path: QUICPath? = nil,
-        timeNow: NetworkClock.Instant = NetworkClock.Instant.now,
+        timeNow: NetworkClock.Instant,
         connection: QUICConnection
     ) -> Bool {
         var packetLost = false
@@ -1281,7 +1281,7 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
         )
         if lossTime != .zero {
             log.datapath("Recovery timer fired, finding lost packets")
-            findLostPacket(connection: connection)
+            findLostPacket(timeNow: timeNow, connection: connection)
         } else {
             log.datapath("Recovery timer fired, PTO")
             connection.withCurrentPath { path in

--- a/Sources/SwiftNetwork/QUIC/Recovery.swift
+++ b/Sources/SwiftNetwork/QUIC/Recovery.swift
@@ -833,7 +833,7 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
     static func logAckElicitingPacketsInFlight(packetCount: Int, connection: QUICConnection) {
         #if QlogOutput
         if let qLog = connection.qLog {
-            qLog.congestionControlUpdated(packetsInFlight: UInt64(packetCount))
+            qLog.congestionControlUpdated(packetsInFlight: UInt64(packetCount), timestamp: connection.now)
         }
         #endif
     }
@@ -847,7 +847,8 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
         if let qLog = connection.qLog {
             qLog.packetLost(
                 packet,
-                trigger: trigger
+                trigger: trigger,
+                timestamp: connection.now
             )
         }
         #endif
@@ -1253,7 +1254,7 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
             qLog.recoveryUpdated(
                 ptoCount: UInt64(path.recoveryState.PTOCount),
                 inRecovery: nil,
-                timestamp: .now
+                timestamp: connection.now
             )
         }
         #endif
@@ -1494,7 +1495,8 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
                                 minRTT: sentPath.rtt.minRTT,
                                 smoothedRTT: sentPath.rtt.smoothedRTT,
                                 latestRTT: sentPath.rtt.latestRTT,
-                                rttVariance: sentPath.rtt.RTTVariance
+                                rttVariance: sentPath.rtt.RTTVariance,
+                                timestamp: connection.now
                             )
                         }
                         #endif

--- a/Sources/SwiftNetwork/QUIC/Recovery.swift
+++ b/Sources/SwiftNetwork/QUIC/Recovery.swift
@@ -664,8 +664,9 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
                 return false
             }
 
+            let now = connection.now
             while let packet = packets.popFirst() {
-                sentPacket(packet, time: connection.now, connection: connection)
+                sentPacket(packet, time: now, connection: connection)
             }
 
             return true
@@ -748,7 +749,7 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
         inBatch = false
         if shouldResetTimer {
             shouldResetTimer = false
-            resetTimer(connection: connection)
+            resetTimer(now: connection.now, connection: connection)
         }
     }
 
@@ -757,13 +758,14 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
         _ sentPackets: inout NetworkUniqueDeque<SentPacketRecord>,
         connection: QUICConnection
     ) {
+        let now = connection.now
         while let packet = sentPackets.popFirst() {
-            sentPacket(packet, time: connection.now, connection: connection)
+            sentPacket(packet, time: now, connection: connection)
         }
         if inBatch {
             shouldResetTimer = true
         } else {
-            resetTimer(connection: connection)
+            resetTimer(now: now, connection: connection)
         }
     }
 
@@ -1104,14 +1106,14 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
         return (earliestTime, pnSpace)
     }
 
-    func setTimer(delay: NetworkDuration, connection: QUICConnection) {
+    func setTimer(delay: NetworkDuration, now: NetworkClock.Instant, connection: QUICConnection) {
         guard let timerID = timerID else {
             return
         }
         connection.timer.reschedule(
             identifier: timerID,
             fromNow: delay,
-            timerNow: connection.now
+            timerNow: now
         )
         log.datapath("Reset loss recovery timer [T\(timerID)] to \(delay)")
     }
@@ -1272,7 +1274,7 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
         }
     }
 
-    mutating func timerFired(timeNow: NetworkClock.Instant) {
+    mutating func timerFired(at timeNow: NetworkClock.Instant) {
         guard let connection = connection else {
             return
         }
@@ -1289,7 +1291,7 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
                 sendPTO(connection: connection, path: path)
             }
         }
-        resetTimer(connection: connection)
+        resetTimer(now: timeNow, connection: connection)
     }
 
     static func PTOPeriod(
@@ -1333,11 +1335,11 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
         return (largestTime >= smallestTime + pto * Constants.persistentCongestionThreshold)
     }
 
-    mutating func resetTimer(connection: QUICConnection) {
+    mutating func resetTimer(now: NetworkClock.Instant, connection: QUICConnection) {
         // if there are ack eliciting packets on any of the innerStates, the L4S error should not be emitted
         if totalAckElicitingPacketsInFlight == 0 && peerCompletedValidation(connection: connection) {
             log.datapath("No ack eliciting packets in flight, cancelling timer")
-            setTimer(delay: .zero, connection: connection)
+            setTimer(delay: .zero, now: now, connection: connection)
             connection.withCurrentPath { path in
                 guard path.isValidated else { return }
                 var bytesInFlight: UInt64 = 0
@@ -1356,7 +1358,6 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
             return
         }
         var timeout: NetworkDuration = .zero
-        let now = connection.now
         let (lossTime, _) = getEarliestTime(earliestTimeType: .lossTime, connection: connection)
         if lossTime != .zero {
             // Time threshold loss detection.
@@ -1366,7 +1367,7 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
                 // lossTime has already passed
                 timeout = .microseconds(1000)
             }
-            setTimer(delay: timeout, connection: connection)
+            setTimer(delay: timeout, now: now, connection: connection)
         } else {
             // Arm PTO
             let (sentTime, pnSpace) = getEarliestTime(
@@ -1377,7 +1378,7 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
             connection.withCurrentPath { path in
                 if pnSpace == .applicationData && !connection.isHandshakeConfirmed {
                     log.datapath("Handshake not confirmed, cancelling timer")
-                    setTimer(delay: .zero, connection: connection)
+                    setTimer(delay: .zero, now: now, connection: connection)
                     path.recoveryState.PTOPeriod = .zero
                     return
                 }
@@ -1391,7 +1392,7 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
                     computedTimeout = timeout
                 }
                 log.datapath("Resetting recovery timer to \(computedTimeout)")
-                setTimer(delay: computedTimeout, connection: connection)
+                setTimer(delay: computedTimeout, now: now, connection: connection)
             }
         }
     }
@@ -1486,7 +1487,7 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
                         }
                         sentPath.rtt.processNewSample(
                             ackDuration: largestAckedEntry.sentTime.duration(to: timeNow),
-                            packetAckedTime: connection.now,
+                            packetAckedTime: timeNow,
                             ackDelay: .microseconds(ack.delay)
                         )
                         #if QlogOutput
@@ -1496,7 +1497,7 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
                                 smoothedRTT: sentPath.rtt.smoothedRTT,
                                 latestRTT: sentPath.rtt.latestRTT,
                                 rttVariance: sentPath.rtt.RTTVariance,
-                                timestamp: connection.now
+                                timestamp: timeNow
                             )
                         }
                         #endif
@@ -1582,7 +1583,7 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
         if inBatch {
             shouldResetTimer = true
         } else {
-            resetTimer(connection: connection)
+            resetTimer(now: timeNow, connection: connection)
         }
 
         // Now that we have deal with all the ACK'ed packets,

--- a/Sources/SwiftNetwork/QUIC/Timer.swift
+++ b/Sources/SwiftNetwork/QUIC/Timer.swift
@@ -32,13 +32,13 @@ internal import os
 @available(Network 0.1.0, *)
 protocol TimerUser {
     var timerID: Timer.TimerID? { get set }
-    func timerFired(timeNow: NetworkClock.Instant)
+    func timerFired(at timeNow: NetworkClock.Instant)
 }
 
 @available(Network 0.1.0, *)
 protocol NonCopyableTimerUser: ~Copyable {
     var timerID: Timer.TimerID? { get set }
-    mutating func timerFired(timeNow: NetworkClock.Instant)
+    mutating func timerFired(at timeNow: NetworkClock.Instant)
 }
 
 @available(Network 0.1.0, *)
@@ -60,6 +60,8 @@ private struct TimerEntry: ~Copyable {
         deadline = .zero
     }
     mutating func schedule(fromNow: NetworkDuration, timerNow: NetworkClock.Instant) {
+        // `.zero` is the disabled sentinel that `isEnabled` reads, so it cannot also mean a
+        // deadline.
         precondition(fromNow != .zero)
         self.deadline = timerNow.advanced(by: fromNow)
     }
@@ -255,7 +257,7 @@ final class Timer: PrefixedLoggable {
         }
     }
 
-    public func timerFired(timeNow: NetworkClock.Instant) {
+    public func timerFired(at timeNow: NetworkClock.Instant) {
         // Timer fired means the kernel woke us up.
         wakeup = .idle
 

--- a/Sources/SwiftNetwork/QUIC/Timer.swift
+++ b/Sources/SwiftNetwork/QUIC/Timer.swift
@@ -59,7 +59,7 @@ private struct TimerEntry: ~Copyable {
     mutating func disable() {
         deadline = .zero
     }
-    mutating func schedule(fromNow: NetworkDuration, timerNow: NetworkClock.Instant = .now) {
+    mutating func schedule(fromNow: NetworkDuration, timerNow: NetworkClock.Instant) {
         precondition(fromNow != .zero)
         self.deadline = timerNow.advanced(by: fromNow)
     }
@@ -112,7 +112,7 @@ final class Timer: PrefixedLoggable {
     func insert(
         description: String,
         fromNow: NetworkDuration = .zero,
-        timerNow: NetworkClock.Instant = .now,
+        timerNow: NetworkClock.Instant,
         closure: @escaping () -> Void
     ) -> TimerID {
         let identifier = nextID
@@ -237,7 +237,7 @@ final class Timer: PrefixedLoggable {
     func reschedule(
         identifier: TimerID,
         fromNow: NetworkDuration,
-        timerNow: NetworkClock.Instant = .now
+        timerNow: NetworkClock.Instant
     ) {
         guard let index = find(identifier) else {
             return
@@ -255,7 +255,7 @@ final class Timer: PrefixedLoggable {
         }
     }
 
-    public func timerFired(timeNow: NetworkClock.Instant = .now) {
+    public func timerFired(timeNow: NetworkClock.Instant) {
         // Timer fired means the kernel woke us up.
         wakeup = .idle
 

--- a/Sources/SwiftNetwork/QUIC/Timer.swift
+++ b/Sources/SwiftNetwork/QUIC/Timer.swift
@@ -46,9 +46,9 @@ private struct TimerEntry: ~Copyable {
     let identifier: Timer.TimerID
     var deadline: NetworkClock.Instant = .zero
     let description: String
-    let closure: () -> Void
+    let closure: (NetworkClock.Instant) -> Void
 
-    init(identifier: Timer.TimerID, description: String, closure: @escaping () -> Void) {
+    init(identifier: Timer.TimerID, description: String, closure: @escaping (NetworkClock.Instant) -> Void) {
         self.identifier = identifier
         self.description = description
         self.closure = closure
@@ -113,7 +113,7 @@ final class Timer: PrefixedLoggable {
         description: String,
         fromNow: NetworkDuration = .zero,
         timerNow: NetworkClock.Instant,
-        closure: @escaping () -> Void
+        closure: @escaping (NetworkClock.Instant) -> Void
     ) -> TimerID {
         let identifier = nextID
         var entry = TimerEntry(identifier: nextID, description: description, closure: closure)
@@ -289,7 +289,7 @@ final class Timer: PrefixedLoggable {
                     )
                 }
                 entries[index].disable()
-                entries[index].closure()
+                entries[index].closure(timeNow)
                 ranOne = true
             }
             index += 1

--- a/Tests/QUICTests/AckTests.swift
+++ b/Tests/QUICTests/AckTests.swift
@@ -26,6 +26,13 @@ import XCTest
 func setAckFrame(_: PacketNumberSpace, _: consuming QUICFrame, _: Bool) {
 }
 
+/// Test-only conveniences that supply a fixed time.
+///
+/// The production signatures deliberately require a time, so that datapath code cannot
+/// silently reach for the real clock. Most ACK tests are about packet-number bookkeeping
+/// and not about time at all, so restating `now:` several hundred times would be noise.
+/// The default here is a *fixed* instant, so those tests stay deterministic. A test
+/// whose premise is timing calls the full form and passes its own instant.
 @available(Network 0.1.0, *)
 extension Ack {
     // only required by the test currently
@@ -37,6 +44,27 @@ extension Ack {
             for: packetNumberSpace,
             setAckFrame: setAckFrame,
             ecnCounter: ecnCounter
+        )
+    }
+
+    func append(packetNumberSpace: PacketNumberSpace, packetNumber: PacketNumber) {
+        self.append(
+            packetNumberSpace: packetNumberSpace,
+            packetNumber: packetNumber,
+            now: .testBase
+        )
+    }
+
+    func buildForTesting(
+        for packetNumberSpace: PacketNumberSpace,
+        setAckFrame: (PacketNumberSpace, consuming QUICFrame, Bool) -> Void,
+        ecnCounter: ECNCounter? = nil
+    ) -> Int {
+        self.buildForTesting(
+            for: packetNumberSpace,
+            setAckFrame: setAckFrame,
+            ecnCounter: ecnCounter,
+            now: .testBase
         )
     }
 }

--- a/Tests/QUICTests/AckTests.swift
+++ b/Tests/QUICTests/AckTests.swift
@@ -888,7 +888,8 @@ final class AckTests: XCTestCase {
             for: .applicationData,
             isAckSet: false,
             setAckFrame: testSetAckFrame,
-            ecnCounter: nil
+            ecnCounter: nil,
+            now: .testBase
         )
         wait(for: [pingExpectation], timeout: 2.0)
         XCTAssertTrue(
@@ -924,7 +925,8 @@ final class AckTests: XCTestCase {
             for: .applicationData,
             isAckSet: false,
             setAckFrame: testSetAckFrame,
-            ecnCounter: nil
+            ecnCounter: nil,
+            now: .testBase
         )
         wait(for: [pingExpectation], timeout: 2.0)
         // Verify that a PING frame was NOT requested

--- a/Tests/QUICTests/AckTests.swift
+++ b/Tests/QUICTests/AckTests.swift
@@ -47,7 +47,7 @@ extension Ack {
         )
     }
 
-    func append(packetNumberSpace: PacketNumberSpace, packetNumber: PacketNumber) {
+    mutating func append(packetNumberSpace: PacketNumberSpace, packetNumber: PacketNumber) {
         self.append(
             packetNumberSpace: packetNumberSpace,
             packetNumber: packetNumber,
@@ -55,7 +55,7 @@ extension Ack {
         )
     }
 
-    func buildForTesting(
+    mutating func buildForTesting(
         for packetNumberSpace: PacketNumberSpace,
         setAckFrame: (PacketNumberSpace, consuming QUICFrame, Bool) -> Void,
         ecnCounter: ECNCounter? = nil

--- a/Tests/QUICTests/CubicTests.swift
+++ b/Tests/QUICTests/CubicTests.swift
@@ -52,11 +52,11 @@ final class CubicTests: XCTestCase {
 
     func testCubicReset() {
         XCTAssertEqual(cubic.availableCongestionWindow, defaultCongestionWindow)
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         cubic.packetSent(bytesSent: 1000)
         cubic.ackBegin()
         cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
-        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(cubic.availableCongestionWindow, 13000)
         cubic.reset(mss: Constants.initialMSS)
         XCTAssertEqual(cubic.availableCongestionWindow, defaultCongestionWindow)
@@ -65,13 +65,14 @@ final class CubicTests: XCTestCase {
     func testCubicLostPackets() {
         XCTAssertEqual(cubic.availableCongestionWindow, defaultCongestionWindow)
         /* "Send" some packets and declare them lost */
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         cubic.packetSent(bytesSent: 1000)
         cubic.packetLost(
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
         XCTAssertEqual(cubic.availableCongestionWindow, 8400)
         /* See if we can send another packet */
@@ -81,7 +82,7 @@ final class CubicTests: XCTestCase {
     func testCubicSlowStart() {
         rtt.smoothedRTT = .microseconds(0)
         /* "Send" some packets and declare one of them lost */
-        var time = NetworkClock.Instant.now
+        var time = NetworkClock.Instant.testBase
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
@@ -94,20 +95,21 @@ final class CubicTests: XCTestCase {
         cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
         cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
         cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
-        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         cubic.packetLost(
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
         XCTAssertEqual(cubic.availableCongestionWindow, 11900)
         /* Make sure that another successful packet doesn't cause us to continue slow start */
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(100))
+        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(100))
         cubic.packetSent(bytesSent: 1000)
         cubic.ackBegin()
         cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
-        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(cubic.availableCongestionWindow, 11953)
     }
 
@@ -115,7 +117,7 @@ final class CubicTests: XCTestCase {
         rtt.smoothedRTT = .microseconds(0)
         XCTAssertEqual(cubic.availableCongestionWindow, defaultCongestionWindow)
         /* Test that CE counts will reduce the congestion window immediately and move CUBIC to Congestion avoidance */
-        var time = NetworkClock.Instant.now
+        var time = NetworkClock.Instant.testBase
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
@@ -136,15 +138,16 @@ final class CubicTests: XCTestCase {
             largestAckedPN: 5,
             largestAckedSentTime: time,
             mss: mss,
-            smoothedRTT: rtt.smoothedRTT
+            smoothedRTT: rtt.smoothedRTT,
+            now: time
         )
-        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(cubic.availableCongestionWindow, 8400)
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(100))
+        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(100))
         cubic.packetSent(bytesSent: 1000)
         cubic.ackBegin()
         cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
-        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         /* congestion window grows during congestion avoidance */
         XCTAssertEqual(cubic.availableCongestionWindow, 8475)
     }
@@ -153,7 +156,7 @@ final class CubicTests: XCTestCase {
         rtt.smoothedRTT = .microseconds(0)
         XCTAssertEqual(cubic.availableCongestionWindow, defaultCongestionWindow)
         /* Test that CE counts will reduce congestion window, enter congestion window recovery and after that we don't decrease congestion window for 1RTT even we receive new CE counts */
-        var time = NetworkClock.Instant.now
+        var time = NetworkClock.Instant.testBase
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
@@ -172,11 +175,12 @@ final class CubicTests: XCTestCase {
             largestAckedPN: 3,
             largestAckedSentTime: time,
             mss: mss,
-            smoothedRTT: rtt.smoothedRTT
+            smoothedRTT: rtt.smoothedRTT,
+            now: time
         )
         /* availableCongestionWindow = congestionWindow - bytesInFlight = 8400 - 2000 = 6400 */
         XCTAssertEqual(cubic.availableCongestionWindow, 6400)
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(100))
+        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(100))
         cubic.ackBegin()
         cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
         cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
@@ -187,9 +191,10 @@ final class CubicTests: XCTestCase {
             largestAckedPN: 5,
             largestAckedSentTime: time,
             mss: mss,
-            smoothedRTT: rtt.smoothedRTT
+            smoothedRTT: rtt.smoothedRTT,
+            now: time
         )
-        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         /* congestion window is the same 8400, bytes in flight has reduced to 0 */
         XCTAssertEqual(cubic.availableCongestionWindow, 8400)
     }
@@ -197,7 +202,7 @@ final class CubicTests: XCTestCase {
     func testCubicAckDuringRecovery() {
         rtt.smoothedRTT = .microseconds(0)
         /* "Send" some packets and declare one of them lost */
-        var time = NetworkClock.Instant.now
+        var time = NetworkClock.Instant.testBase
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
@@ -214,21 +219,22 @@ final class CubicTests: XCTestCase {
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
-        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: true)
+        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: true, now: time)
         XCTAssertEqual(cubic.availableCongestionWindow, 8400)
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(100))
+        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(100))
         cubic.packetSent(bytesSent: 1000)
         cubic.ackBegin()
         cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
-        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(cubic.availableCongestionWindow, 8475)
     }
 
     func testCubicIdleTimeout() {
         XCTAssertEqual(cubic.availableCongestionWindow, defaultCongestionWindow)
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
@@ -242,7 +248,7 @@ final class CubicTests: XCTestCase {
         cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
         cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
         cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
-        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(cubic.availableCongestionWindow, 18000)
         cubic.idleTimeout(mss: mss)
         XCTAssertEqual(cubic.availableCongestionWindow, defaultCongestionWindow)
@@ -258,7 +264,15 @@ final class CubicTests: XCTestCase {
     }
 
     func testCubicCongestionLimited() {
-        var time = NetworkClock.Instant.now
+        // `sentTime` is when the packets went out; `detectedAt` is when their loss was noticed,
+        // which is necessarily later. Dating a send after the recovery period it is compared
+        // against re-enters recovery on every loss instead of once per round.
+        //
+        // RFC 9002 Section 7.3.2 allows one reduction per recovery period, and Appendix B opens a
+        // new period only for a packet sent after the current one started. Three rounds of sending
+        // therefore give three reductions.
+        var sentTime = NetworkClock.Instant.testBase
+        var detectedAt = sentTime.advanced(by: .microseconds(100))
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
@@ -266,65 +280,75 @@ final class CubicTests: XCTestCase {
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
         cubic.ackBegin()
-        cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
-        cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
-        cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
-        cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
-        cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
+        cubic.packetsAcked(bytesAcked: 1000, sentTime: sentTime)
+        cubic.packetsAcked(bytesAcked: 1000, sentTime: sentTime)
+        cubic.packetsAcked(bytesAcked: 1000, sentTime: sentTime)
+        cubic.packetsAcked(bytesAcked: 1000, sentTime: sentTime)
+        cubic.packetsAcked(bytesAcked: 1000, sentTime: sentTime)
         cubic.packetLost(
             bytesLost: 1000,
-            largestLostSentTime: time,
+            largestLostSentTime: sentTime,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: detectedAt
         )
         XCTAssertEqual(cubic.availableCongestionWindow, 8400)
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(1000))
+        sentTime = sentTime.advanced(by: .microseconds(1000))
+        detectedAt = sentTime.advanced(by: .microseconds(100))
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
         cubic.packetLost(
             bytesLost: 1000,
-            largestLostSentTime: time,
+            largestLostSentTime: sentTime,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: detectedAt
         )
         cubic.packetLost(
             bytesLost: 1000,
-            largestLostSentTime: time,
+            largestLostSentTime: sentTime,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: detectedAt
         )
         cubic.packetLost(
             bytesLost: 1000,
-            largestLostSentTime: time,
+            largestLostSentTime: sentTime,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: detectedAt
         )
         cubic.packetLost(
             bytesLost: 1000,
-            largestLostSentTime: time,
+            largestLostSentTime: sentTime,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: detectedAt
         )
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(2000))
+        sentTime = sentTime.advanced(by: .microseconds(1000))
+        detectedAt = sentTime.advanced(by: .microseconds(100))
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
         cubic.packetLost(
             bytesLost: 1000,
-            largestLostSentTime: time,
+            largestLostSentTime: sentTime,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: detectedAt
         )
         cubic.packetLost(
             bytesLost: 1000,
-            largestLostSentTime: time,
+            largestLostSentTime: sentTime,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: detectedAt
         )
-        XCTAssert(
-            (cubic.availableCongestionWindow >= 2400) && (cubic.availableCongestionWindow < 3000)
-        )
+        // One reduction per round, three rounds: 12000 -> 8400 -> 5880 -> 4116, each step
+        // `UInt64(Double(window) * Cubic.beta)`. Written out rather than as `pow(beta, 3)`, which
+        // is 0.34299999999999997 and truncates to 4115; the reductions compound one at a time.
+        XCTAssertEqual(cubic.availableCongestionWindow, 4116)
         XCTAssertFalse(cubic.canSend(packetLength: 10000))
     }
 
@@ -335,7 +359,7 @@ final class CubicTests: XCTestCase {
     }
 
     func testCubicSpuriousRetransmit() {
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
@@ -344,7 +368,8 @@ final class CubicTests: XCTestCase {
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
         cubic.spuriousRetransmit()
         XCTAssertEqual(cubic.availableCongestionWindow, 9000)
@@ -352,7 +377,7 @@ final class CubicTests: XCTestCase {
 
     /* Tests that we can enter CA without any loss after idle period */
     func testCubicCongestionAvoidance() {
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
@@ -363,9 +388,10 @@ final class CubicTests: XCTestCase {
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
-        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: true)
+        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: true, now: time)
         XCTAssertEqual(cubic.availableCongestionWindow, 8400)
         cubic.idleTimeout(mss: mss)
         XCTAssertEqual(cubic.availableCongestionWindow, 8400)
@@ -376,7 +402,7 @@ final class CubicTests: XCTestCase {
         cubic.packetsAcked(bytesAcked: 1200, sentTime: time)
         cubic.packetsAcked(bytesAcked: 1200, sentTime: time)
         cubic.packetsAcked(bytesAcked: 1200, sentTime: time)
-        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         /* Enter CA */
         XCTAssertEqual(cubic.availableCongestionWindow, 12000)
         for _ in 0..<12 {
@@ -386,7 +412,7 @@ final class CubicTests: XCTestCase {
         for _ in 0..<12 {
             cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
         }
-        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(cubic.availableCongestionWindow, 13200)
 
     }
@@ -400,13 +426,13 @@ final class CubicTests: XCTestCase {
         XCTAssertTrue(dataTransferSnapshot.transportCongestionWindow > 0)
         XCTAssertTrue(dataTransferSnapshot.transportSlowStartThreshold > 0)
         let existingCongestionWindow = dataTransferSnapshot.transportCongestionWindow
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         cubic.packetSent(bytesSent: 1000)
         cubic.packetSent(bytesSent: 1000)
         cubic.ackBegin()
         cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
         cubic.packetsAcked(bytesAcked: 1000, sentTime: time)
-        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        cubic.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
 
         cubic.filloutDataTransferSnapshot(dataTransferSnapshot: &dataTransferSnapshot)
         XCTAssertEqual(

--- a/Tests/QUICTests/LedbatTests.swift
+++ b/Tests/QUICTests/LedbatTests.swift
@@ -353,82 +353,54 @@ final class LedbatTests: XCTestCase {
     }
 
     func testLedbatCongestionLimited() {
-        /* SRTT = 100ms, base RTT = 100ms network RTT = 120ms */
+        // `sentTime` is when the packets went out, `detectedAt` when their loss was noticed.
+        // RFC 9002 Section 7.3.2 allows one reduction per recovery period, so three rounds of
+        // sending give three reductions.
+        //
+        // LEDBAT starts *on* its own floor — `initialCongestionWindow` is `min(2 * mss, 2944)`
+        // and `minCongestionWindow` is `2 * mss`, both 2400 here — so the window has to be grown
+        // first, or every reduction clamps back and the assertion holds whatever the controller
+        // does.
+        /* SRTT = 100ms, base RTT = 100ms, network RTT = 120ms */
         rtt.adjustedRTT = .milliseconds(120)
         rtt.smoothedRTT = .milliseconds(100)
-        var time = NetworkClock.Instant.testBase
-        ledbat.packetSent(bytesSent: 1000)
-        ledbat.packetSent(bytesSent: 1000)
-        ledbat.packetSent(bytesSent: 1000)
-        ledbat.packetSent(bytesSent: 1000)
-        ledbat.packetSent(bytesSent: 1000)
-        ledbat.packetSent(bytesSent: 1000)
-        ledbat.ackBegin()
-        ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.packetLost(
-            bytesLost: 1000,
-            largestLostSentTime: time,
-            mss: mss,
-            smoothedRTT: .microseconds(0),
-            now: time
-        )
-        XCTAssertEqual(ledbat.availableCongestionWindow, 2400)
-        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(1000))
-        ledbat.packetSent(bytesSent: 1000)
-        ledbat.packetSent(bytesSent: 1000)
-        ledbat.packetSent(bytesSent: 1000)
-        ledbat.packetSent(bytesSent: 1000)
-        ledbat.packetLost(
-            bytesLost: 1000,
-            largestLostSentTime: time,
-            mss: mss,
-            smoothedRTT: .microseconds(0),
-            now: time
-        )
-        ledbat.packetLost(
-            bytesLost: 1000,
-            largestLostSentTime: time,
-            mss: mss,
-            smoothedRTT: .microseconds(0),
-            now: time
-        )
-        ledbat.packetLost(
-            bytesLost: 1000,
-            largestLostSentTime: time,
-            mss: mss,
-            smoothedRTT: .microseconds(0),
-            now: time
-        )
-        ledbat.packetLost(
-            bytesLost: 1000,
-            largestLostSentTime: time,
-            mss: mss,
-            smoothedRTT: .microseconds(0),
-            now: time
-        )
-        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(2000))
-        ledbat.packetSent(bytesSent: 1000)
-        ledbat.packetSent(bytesSent: 1000)
-        ledbat.packetLost(
-            bytesLost: 1000,
-            largestLostSentTime: time,
-            mss: mss,
-            smoothedRTT: .microseconds(0),
-            now: time
-        )
-        ledbat.packetLost(
-            bytesLost: 1000,
-            largestLostSentTime: time,
-            mss: mss,
-            smoothedRTT: .microseconds(0),
-            now: time
-        )
-        XCTAssertEqual(ledbat.availableCongestionWindow, 2400)
-        XCTAssertFalse(ledbat.canSend(packetLength: 3000))
+
+        // Slow start, since the queuing delay of 20ms is under three quarters of the 60ms target.
+        // Each round adds `gain(baseRTT) * min(bytesAcked, 10 * mss)`, and `gain` is 0.5 at this
+        // base RTT, so 12000 bytes acked lift the window by 6000: 2400 -> 26400 over four rounds.
+        // The rounds fit inside one smoothed RTT, so congestion window validation never takes a
+        // pipeack sample and `lossFlightSize` stays equal to the window.
+        var sentTime = NetworkClock.Instant.testBase
+        for _ in 0..<4 {
+            ledbat.packetSent(bytesSent: 12000)
+            ledbat.ackBegin()
+            ledbat.packetsAcked(bytesAcked: 12000, sentTime: sentTime)
+            ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: sentTime)
+            sentTime = sentTime.advanced(by: .milliseconds(1))
+        }
+        XCTAssertEqual(ledbat.availableCongestionWindow, 26400)
+
+        // Three rounds, four losses each, halving the window once per round.
+        for expectedWindow in [UInt64(13200), 6600, 3300] {
+            let detectedAt = sentTime.advanced(by: .microseconds(100))
+            for _ in 0..<4 {
+                ledbat.packetSent(bytesSent: 1000)
+            }
+            for lossIndex in 0..<4 {
+                let openedRecovery = ledbat.packetLost(
+                    bytesLost: 1000,
+                    largestLostSentTime: sentTime,
+                    mss: mss,
+                    smoothedRTT: .microseconds(0),
+                    now: detectedAt
+                )
+                // Only the first loss opens a period; the rest were sent before it started.
+                XCTAssertEqual(openedRecovery, lossIndex == 0)
+            }
+            XCTAssertEqual(ledbat.availableCongestionWindow, expectedWindow)
+            sentTime = sentTime.advanced(by: .milliseconds(1))
+        }
+        XCTAssertFalse(ledbat.canSend(packetLength: 4000))
     }
 
     func testLedbatPacketDiscard() {

--- a/Tests/QUICTests/LedbatTests.swift
+++ b/Tests/QUICTests/LedbatTests.swift
@@ -55,11 +55,11 @@ final class LedbatTests: XCTestCase {
         rtt.adjustedRTT = .milliseconds(120)
         rtt.smoothedRTT = .milliseconds(100)
 
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         ledbat.packetSent(bytesSent: 1000)
         ledbat.ackBegin()
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(ledbat.availableCongestionWindow, 2900)
         ledbat.reset(mss: Constants.initialMSS)
         XCTAssertEqual(ledbat.availableCongestionWindow, defaultCongestionWindow)
@@ -71,7 +71,7 @@ final class LedbatTests: XCTestCase {
         rtt.adjustedRTT = .milliseconds(120)
         rtt.smoothedRTT = .milliseconds(100)
 
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         /* Send to increase cwnd */
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
@@ -82,7 +82,7 @@ final class LedbatTests: XCTestCase {
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(ledbat.availableCongestionWindow, 4400)
         /* Send a packet and declare them lost */
         ledbat.packetSent(bytesSent: 1000)
@@ -90,7 +90,8 @@ final class LedbatTests: XCTestCase {
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
         XCTAssertEqual(ledbat.availableCongestionWindow, 2400)
         /* See if we can send another packet */
@@ -104,7 +105,7 @@ final class LedbatTests: XCTestCase {
         rtt.smoothedRTT = .milliseconds(100)
         /* Send some packets to increase cwnd */
 
-        var time = NetworkClock.Instant.now
+        var time = NetworkClock.Instant.testBase
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
@@ -116,7 +117,7 @@ final class LedbatTests: XCTestCase {
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(ledbat.availableCongestionWindow, 4900)
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
@@ -126,26 +127,27 @@ final class LedbatTests: XCTestCase {
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
         XCTAssertEqual(ledbat.availableCongestionWindow, 2450)
         /* Additive increase during CA */
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(100))
+        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(100))
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
         ledbat.ackBegin()
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(ledbat.availableCongestionWindow, 2939)
         /* Mulitplicative decrease during CA */
         /* Current RTT = 180ms */
         rtt.adjustedRTT = .milliseconds(180)
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(100))
+        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(100))
         ledbat.packetSent(bytesSent: 1000)
         ledbat.ackBegin()
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(ledbat.availableCongestionWindow, 2606)
     }
 
@@ -156,7 +158,7 @@ final class LedbatTests: XCTestCase {
         XCTAssertEqual(ledbat.availableCongestionWindow, defaultCongestionWindow)
 
         /* Lets increase the window first to go higher than MIN_CWND */
-        var time = NetworkClock.Instant.now
+        var time = NetworkClock.Instant.testBase
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
@@ -170,10 +172,10 @@ final class LedbatTests: XCTestCase {
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(ledbat.availableCongestionWindow, 5400)
 
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(100))
+        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(100))
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
@@ -194,16 +196,17 @@ final class LedbatTests: XCTestCase {
             largestAckedPN: 5,
             largestAckedSentTime: time,
             mss: mss,
-            smoothedRTT: rtt.smoothedRTT
+            smoothedRTT: rtt.smoothedRTT,
+            now: time
         )
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(ledbat.availableCongestionWindow, 2700)
 
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(200))
+        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(200))
         ledbat.packetSent(bytesSent: 1000)
         ledbat.ackBegin()
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         /* cwnd grows during congestion avoidance */
         XCTAssertEqual(ledbat.availableCongestionWindow, 2922)
     }
@@ -214,7 +217,7 @@ final class LedbatTests: XCTestCase {
         rtt.smoothedRTT = .milliseconds(100)
         XCTAssertEqual(ledbat.availableCongestionWindow, defaultCongestionWindow)
         /* Lets increase the window first to go higher than MIN_CWND */
-        var time = NetworkClock.Instant.now
+        var time = NetworkClock.Instant.testBase
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
@@ -228,11 +231,11 @@ final class LedbatTests: XCTestCase {
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(ledbat.availableCongestionWindow, 5400)
         /* Test that CE counts will reduce cwnd, enter CWR and after that we don't decrease cwnd for 1RTT even we receive new CE counts */
 
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(100))
+        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(100))
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
@@ -251,9 +254,10 @@ final class LedbatTests: XCTestCase {
             largestAckedPN: 3,
             largestAckedSentTime: time,
             mss: mss,
-            smoothedRTT: rtt.smoothedRTT
+            smoothedRTT: rtt.smoothedRTT,
+            now: time
         )
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
 
         /* allowed cwnd = cwnd - bytes_in_flight = 2700 - 2000 = 700 */
         XCTAssertEqual(ledbat.availableCongestionWindow, 700)
@@ -268,9 +272,10 @@ final class LedbatTests: XCTestCase {
             largestAckedPN: 5,
             largestAckedSentTime: time,
             mss: mss,
-            smoothedRTT: rtt.smoothedRTT
+            smoothedRTT: rtt.smoothedRTT,
+            now: time
         )
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         /* cwnd is same 2700, bytes in flight has reduced to 0 */
         XCTAssertEqual(ledbat.availableCongestionWindow, 2700)
     }
@@ -280,7 +285,7 @@ final class LedbatTests: XCTestCase {
         rtt.adjustedRTT = .milliseconds(120)
         rtt.smoothedRTT = .milliseconds(100)
         /* "Send" some packets and declare one of them lost */
-        var time = NetworkClock.Instant.now
+        var time = NetworkClock.Instant.testBase
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
@@ -297,15 +302,16 @@ final class LedbatTests: XCTestCase {
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: true)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: true, now: time)
         XCTAssertEqual(ledbat.availableCongestionWindow, 2400)
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(100))
+        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(100))
         ledbat.packetSent(bytesSent: 1000)
         ledbat.ackBegin()
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(ledbat.availableCongestionWindow, 2650)
     }
 
@@ -314,7 +320,7 @@ final class LedbatTests: XCTestCase {
         /* SRTT = 100ms, base RTT = 100ms network RTT = 120ms */
         rtt.adjustedRTT = .milliseconds(120)
         rtt.smoothedRTT = .milliseconds(100)
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
@@ -328,7 +334,7 @@ final class LedbatTests: XCTestCase {
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(ledbat.availableCongestionWindow, 5400)
         ledbat.idleTimeout(mss: mss)
         XCTAssertEqual(ledbat.availableCongestionWindow, defaultCongestionWindow)
@@ -350,7 +356,7 @@ final class LedbatTests: XCTestCase {
         /* SRTT = 100ms, base RTT = 100ms network RTT = 120ms */
         rtt.adjustedRTT = .milliseconds(120)
         rtt.smoothedRTT = .milliseconds(100)
-        var time = NetworkClock.Instant.now
+        var time = NetworkClock.Instant.testBase
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
@@ -367,10 +373,11 @@ final class LedbatTests: XCTestCase {
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
         XCTAssertEqual(ledbat.availableCongestionWindow, 2400)
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(1000))
+        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(1000))
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
@@ -379,40 +386,46 @@ final class LedbatTests: XCTestCase {
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
         ledbat.packetLost(
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
         ledbat.packetLost(
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
         ledbat.packetLost(
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(2000))
+        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(2000))
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetLost(
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
         ledbat.packetLost(
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
         XCTAssertEqual(ledbat.availableCongestionWindow, 2400)
         XCTAssertFalse(ledbat.canSend(packetLength: 3000))
@@ -428,18 +441,19 @@ final class LedbatTests: XCTestCase {
         /* SRTT = 100ms, base RTT = 100ms network RTT = 120ms */
         rtt.adjustedRTT = .milliseconds(120)
         rtt.smoothedRTT = .milliseconds(100)
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         ledbat.packetSent(bytesSent: 1000)
         ledbat.ackBegin()
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(ledbat.availableCongestionWindow, 2900)
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetLost(
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
         ledbat.spuriousRetransmit()
         XCTAssertEqual(ledbat.availableCongestionWindow, 2900)
@@ -450,7 +464,7 @@ final class LedbatTests: XCTestCase {
         /* SRTT = 100ms, base RTT = 100ms network RTT = 120ms */
         rtt.adjustedRTT = .milliseconds(120)
         rtt.smoothedRTT = .milliseconds(100)
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
         ledbat.packetSent(bytesSent: 1000)
@@ -461,9 +475,10 @@ final class LedbatTests: XCTestCase {
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: true)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: true, now: time)
         XCTAssertEqual(ledbat.availableCongestionWindow, 2400)
         ledbat.idleTimeout(mss: mss)
         XCTAssertEqual(ledbat.availableCongestionWindow, 2400)
@@ -472,7 +487,7 @@ final class LedbatTests: XCTestCase {
         ledbat.ackBegin()
         ledbat.packetsAcked(bytesAcked: 1200, sentTime: time)
         ledbat.packetsAcked(bytesAcked: 1200, sentTime: time)
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         /* Enter CA */
         XCTAssertEqual(ledbat.availableCongestionWindow, 3000)
         for _ in 0..<3 {
@@ -482,7 +497,7 @@ final class LedbatTests: XCTestCase {
         for _ in 0..<3 {
             ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
         }
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(ledbat.availableCongestionWindow, 3600)
 
     }
@@ -497,11 +512,11 @@ final class LedbatTests: XCTestCase {
         XCTAssertTrue(dataTransferSnapshot.transportSlowStartThreshold > 0)
         rtt.adjustedRTT = .milliseconds(120)
         rtt.smoothedRTT = .milliseconds(100)
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         ledbat.packetSent(bytesSent: 1000)
         ledbat.ackBegin()
         ledbat.packetsAcked(bytesAcked: 1000, sentTime: time)
-        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        ledbat.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
 
         ledbat.filloutDataTransferSnapshot(dataTransferSnapshot: &dataTransferSnapshot)
         XCTAssertEqual(dataTransferSnapshot.transportCongestionWindow, 2900)

--- a/Tests/QUICTests/MigrationTests.swift
+++ b/Tests/QUICTests/MigrationTests.swift
@@ -109,6 +109,45 @@ final class MigrationTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 5.0)
     }
+
+    // `Timer` fires an entry up to `Timer.timerThreshold` before its deadline and disables it
+    // first, so the migration handler can be woken with an instant that precedes the challenge it
+    // woke for. It must re-arm anyway; otherwise probing stalls on an otherwise idle path until an
+    // unrelated event happens to arm the timer again.
+    func testMigrationTimerRearmsWhenFiredInsideTimerLeeway() {
+        let expectation = XCTestExpectation()
+        connection.context.async {
+            let path = self.makePath(dcid: Self.oldCID, sequenceNumber: 1, validated: false)
+            self.connection.currentPath = path
+            self.connection.multiplexingPaths[path.identifier] = path
+            path.changeState(to: .probing)
+
+            // Send the first challenge, which sets the next challenge deadline and arms the timer.
+            let base = NetworkClock.Instant.testBase
+            var pendingItems = PendingItems(packetNumberSpace: .applicationData)
+            path.addPathChallenge(to: &pendingItems, now: base)
+            guard let nextChallengeTime = path.nextChallengeTime else {
+                XCTFail("First challenge did not schedule a follow-up")
+                expectation.fulfill()
+                return
+            }
+            XCTAssertEqual(self.connection.timer.nextDeadline, nextChallengeTime)
+
+            // Wake one microsecond early, which is inside the leeway window `Timer` allows. Go
+            // through `Timer.timerFired`, since that is what disables the entry before handing the
+            // instant to the handler.
+            self.connection.timer.timerFired(at: nextChallengeTime.advanced(by: .microseconds(-1)))
+
+            XCTAssertEqual(
+                self.connection.timer.nextDeadline,
+                nextChallengeTime,
+                "Migration timer left disarmed after an early fire"
+            )
+
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5.0)
+    }
 }
 
 #endif

--- a/Tests/QUICTests/PragueTests.swift
+++ b/Tests/QUICTests/PragueTests.swift
@@ -52,11 +52,11 @@ final class PragueTests: XCTestCase {
 
     func testPragueReset() {
         XCTAssertEqual(prague.availableCongestionWindow, defaultCongestionWindow)
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         prague.packetSent(bytesSent: 1000)
         prague.ackBegin()
         prague.packetsAcked(bytesAcked: 1000, sentTime: time)
-        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(prague.availableCongestionWindow, 13000)
         prague.reset(mss: Constants.initialMSS)
         XCTAssertEqual(prague.availableCongestionWindow, defaultCongestionWindow)
@@ -65,13 +65,14 @@ final class PragueTests: XCTestCase {
     func testPragueLostPackets() {
         XCTAssertEqual(prague.availableCongestionWindow, defaultCongestionWindow)
         /* "Send" some packets and declare them lost */
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         prague.packetSent(bytesSent: 1000)
         prague.packetLost(
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
         XCTAssertEqual(prague.availableCongestionWindow, 8400)
         /* See if we can send another packet */
@@ -81,7 +82,7 @@ final class PragueTests: XCTestCase {
     func testPragueSlowStart() {
         rtt.smoothedRTT = .microseconds(10)
         /* "Send" some packets and declare one of them lost */
-        var time = NetworkClock.Instant.now
+        var time = NetworkClock.Instant.testBase
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
@@ -94,20 +95,21 @@ final class PragueTests: XCTestCase {
         prague.packetsAcked(bytesAcked: 1000, sentTime: time)
         prague.packetsAcked(bytesAcked: 1000, sentTime: time)
         prague.packetsAcked(bytesAcked: 1000, sentTime: time)
-        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         prague.packetLost(
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
         XCTAssertEqual(prague.availableCongestionWindow, 11900)
         /* Make sure that another successful packet doesn't cause us to continue slow start */
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(100))
+        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(100))
         prague.packetSent(bytesSent: 1000)
         prague.ackBegin()
         prague.packetsAcked(bytesAcked: 1000, sentTime: time)
-        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(prague.availableCongestionWindow, 11953)
     }
 
@@ -115,7 +117,7 @@ final class PragueTests: XCTestCase {
         rtt.smoothedRTT = .milliseconds(15)
         XCTAssertEqual(prague.availableCongestionWindow, defaultCongestionWindow)
         /* Test that CE counts will reduce the congestion window immediately and move Prague to Congestion avoidance */
-        var time = NetworkClock.Instant.now
+        var time = NetworkClock.Instant.testBase
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
@@ -136,17 +138,18 @@ final class PragueTests: XCTestCase {
             largestAckedPN: 5,
             largestAckedSentTime: time,
             mss: mss,
-            smoothedRTT: rtt.smoothedRTT
+            smoothedRTT: rtt.smoothedRTT,
+            now: time
         )
-        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         // cwnd after reduction = 6313 and after AI increase for 5 unmarked packets = 6826
         XCTAssertEqual(prague.availableCongestionWindow, 6826)
 
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(100))
+        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(100))
         prague.packetSent(bytesSent: 1000)
         prague.ackBegin()
         prague.packetsAcked(bytesAcked: 1000, sentTime: time)
-        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         /* congestion window grows during congestion avoidance */
         XCTAssertEqual(prague.availableCongestionWindow, 6924)
     }
@@ -155,7 +158,7 @@ final class PragueTests: XCTestCase {
         rtt.smoothedRTT = .milliseconds(15)
         XCTAssertEqual(prague.availableCongestionWindow, defaultCongestionWindow)
         /* Test that CE counts will reduce congestion window, enter CWR and after that we don't decrease congestion window for 1RTT even we receive new CE counts */
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
@@ -174,9 +177,10 @@ final class PragueTests: XCTestCase {
             largestAckedPN: 3,
             largestAckedSentTime: time,
             mss: mss,
-            smoothedRTT: rtt.smoothedRTT
+            smoothedRTT: rtt.smoothedRTT,
+            now: time
         )
-        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         // cwnd after decrease = 6282, after AI increase = 6582
         // allowed cwnd = cwnd - bytes_in_flight = 6582 - 2000 = 4582
         XCTAssertEqual(prague.availableCongestionWindow, 4582)
@@ -191,9 +195,10 @@ final class PragueTests: XCTestCase {
             largestAckedPN: 5,
             largestAckedSentTime: time,
             mss: mss,
-            smoothedRTT: rtt.smoothedRTT
+            smoothedRTT: rtt.smoothedRTT,
+            now: time
         )
-        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         // cwnd is 6664 after AI for 1 unmarked packet
         XCTAssertEqual(prague.availableCongestionWindow, 6664)
     }
@@ -201,7 +206,7 @@ final class PragueTests: XCTestCase {
     func testPragueAckDuringRecovery() {
         rtt.smoothedRTT = .microseconds(10)
         /* "Send" some packets and declare one of them lost */
-        var time = NetworkClock.Instant.now
+        var time = NetworkClock.Instant.testBase
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
@@ -218,21 +223,22 @@ final class PragueTests: XCTestCase {
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
-        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: true)
+        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: true, now: time)
         XCTAssertEqual(prague.availableCongestionWindow, 8400)
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(100))
+        time = NetworkClock.Instant.testBase.advanced(by: .microseconds(100))
         prague.packetSent(bytesSent: 1000)
         prague.ackBegin()
         prague.packetsAcked(bytesAcked: 1000, sentTime: time)
-        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(prague.availableCongestionWindow, 8475)
     }
 
     func testPragueIdleTimeout() {
         XCTAssertEqual(prague.availableCongestionWindow, defaultCongestionWindow)
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
@@ -246,7 +252,7 @@ final class PragueTests: XCTestCase {
         prague.packetsAcked(bytesAcked: 1000, sentTime: time)
         prague.packetsAcked(bytesAcked: 1000, sentTime: time)
         prague.packetsAcked(bytesAcked: 1000, sentTime: time)
-        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(prague.availableCongestionWindow, 18000)
         prague.idleTimeout(mss: mss)
         XCTAssertEqual(prague.availableCongestionWindow, defaultCongestionWindow)
@@ -262,7 +268,13 @@ final class PragueTests: XCTestCase {
     }
 
     func testPragueCongestionLimited() {
-        var time = NetworkClock.Instant.now
+        // See `CubicTests.testCubicCongestionLimited`: `sentTime` is when the packets went
+        // out, `detectedAt` when their loss was noticed. The old test pushed the send times
+        // ahead of the system clock, so every loss re-entered recovery. RFC 9002
+        // Section 7.3.2 allows one reduction per recovery period; three rounds of sending
+        // give three reductions.
+        var sentTime = NetworkClock.Instant.testBase
+        var detectedAt = sentTime.advanced(by: .microseconds(100))
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
@@ -270,65 +282,75 @@ final class PragueTests: XCTestCase {
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
         prague.ackBegin()
-        prague.packetsAcked(bytesAcked: 1000, sentTime: time)
-        prague.packetsAcked(bytesAcked: 1000, sentTime: time)
-        prague.packetsAcked(bytesAcked: 1000, sentTime: time)
-        prague.packetsAcked(bytesAcked: 1000, sentTime: time)
-        prague.packetsAcked(bytesAcked: 1000, sentTime: time)
+        prague.packetsAcked(bytesAcked: 1000, sentTime: sentTime)
+        prague.packetsAcked(bytesAcked: 1000, sentTime: sentTime)
+        prague.packetsAcked(bytesAcked: 1000, sentTime: sentTime)
+        prague.packetsAcked(bytesAcked: 1000, sentTime: sentTime)
+        prague.packetsAcked(bytesAcked: 1000, sentTime: sentTime)
         prague.packetLost(
             bytesLost: 1000,
-            largestLostSentTime: time,
+            largestLostSentTime: sentTime,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: detectedAt
         )
         XCTAssertEqual(prague.availableCongestionWindow, 8400)
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(1000))
+        sentTime = sentTime.advanced(by: .microseconds(1000))
+        detectedAt = sentTime.advanced(by: .microseconds(100))
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
         prague.packetLost(
             bytesLost: 1000,
-            largestLostSentTime: time,
+            largestLostSentTime: sentTime,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: detectedAt
         )
         prague.packetLost(
             bytesLost: 1000,
-            largestLostSentTime: time,
+            largestLostSentTime: sentTime,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: detectedAt
         )
         prague.packetLost(
             bytesLost: 1000,
-            largestLostSentTime: time,
+            largestLostSentTime: sentTime,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: detectedAt
         )
         prague.packetLost(
             bytesLost: 1000,
-            largestLostSentTime: time,
+            largestLostSentTime: sentTime,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: detectedAt
         )
-        time = NetworkClock.Instant.now.advanced(by: .microseconds(2000))
+        sentTime = sentTime.advanced(by: .microseconds(1000))
+        detectedAt = sentTime.advanced(by: .microseconds(100))
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
         prague.packetLost(
             bytesLost: 1000,
-            largestLostSentTime: time,
+            largestLostSentTime: sentTime,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: detectedAt
         )
         prague.packetLost(
             bytesLost: 1000,
-            largestLostSentTime: time,
+            largestLostSentTime: sentTime,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: detectedAt
         )
-        XCTAssert(
-            (prague.availableCongestionWindow >= 2400) && (prague.availableCongestionWindow < 3000)
-        )
+        // One reduction per round, three rounds: 12000 -> 8400 -> 5880 -> 4116, each step
+        // `UInt64(Double(window) * Prague.beta)`. Written out rather than as `pow(beta, 3)`, which
+        // is 0.34299999999999997 and truncates to 4115; the reductions compound one at a time.
+        XCTAssertEqual(prague.availableCongestionWindow, 4116)
         XCTAssertFalse(prague.canSend(packetLength: 10000))
     }
 
@@ -339,7 +361,7 @@ final class PragueTests: XCTestCase {
     }
 
     func testPragueSpuriousRetransmit() {
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
@@ -348,7 +370,8 @@ final class PragueTests: XCTestCase {
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
         prague.spuriousRetransmit()
         XCTAssertEqual(prague.availableCongestionWindow, 9000)
@@ -356,7 +379,7 @@ final class PragueTests: XCTestCase {
 
     /* Tests that we can enter CA without any loss after idle period */
     func testPragueCongestionAvoidance() {
-        var time = NetworkClock.Instant.now
+        var time = NetworkClock.Instant.testBase
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
@@ -367,13 +390,14 @@ final class PragueTests: XCTestCase {
             bytesLost: 1000,
             largestLostSentTime: time,
             mss: mss,
-            smoothedRTT: .microseconds(0)
+            smoothedRTT: .microseconds(0),
+            now: time
         )
-        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: true)
+        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: true, now: time)
         XCTAssertEqual(prague.availableCongestionWindow, 8400)
         prague.idleTimeout(mss: mss)
         XCTAssertEqual(prague.availableCongestionWindow, 8400)
-        time = NetworkClock.Instant.now
+        time = NetworkClock.Instant.testBase
         prague.packetSent(bytesSent: 1200)
         prague.packetSent(bytesSent: 1200)
         prague.packetSent(bytesSent: 1200)
@@ -381,7 +405,7 @@ final class PragueTests: XCTestCase {
         prague.packetsAcked(bytesAcked: 1200, sentTime: time)
         prague.packetsAcked(bytesAcked: 1200, sentTime: time)
         prague.packetsAcked(bytesAcked: 1200, sentTime: time)
-        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         /* Enter CA */
         XCTAssertEqual(prague.availableCongestionWindow, 12000)
         for _ in 0..<12 {
@@ -391,7 +415,7 @@ final class PragueTests: XCTestCase {
         for _ in 0..<12 {
             prague.packetsAcked(bytesAcked: 1000, sentTime: time)
         }
-        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
         XCTAssertEqual(prague.availableCongestionWindow, 13200)
     }
 
@@ -404,13 +428,13 @@ final class PragueTests: XCTestCase {
         XCTAssertTrue(dataTransferSnapshot.transportCongestionWindow > 0)
         XCTAssertTrue(dataTransferSnapshot.transportSlowStartThreshold > 0)
         let existingCongestionWindow = dataTransferSnapshot.transportCongestionWindow
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         prague.packetSent(bytesSent: 1000)
         prague.packetSent(bytesSent: 1000)
         prague.ackBegin()
         prague.packetsAcked(bytesAcked: 1000, sentTime: time)
         prague.packetsAcked(bytesAcked: 1000, sentTime: time)
-        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false)
+        prague.ackEnd(rtt: rtt, mss: mss, packetsLost: false, now: time)
 
         prague.filloutDataTransferSnapshot(dataTransferSnapshot: &dataTransferSnapshot)
         XCTAssertEqual(
@@ -433,7 +457,7 @@ final class PragueTests: XCTestCase {
         XCTAssertEqual(path.pacer.burstSize, 10000)
 
         XCTAssertEqual(path.congestionControlWindow, 12000)
-        let time = NetworkClock.Instant.now
+        let time = NetworkClock.Instant.testBase
         for _ in 0..<10 {
             path.congestionControlPacketsSent(bytesSent: 1000)
         }

--- a/Tests/QUICTests/PragueTests.swift
+++ b/Tests/QUICTests/PragueTests.swift
@@ -268,11 +268,9 @@ final class PragueTests: XCTestCase {
     }
 
     func testPragueCongestionLimited() {
-        // See `CubicTests.testCubicCongestionLimited`: `sentTime` is when the packets went
-        // out, `detectedAt` when their loss was noticed. The old test pushed the send times
-        // ahead of the system clock, so every loss re-entered recovery. RFC 9002
-        // Section 7.3.2 allows one reduction per recovery period; three rounds of sending
-        // give three reductions.
+        // `sentTime` is when the packets went out, `detectedAt` when their loss was noticed.
+        // RFC 9002 Section 7.3.2 allows one reduction per recovery period, so three rounds of
+        // sending give three reductions.
         var sentTime = NetworkClock.Instant.testBase
         var detectedAt = sentTime.advanced(by: .microseconds(100))
         prague.packetSent(bytesSent: 1000)

--- a/Tests/QUICTests/QUICTestClock.swift
+++ b/Tests/QUICTests/QUICTestClock.swift
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if !NETWORK_NO_SWIFT_QUIC
+
+#if canImport(SwiftNetwork)
+@_spi(Essentials) @_spi(ProtocolProvider) @testable import SwiftNetwork
+#elseif canImport(Network)
+@_spi(Essentials) @_spi(ProtocolProvider) @testable import Network
+#endif
+
+@available(Network 0.1.0, *)
+extension NetworkClock.Instant {
+    /// A fixed instant to seed tests that need one.
+    ///
+    /// The congestion controllers only order instants and measure durations between
+    /// them, so the absolute value is arbitrary, but it has to be *fixed*. Seeding from
+    /// the real clock makes every duration depend on how long the test itself took to run.
+    ///
+    /// Non-zero because much of the stack treats `.zero` as "unset".
+    static var testBase: NetworkClock.Instant {
+        NetworkClock.Instant(milliseconds: 1000)
+    }
+}
+
+/// Test-only conveniences that supply a fixed time.
+///
+/// The production signatures deliberately require a time, so that datapath code cannot
+/// silently reach for the real clock. Most ACK tests are about packet-number bookkeeping
+/// and not about time at all, so restating `now:` several hundred times would be noise.
+/// The default here is a *fixed* instant, so those tests stay deterministic. A test
+/// whose premise is timing calls the full form and passes its own instant.
+@available(Network 0.1.0, *)
+extension Ack {
+    func append(packetNumberSpace: PacketNumberSpace, packetNumber: PacketNumber) {
+        self.append(
+            packetNumberSpace: packetNumberSpace,
+            packetNumber: packetNumber,
+            now: .testBase
+        )
+    }
+
+    func buildForTesting(
+        for packetNumberSpace: PacketNumberSpace,
+        setAckFrame: (PacketNumberSpace, consuming QUICFrame, Bool) -> Void,
+        ecnCounter: ECNCounter? = nil
+    ) -> Int {
+        self.buildForTesting(
+            for: packetNumberSpace,
+            setAckFrame: setAckFrame,
+            ecnCounter: ecnCounter,
+            now: .testBase
+        )
+    }
+}
+#endif

--- a/Tests/QUICTests/RecoveryTests.swift
+++ b/Tests/QUICTests/RecoveryTests.swift
@@ -588,12 +588,15 @@ final class RecoveryTests: XCTestCase {
             XCTAssertEqual(innerState.ackElicitingPacketsInFlight, 0)
         }
         XCTAssertEqual(path.recoveryState.PTOCount, 0)
-        XCTAssertGreaterThan(connection.recovery.computedTimeout, .milliseconds(900))
+        // `PTOPeriod` is the backed-off period; `computedTimeout` is what remains of it once the
+        // fired instant is taken into account, and this test advances its own clock by whole
+        // seconds between fires, so only the former doubles.
+        XCTAssertGreaterThan(path.recoveryState.PTOPeriod, .milliseconds(900))
 
         var expectation = XCTestExpectation()
         self.connection.context.async {
             timeNow = timeNow.advanced(by: .seconds(1))
-            self.connection.recovery.timerFired(timeNow: timeNow)
+            self.connection.recovery.timerFired(at: timeNow)
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 5.0)
@@ -609,12 +612,12 @@ final class RecoveryTests: XCTestCase {
             XCTAssertEqual(innerState.ackElicitingPacketsInFlight, 0)
         }
         XCTAssertEqual(path.recoveryState.PTOCount, 1)
-        XCTAssertGreaterThan(connection.recovery.computedTimeout, .milliseconds(1900))
+        XCTAssertGreaterThan(path.recoveryState.PTOPeriod, .milliseconds(1900))
 
         expectation = XCTestExpectation()
         self.connection.context.async {
             timeNow = timeNow.advanced(by: .seconds(2))
-            self.connection.recovery.timerFired(timeNow: timeNow)
+            self.connection.recovery.timerFired(at: timeNow)
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 5.0)
@@ -630,12 +633,12 @@ final class RecoveryTests: XCTestCase {
             XCTAssertEqual(innerState.ackElicitingPacketsInFlight, 0)
         }
         XCTAssertEqual(path.recoveryState.PTOCount, 2)
-        XCTAssertGreaterThan(connection.recovery.computedTimeout, .milliseconds(3900))
+        XCTAssertGreaterThan(path.recoveryState.PTOPeriod, .milliseconds(3900))
 
         expectation = XCTestExpectation()
         self.connection.context.async {
             timeNow = timeNow.advanced(by: .seconds(4))
-            self.connection.recovery.timerFired(timeNow: timeNow)
+            self.connection.recovery.timerFired(at: timeNow)
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 5.0)
@@ -651,7 +654,7 @@ final class RecoveryTests: XCTestCase {
             XCTAssertEqual(innerState.ackElicitingPacketsInFlight, 0)
         }
         XCTAssertEqual(path.recoveryState.PTOCount, 3)
-        XCTAssertGreaterThan(connection.recovery.computedTimeout, .milliseconds(7900))
+        XCTAssertGreaterThan(path.recoveryState.PTOPeriod, .milliseconds(7900))
     }
 
     // A PTO with ack-eliciting data in flight must emit a probe, even when the only outstanding

--- a/Tests/QUICTests/TestClock.swift
+++ b/Tests/QUICTests/TestClock.swift
@@ -34,34 +34,4 @@ extension NetworkClock.Instant {
     }
 }
 
-/// Test-only conveniences that supply a fixed time.
-///
-/// The production signatures deliberately require a time, so that datapath code cannot
-/// silently reach for the real clock. Most ACK tests are about packet-number bookkeeping
-/// and not about time at all, so restating `now:` several hundred times would be noise.
-/// The default here is a *fixed* instant, so those tests stay deterministic. A test
-/// whose premise is timing calls the full form and passes its own instant.
-@available(Network 0.1.0, *)
-extension Ack {
-    func append(packetNumberSpace: PacketNumberSpace, packetNumber: PacketNumber) {
-        self.append(
-            packetNumberSpace: packetNumberSpace,
-            packetNumber: packetNumber,
-            now: .testBase
-        )
-    }
-
-    func buildForTesting(
-        for packetNumberSpace: PacketNumberSpace,
-        setAckFrame: (PacketNumberSpace, consuming QUICFrame, Bool) -> Void,
-        ecnCounter: ECNCounter? = nil
-    ) -> Int {
-        self.buildForTesting(
-            for: packetNumberSpace,
-            setAckFrame: setAckFrame,
-            ecnCounter: ecnCounter,
-            now: .testBase
-        )
-    }
-}
 #endif

--- a/Tests/QUICTests/TimerTests.swift
+++ b/Tests/QUICTests/TimerTests.swift
@@ -38,7 +38,7 @@ final class TimerTests: XCTestCase {
             semaphore.signal()
         }
         XCTAssertEqual(timer.nextDeadline, .init(milliseconds: 1000))
-        timer.timerFired(timeNow: .init(milliseconds: 1000))
+        timer.timerFired(at: .init(milliseconds: 1000))
         XCTAssertEqual(
             semaphore.wait(timeout: DispatchTime.now() + .seconds(1)),
             DispatchTimeoutResult.success
@@ -55,7 +55,7 @@ final class TimerTests: XCTestCase {
         XCTAssertEqual(timer.nextDeadline, .zero)
         timer.reschedule(identifier: oneId, fromNow: .milliseconds(1000), timerNow: .zero)
         XCTAssertEqual(timer.nextDeadline, .init(milliseconds: 1000))
-        timer.timerFired(timeNow: .init(milliseconds: 1000))
+        timer.timerFired(at: .init(milliseconds: 1000))
         XCTAssertEqual(
             semaphore.wait(timeout: DispatchTime.now() + .seconds(1)),
             DispatchTimeoutResult.success
@@ -73,7 +73,7 @@ final class TimerTests: XCTestCase {
             semaphore.signal()
         }
         XCTAssertEqual(timer.nextDeadline, .init(milliseconds: 1000))
-        timer.timerFired(timeNow: .init(milliseconds: 1000))
+        timer.timerFired(at: .init(milliseconds: 1000))
         XCTAssertNotEqual(oneId, twoId)
         XCTAssertEqual(
             semaphore.wait(timeout: DispatchTime.now() + .seconds(2)),
@@ -98,9 +98,9 @@ final class TimerTests: XCTestCase {
             semaphore.signal()
         }
         XCTAssertEqual(timer.nextDeadline, .init(milliseconds: 1000))
-        timer.timerFired(timeNow: .init(milliseconds: 1000))
+        timer.timerFired(at: .init(milliseconds: 1000))
         XCTAssertEqual(timer.nextDeadline, .init(milliseconds: 2000))
-        timer.timerFired(timeNow: .init(milliseconds: 2000))
+        timer.timerFired(at: .init(milliseconds: 2000))
         XCTAssertNotEqual(oneId, twoId)
         XCTAssertEqual(
             semaphore.wait(timeout: DispatchTime.now() + .seconds(2)),
@@ -126,9 +126,9 @@ final class TimerTests: XCTestCase {
             semaphore.signal()
         }
         XCTAssertEqual(timer.nextDeadline, .init(milliseconds: 1500))
-        timer.timerFired(timeNow: .init(milliseconds: 1500))
+        timer.timerFired(at: .init(milliseconds: 1500))
         XCTAssertEqual(timer.nextDeadline, .init(milliseconds: 2500))
-        timer.timerFired(timeNow: .init(milliseconds: 2500))
+        timer.timerFired(at: .init(milliseconds: 2500))
         XCTAssertNotEqual(oneId, twoId)
         XCTAssertEqual(
             semaphore.wait(timeout: DispatchTime.now() + .seconds(2)),
@@ -162,7 +162,7 @@ final class TimerTests: XCTestCase {
 
         // Timer should stay the same
         XCTAssertEqual(timer.nextDeadline, .init(microseconds: 1_000_000))
-        timer.timerFired(timeNow: .init(microseconds: 1_000_000))
+        timer.timerFired(at: .init(microseconds: 1_000_000))
         XCTAssertNotEqual(oneId, twoId)
         XCTAssertEqual(
             semaphore.wait(timeout: DispatchTime.now() + .seconds(2)),
@@ -209,13 +209,13 @@ final class TimerTests: XCTestCase {
         // Simulate a wakeup which is 0.5ms early. With the 1ms leeway,
         // post-leeway 'now' = 2s + 500us, which is still before B's
         // deadline (2s + 999us), so B doesn't fire and the spurious path runs.
-        timer.timerFired(timeNow: .init(.seconds(2) - .microseconds(500)))
+        timer.timerFired(at: .init(.seconds(2) - .microseconds(500)))
 
         // timerFired needs to rearm the wakeup.
         XCTAssertEqual(timer.nextDeadline, .init(.seconds(2) + .microseconds(999)))
 
         // Make sure B fires.
-        timer.timerFired(timeNow: .init(.seconds(2) + .microseconds(999)))
+        timer.timerFired(at: .init(.seconds(2) + .microseconds(999)))
         XCTAssertEqual(
             semaphore.wait(timeout: DispatchTime.now() + .seconds(1)),
             DispatchTimeoutResult.success
@@ -246,7 +246,7 @@ final class TimerTests: XCTestCase {
             semaphore.signal()
         }
         XCTAssertEqual(timer.nextDeadline, .init(.seconds(2) + .microseconds(500)))
-        timer.timerFired(timeNow: .init(.seconds(2) + .microseconds(500)))
+        timer.timerFired(at: .init(.seconds(2) + .microseconds(500)))
         XCTAssertEqual(
             semaphore.wait(timeout: DispatchTime.now() + .seconds(1)),
             DispatchTimeoutResult.success

--- a/Tests/QUICTests/TimerTests.swift
+++ b/Tests/QUICTests/TimerTests.swift
@@ -34,7 +34,7 @@ final class TimerTests: XCTestCase {
     func testOneTimer() {
         let timer = QUICTimer(timerReference: TimerReference(), logPrefixer: timerTestsLogPrefixer)
         let semaphore = DispatchSemaphore(value: 0)
-        let oneId = timer.insert(description: "one", fromNow: .milliseconds(1000), timerNow: .zero) {
+        let oneId = timer.insert(description: "one", fromNow: .milliseconds(1000), timerNow: .zero) { _ in
             semaphore.signal()
         }
         XCTAssertEqual(timer.nextDeadline, .init(milliseconds: 1000))
@@ -49,7 +49,7 @@ final class TimerTests: XCTestCase {
     func testReschedule() {
         let timer = QUICTimer(timerReference: TimerReference(), logPrefixer: timerTestsLogPrefixer)
         let semaphore = DispatchSemaphore(value: 0)
-        let oneId = timer.insert(description: "one-reschedule", timerNow: .zero) {
+        let oneId = timer.insert(description: "one-reschedule", timerNow: .zero) { _ in
             semaphore.signal()
         }
         XCTAssertEqual(timer.nextDeadline, .zero)
@@ -66,10 +66,10 @@ final class TimerTests: XCTestCase {
     func testTwoTimersAtSameTime() throws {
         let timer = QUICTimer(timerReference: TimerReference(), logPrefixer: timerTestsLogPrefixer)
         let semaphore = DispatchSemaphore(value: 0)
-        let oneId = timer.insert(description: "one", fromNow: .milliseconds(1000), timerNow: .zero) {
+        let oneId = timer.insert(description: "one", fromNow: .milliseconds(1000), timerNow: .zero) { _ in
             semaphore.signal()
         }
-        let twoId = timer.insert(description: "two", fromNow: .milliseconds(1000), timerNow: .zero) {
+        let twoId = timer.insert(description: "two", fromNow: .milliseconds(1000), timerNow: .zero) { _ in
             semaphore.signal()
         }
         XCTAssertEqual(timer.nextDeadline, .init(milliseconds: 1000))
@@ -90,11 +90,11 @@ final class TimerTests: XCTestCase {
     func testTwoTimersAtDifferentTimes() throws {
         let timer = QUICTimer(timerReference: TimerReference(), logPrefixer: timerTestsLogPrefixer)
         let semaphore = DispatchSemaphore(value: 0)
-        let oneId = timer.insert(description: "one", fromNow: .milliseconds(2000), timerNow: .zero) {
+        let oneId = timer.insert(description: "one", fromNow: .milliseconds(2000), timerNow: .zero) { _ in
             semaphore.signal()
         }
         XCTAssertEqual(timer.nextDeadline, .init(milliseconds: 2000))
-        let twoId = timer.insert(description: "two", fromNow: .milliseconds(1000), timerNow: .zero) {
+        let twoId = timer.insert(description: "two", fromNow: .milliseconds(1000), timerNow: .zero) { _ in
             semaphore.signal()
         }
         XCTAssertEqual(timer.nextDeadline, .init(milliseconds: 1000))
@@ -117,12 +117,11 @@ final class TimerTests: XCTestCase {
     func testRecalculateAfterMissingTimer() throws {
         let timer = QUICTimer(timerReference: TimerReference(), logPrefixer: timerTestsLogPrefixer)
         let semaphore = DispatchSemaphore(value: 0)
-        let oneId = timer.insert(description: "one", fromNow: .milliseconds(1000), timerNow: .zero) {
+        let oneId = timer.insert(description: "one", fromNow: .milliseconds(1000), timerNow: .zero) { _ in
             semaphore.signal()
         }
         XCTAssertEqual(timer.nextDeadline, .init(milliseconds: 1000))
-        let twoId = timer.insert(description: "two", fromNow: .milliseconds(1000), timerNow: .init(milliseconds: 1500))
-        {
+        let twoId = timer.insert(description: "two", fromNow: .milliseconds(1000), timerNow: .init(milliseconds: 1500)) { _ in
             semaphore.signal()
         }
         XCTAssertEqual(timer.nextDeadline, .init(milliseconds: 1500))
@@ -146,7 +145,7 @@ final class TimerTests: XCTestCase {
     func testRecalculateWithinThreshold() throws {
         let timer = QUICTimer(timerReference: TimerReference(), logPrefixer: timerTestsLogPrefixer)
         let semaphore = DispatchSemaphore(value: 0)
-        let oneId = timer.insert(description: "one", fromNow: .microseconds(1_000_000), timerNow: .zero) {
+        let oneId = timer.insert(description: "one", fromNow: .microseconds(1_000_000), timerNow: .zero) { _ in
             semaphore.signal()
         }
         XCTAssertEqual(timer.nextDeadline, .init(microseconds: 1_000_000))
@@ -156,7 +155,7 @@ final class TimerTests: XCTestCase {
             description: "two",
             fromNow: .microseconds(1_000_000),
             timerNow: .init(microseconds: 2)
-        ) {
+        ) { _ in
             semaphore.signal()
         }
 
@@ -185,7 +184,7 @@ final class TimerTests: XCTestCase {
         let semaphore = DispatchSemaphore(value: 0)
 
         // A, in 2s
-        let idA = timer.insert(description: "A", fromNow: .seconds(2), timerNow: .zero) {
+        let idA = timer.insert(description: "A", fromNow: .seconds(2), timerNow: .zero) { _ in
             XCTFail("A was disabled and must not fire")
         }
         XCTAssertEqual(timer.nextDeadline, .init(.seconds(2)))
@@ -195,7 +194,7 @@ final class TimerTests: XCTestCase {
             description: "B",
             fromNow: .seconds(2) + .microseconds(999),
             timerNow: .zero
-        ) {
+        ) { _ in
             semaphore.signal()
         }
         // A was earlier, deadline is unchanged
@@ -229,7 +228,7 @@ final class TimerTests: XCTestCase {
         let timer = QUICTimer(timerReference: TimerReference(), logPrefixer: timerTestsLogPrefixer)
         let semaphore = DispatchSemaphore(value: 0)
 
-        let idA = timer.insert(description: "A", fromNow: .seconds(2), timerNow: .zero) {
+        let idA = timer.insert(description: "A", fromNow: .seconds(2), timerNow: .zero) { _ in
             XCTFail("A was cancelled and must not fire")
         }
         XCTAssertEqual(timer.nextDeadline, .init(.seconds(2)))
@@ -242,7 +241,7 @@ final class TimerTests: XCTestCase {
             description: "B",
             fromNow: .seconds(2) + .microseconds(500),
             timerNow: .zero
-        ) {
+        ) { _ in
             semaphore.signal()
         }
         XCTAssertEqual(timer.nextDeadline, .init(.seconds(2) + .microseconds(500)))

--- a/Tests/QUICTests/TimerTests.swift
+++ b/Tests/QUICTests/TimerTests.swift
@@ -121,7 +121,8 @@ final class TimerTests: XCTestCase {
             semaphore.signal()
         }
         XCTAssertEqual(timer.nextDeadline, .init(milliseconds: 1000))
-        let twoId = timer.insert(description: "two", fromNow: .milliseconds(1000), timerNow: .init(milliseconds: 1500)) { _ in
+        let twoId = timer.insert(description: "two", fromNow: .milliseconds(1000), timerNow: .init(milliseconds: 1500))
+        { _ in
             semaphore.signal()
         }
         XCTAssertEqual(timer.nextDeadline, .init(milliseconds: 1500))

--- a/Tests/SwiftNetworkTests/SwiftNetworkQUICIdleTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkQUICIdleTests.swift
@@ -85,7 +85,7 @@ final class SwiftNetworkQUICIdleTests: NetTestCase {
                         )
 
                         // Once the delayed ACK has been sent there are no obligations left.
-                        client.ack.timerFired(timeNow: .now)
+                        client.ack.timerFired(at: .now)
                         XCTAssertEqual(
                             client.ack.unackedPacketCount,
                             0,


### PR DESCRIPTION
This PR's primary goal is to lay the groundwork for making a clock/time injectable: while datapath code reads `NetworkClock.Instant.now` directly, no test can control it. This threads the instant through from the caller instead, so a later change can supply  it, e.g. from a scheduler.

Whilst doing this work I discovered a couple of potential issues/improvements.

Sampling the clock wherever a time was needed meant one inbound batch read it repeatedly, and loss detection compared recorded deadlines against an instant sampled later than the one its timer fired at.

Changes:
* Congestion control and loss detection take `now` from their caller; `QUICPath` supplies the instant `QUICConnection` already caches for the batch.
* `QLog` events take the timestamp of the event rather than of the write.
* `Timer` closures receive the instant the timer fired instead of reading the clock again.

Two behavior changes:

* The frames of an inbound batch share one receive timestamp, so inter-arrival within a batch now reads zero. An `@autoclosure` keeps the read out of stacks that never ask for timestamps.
* `CubicTests.testCubicCongestionLimited` and its Prague analogue now seed from a fixed instant. From the system clock they had send times in their own future, so every loss opened a new recovery period instead of one per round.

A few `NetworkClock.Instant.now` reads remain; those are where a scheduler-supplied clock would hook in.