### PR TITLE
Finalize frames before returning early

### DIFF
--- a/Sources/SwiftNetwork/EndpointFlow/EndpointFlowProtocols.swift
+++ b/Sources/SwiftNetwork/EndpointFlow/EndpointFlowProtocols.swift
@@ -341,6 +341,7 @@ final class DatagramEndpointFlowProtocol: EndpointFlowProtocol<InboundDatagramLi
                     minimumDatagramSize: length
                 )
                 guard var frames = frames else {
+                    datagram.finalize(success: false)
                     log.error("Failed to get datagram to send")
                     return false
                 }
@@ -359,6 +360,7 @@ final class DatagramEndpointFlowProtocol: EndpointFlowProtocol<InboundDatagramLi
                 try lower.invokeSendDatagrams(reference, datagrams: frames)
                 return true
             } catch {
+                datagram.finalize(success: false)
                 return false
             }
         }

--- a/Sources/SwiftNetwork/Protocols/BridgeProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/BridgeProtocol.swift
@@ -300,6 +300,7 @@ public struct BridgeDatagramProtocol: NetworkProtocol {
 
         public static func injectDatagram(_ datagram: consuming Frame, to remotePort: UInt16) {
             guard let remoteInstance = BridgeInstance.instances[remotePort] else {
+                datagram.finalize(success: false)
                 return
             }
             remoteInstance.incomingFrames.add(frames: .init(frame: datagram))

--- a/Sources/SwiftNetwork/Protocols/DemuxProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/DemuxProtocol.swift
@@ -427,7 +427,10 @@ public struct DemuxProtocol: NetworkProtocol {
             _ from: ProtocolInstanceReference,
             datagrams: consuming FrameArray
         ) throws(NetworkError) {
-            do { try validate(upper: from, #function) } catch { throw NetworkError.posix(EINVAL) }
+            do { try validate(upper: from, #function) } catch {
+                datagrams.finalizeAllFramesAsFailed()
+                throw NetworkError.posix(EINVAL)
+            }
             try lower.invokeSendDatagrams(self.reference, datagrams: datagrams)
         }
 

--- a/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
@@ -1404,7 +1404,10 @@ extension ManyToManyApplicationStreamProtocol where Flow: AutomaticUpperStreamPr
         flow flowID: MultiplexedFlowIdentifier,
         streamData: consuming FrameArray
     ) throws(NetworkError) {
-        guard var flow = self.flow(for: flowID) else { throw NetworkError.posix(EINVAL) }
+        guard var flow = self.flow(for: flowID) else {
+            streamData.finalizeAllFramesAsFailed()
+            throw NetworkError.posix(EINVAL)
+        }
         return try flow.addToUpperReceiveQueue(streamData)
     }
 
@@ -1417,7 +1420,10 @@ extension ManyToManyApplicationStreamProtocol where Flow: AutomaticUpperStreamPr
         flow flowID: MultiplexedFlowIdentifier,
         streamData: consuming FrameArray
     ) throws(NetworkError) {
-        guard var flow = self.flow(for: flowID) else { throw NetworkError.posix(EINVAL) }
+        guard var flow = self.flow(for: flowID) else {
+            streamData.finalizeAllFramesAsFailed()
+            throw NetworkError.posix(EINVAL)
+        }
         try deliverInboundStreamData(flow: &flow, streamData: streamData)
     }
 
@@ -1614,7 +1620,10 @@ extension ManyToManyApplicationDatagramProtocol where Flow: AutomaticUpperDatagr
         flow flowID: MultiplexedFlowIdentifier,
         datagrams: consuming FrameArray
     ) throws(NetworkError) {
-        guard var flow = self.flow(for: flowID) else { throw NetworkError.posix(EINVAL) }
+        guard var flow = self.flow(for: flowID) else {
+            datagrams.finalizeAllFramesAsFailed()
+            throw NetworkError.posix(EINVAL)
+        }
         return try flow.addToUpperReceiveQueue(datagrams)
     }
 
@@ -1628,7 +1637,10 @@ extension ManyToManyApplicationDatagramProtocol where Flow: AutomaticUpperDatagr
         flow flowID: MultiplexedFlowIdentifier,
         datagrams: consuming FrameArray
     ) throws(NetworkError) {
-        guard var flow = self.flow(for: flowID) else { throw NetworkError.posix(EINVAL) }
+        guard var flow = self.flow(for: flowID) else {
+            datagrams.finalizeAllFramesAsFailed()
+            throw NetworkError.posix(EINVAL)
+        }
         try flow.addToUpperReceiveQueue(datagrams)
         flow.serviceUpperReceiveQueue()
     }
@@ -1656,7 +1668,10 @@ extension HeterogeneousManyToManyProtocolHandler where SecondaryFlow: AutomaticU
         flow flowID: MultiplexedFlowIdentifier,
         datagrams: consuming FrameArray
     ) throws(NetworkError) {
-        guard var flow = self.secondaryFlow(for: flowID) else { throw NetworkError.posix(EINVAL) }
+        guard var flow = self.secondaryFlow(for: flowID) else {
+            datagrams.finalizeAllFramesAsFailed()
+            throw NetworkError.posix(EINVAL)
+        }
         return try flow.addToUpperReceiveQueue(datagrams)
     }
 
@@ -1670,7 +1685,10 @@ extension HeterogeneousManyToManyProtocolHandler where SecondaryFlow: AutomaticU
         flow flowID: MultiplexedFlowIdentifier,
         datagrams: consuming FrameArray
     ) throws(NetworkError) {
-        guard var flow = self.secondaryFlow(for: flowID) else { throw NetworkError.posix(EINVAL) }
+        guard var flow = self.secondaryFlow(for: flowID) else {
+            datagrams.finalizeAllFramesAsFailed()
+            throw NetworkError.posix(EINVAL)
+        }
         try deliverInboundDatagrams(flow: &flow, datagrams: datagrams)
     }
 
@@ -2033,7 +2051,10 @@ extension ManyToManyOutboundDatagramProtocol where Path: AutomaticLowerDatagramP
         path pathID: MultiplexingPathIdentifier,
         datagrams: consuming FrameArray
     ) throws(NetworkError) {
-        guard var path = self.path(for: pathID) else { throw NetworkError.posix(EINVAL) }
+        guard var path = self.path(for: pathID) else {
+            datagrams.finalizeAllFramesAsFailed()
+            throw NetworkError.posix(EINVAL)
+        }
         return try path.addToLowerSendQueue(datagrams)
     }
 

--- a/Sources/SwiftNetwork/Protocols/ProtocolStreamHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolStreamHandlers.swift
@@ -400,7 +400,10 @@ extension ProtocolInstanceReference {
                 }
             #endif
             // Sending early stream data not supported on the protocol
-            default: throw NetworkError.posix(ENOTSUP)
+            default:
+                var streamData = streamData
+                streamData.finalizeAllFramesAsFailed()
+                throw NetworkError.posix(ENOTSUP)
             }
         }
     }

--- a/Sources/SwiftNetwork/Protocols/SwiftTLSProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/SwiftTLSProtocol.swift
@@ -503,6 +503,7 @@ public struct SwiftTLSProtocol: NetworkProtocol {
 
             func sendStreamData(_ streamData: consuming FrameArray) throws(NetworkError) {
                 guard !lower.isDetached else {
+                    streamData.finalizeAllFramesAsFailed()
                     throw NetworkError.posix(EINVAL)
                 }
                 try lower.invokeSendStreamData(reference, streamData: streamData)
@@ -766,6 +767,7 @@ public struct SwiftTLSProtocol: NetworkProtocol {
         }
 
         func sendStreamData(_ streamData: consuming FrameArray) throws(NetworkError) {
+            streamData.finalizeAllFramesAsFailed()
             throw NetworkError.posix(ENOTSUP)
         }
 


### PR DESCRIPTION
Some methods that `consume` a `Frame` or `FrameArray` do not call `finalize` on the `Frame`(s) before throwing or returning early. In these cases, a precondition failure is hit when the frame is `deinit`ed. This PR adds `finalize` calls in those places.