### PR TITLE
SwiftNetwork: PERF: Optimize UDP checksum16

### DIFF
--- a/Sources/SwiftNetwork/Protocols/Checksum.swift
+++ b/Sources/SwiftNetwork/Protocols/Checksum.swift
@@ -142,26 +142,13 @@ extension Frame {
             )
             throw ChecksumError.invalidLength
         }
-        // Operate directly on the underlying storage
-        switch buffer {
-        case .bytes:
-            let lowerBound = startOffset + offset
-            return _bytes.span.withUnsafeBytes { raw in
-                let offsetBuffer = UnsafeRawBufferPointer(
-                    start: raw.baseAddress!.advanced(by: lowerBound),
-                    count: length
-                )
-                return offsetBuffer.checksum16()
-            }
-        default:
-            guard let unsafeUnclaimedBuffer else {
-                Logger.proto.info("Frame is no longer valid in checksum16")
-                throw ChecksumError.invalidBuffer
-            }
-            let offsetBuffer = UnsafeRawBufferPointer(
-                start: unsafeUnclaimedBuffer.baseAddress!.advanced(by: offset),
-                count: length
-            )
+        guard let buffer = self.bytes else {
+            Logger.proto.info("Frame is no longer valid in checksum16")
+            throw ChecksumError.invalidBuffer
+        }
+
+        return buffer.withUnsafeBytes { buffer in
+            let offsetBuffer = UnsafeRawBufferPointer(start: buffer.baseAddress!.advanced(by: offset), count: length)
             return offsetBuffer.checksum16()
         }
     }

--- a/Sources/SwiftNetwork/Protocols/Checksum.swift
+++ b/Sources/SwiftNetwork/Protocols/Checksum.swift
@@ -52,8 +52,8 @@ extension UInt32 {
     }
 }
 
-@available(Network 0.1.0, *)
-public enum ChecksumError: Error {
+@usableFromInline
+enum ChecksumError: Error {
     case invalidLength
     case invalidBuffer
 }

--- a/Sources/SwiftNetwork/Protocols/Checksum.swift
+++ b/Sources/SwiftNetwork/Protocols/Checksum.swift
@@ -52,7 +52,8 @@ extension UInt32 {
     }
 }
 
-enum ChecksumError: Error {
+@available(Network 0.1.0, *)
+public enum ChecksumError: Error {
     case invalidLength
     case invalidBuffer
 }
@@ -128,31 +129,45 @@ struct Checksum: ~Copyable {
 
 @available(Network 0.1.0, *)
 extension Frame {
+    @usableFromInline
     func checksum16(offset: Int, length: Int) throws(ChecksumError) -> UInt16 {
         let frameLength = self.unclaimedLength
         guard offset <= frameLength else {
             Logger.proto.fault("Offset \(offset) > frame length \(frameLength) in checksum16")
             throw ChecksumError.invalidLength
         }
-
         guard length <= (frameLength - offset) else {
             Logger.proto.fault(
                 "Checksum length \(length) > effective frame length \(frameLength - offset) in checksum16"
             )
             throw ChecksumError.invalidLength
         }
-
-        guard let buffer = self.bytes else {
-            Logger.proto.info("Frame is no longer valid in checksum16")
-            throw ChecksumError.invalidBuffer
-        }
-
-        return buffer.withUnsafeBytes { buffer in
-            let offsetBuffer = UnsafeRawBufferPointer(start: buffer.baseAddress!.advanced(by: offset), count: length)
+        // Operate directly on the underlying storage
+        switch buffer {
+        case .bytes:
+            let lowerBound = startOffset + offset
+            return _bytes.span.withUnsafeBytes { raw in
+                let offsetBuffer = UnsafeRawBufferPointer(
+                    start: raw.baseAddress!.advanced(by: lowerBound),
+                    count: length
+                )
+                return offsetBuffer.checksum16()
+            }
+        default:
+            guard let unsafeUnclaimedBuffer else {
+                Logger.proto.info("Frame is no longer valid in checksum16")
+                throw ChecksumError.invalidBuffer
+            }
+            let offsetBuffer = UnsafeRawBufferPointer(
+                start: unsafeUnclaimedBuffer.baseAddress!.advanced(by: offset),
+                count: length
+            )
             return offsetBuffer.checksum16()
         }
     }
 
+    @inlinable
+    @inline(always)
     func ipChecksum(offset: Int, length: Int) throws(ChecksumError) -> UInt16 {
         let value = try self.checksum16(offset: offset, length: length)
         return ((~value) & 0xffff)
@@ -183,44 +198,25 @@ extension Frame {
 }
 
 extension UnsafeRawBufferPointer {
+    @inlinable
+    @inline(always)
     func checksum16() -> UInt16 {
-        let divisibleBuffer: UnsafeRawBufferPointer
-        let remainderBuffer: UnsafeRawBufferPointer?
-        if self.count % MemoryLayout<UInt32>.size != 0 {
-            // Need to extract a remainder
-            let divisibleCount = (self.count / MemoryLayout<UInt32>.size) * MemoryLayout<UInt32>.size
-            let remainder = self.count - divisibleCount
-            divisibleBuffer = UnsafeRawBufferPointer(start: self.baseAddress!, count: divisibleCount)
-            remainderBuffer = UnsafeRawBufferPointer(
-                start: self.baseAddress!.advanced(by: divisibleCount),
-                count: remainder
-            )
-        } else {
-            divisibleBuffer = self
-            remainderBuffer = nil
+        guard let baseAddress else { return 0 }
+        let byteCount = count
+        let wordCount = byteCount / 2
+        let words = UnsafeBufferPointer(
+            start: baseAddress.bindMemory(to: UInt16.self, capacity: wordCount),
+            count: wordCount
+        )
+        var sum: UInt32 = 0
+        for word in words {
+            sum &+= UInt32(word)
         }
-        var partial = divisibleBuffer.withMemoryRebound(to: UInt32.self) { elements in
-            elements.reduce(into: UInt64(0)) { $0 &+= UInt64($1) }
+        if byteCount % 2 != 0 {
+            sum &+= UInt32(baseAddress.load(fromByteOffset: byteCount &- 1, as: UInt8.self))
         }
-
-        if let remainderBuffer = remainderBuffer {
-            if remainderBuffer.count == 3 {
-                partial &+= UInt64(remainderBuffer.load(as: UInt16.self))
-                partial &+= UInt64(remainderBuffer[2])
-            } else if remainderBuffer.count == 2 {
-                partial &+= UInt64(remainderBuffer.load(as: UInt16.self))
-            } else {
-                partial &+= UInt64(remainderBuffer[0])
-            }
-        }
-        var sum: UInt64 = (UInt64(partial) >> 32) &+ UInt64(partial & 0xffff_ffff)
-        sum = (sum >> 32) &+ (sum & 0xffff_ffff)
-
-        var finalAccumulator: UInt32 =
-            UInt32(sum >> 48) &+ UInt32((sum >> 32) & 0xffff) &+ UInt32((sum >> 16) & 0xffff) &+ UInt32(sum & 0xffff)
-        finalAccumulator = (finalAccumulator >> 16) &+ (finalAccumulator & 0xffff)
-        finalAccumulator = (finalAccumulator >> 16) &+ (finalAccumulator & 0xffff)
-
-        return UInt16(truncatingIfNeeded: finalAccumulator)
+        sum = (sum >> 16) &+ (sum & 0xffff)
+        sum = (sum >> 16) &+ (sum & 0xffff)
+        return UInt16(sum)
     }
 }

--- a/Tests/SwiftNetworkTests/SwiftNetworkChecksumTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkChecksumTests.swift
@@ -103,4 +103,75 @@ final class SwiftNetworkChecksumTests: NetTestCase {
         let checksum = string.withUTF8 { $0.withUnsafeBytes { $0.checksum16() } }
         XCTAssertEqual(checksum, expectedValue, "Checksum didn't match (\(checksum) != \(expectedValue))")
     }
+
+    func testChecksum16EmptyBuffer() {
+        let buffer: [UInt8] = []
+        let expectedValue = UInt16(0)
+        let checksum = buffer.withUnsafeBytes { $0.checksum16() }
+        XCTAssertEqual(checksum, expectedValue, "Checksum didn't match (\(checksum) != \(expectedValue))")
+    }
+
+    func testChecksum16SingleByte() {
+        let buffer: [UInt8] = [0xAB]
+        let expectedValue = UInt16(0x00AB)
+        let checksum = buffer.withUnsafeBytes { $0.checksum16() }
+        XCTAssertEqual(checksum, expectedValue, "Checksum didn't match (\(checksum) != \(expectedValue))")
+    }
+
+    func testChecksum16SingleWord() {
+        let buffer: [UInt8] = [0x12, 0x34]
+        let expectedValue = UInt16(0x3412)
+        let checksum = buffer.withUnsafeBytes { $0.checksum16() }
+        XCTAssertEqual(checksum, expectedValue, "Checksum didn't match (\(checksum) != \(expectedValue))")
+    }
+
+    func testChecksum16OddLength() {
+        // This makes sure that the remainder calculates
+        let buffer: [UInt8] = [0x01, 0x02, 0x03]
+        let expectedValue = UInt16(0x0204)
+        let checksum = buffer.withUnsafeBytes { $0.checksum16() }
+        XCTAssertEqual(checksum, expectedValue, "Checksum didn't match (\(checksum) != \(expectedValue))")
+    }
+
+    func testChecksum16evenAllOnesFoldsToUInt16Max() {
+        let buffer: [UInt8] = Array(repeating: 0xFF, count: 8)
+        let expectedValue = UInt16(0xFFFF)
+        let checksum = buffer.withUnsafeBytes { $0.checksum16() }
+        XCTAssertEqual(checksum, expectedValue, "Checksum didn't match (\(checksum) != \(expectedValue))")
+        XCTAssertEqual(checksum, UInt16.max, "Checksum didn't match (\(checksum) != \(UInt16.max))")
+    }
+
+    func testChecksum16OddAllOnesRequiresDoubleFold() {
+        // The double fold lands on a 0x00FF
+        let buffer: [UInt8] = Array(repeating: 0xFF, count: 9)
+        let expectedValue = UInt16(0x00FF)
+        let checksum = buffer.withUnsafeBytes { $0.checksum16() }
+        XCTAssertEqual(checksum, expectedValue, "Checksum didn't match (\(checksum) != \(expectedValue))")
+    }
+
+    func testChecksum16AllZeros() {
+        let buffer: [UInt8] = Array(repeating: 0x00, count: 16)
+        let expectedValue = UInt16(0)
+        let checksum = buffer.withUnsafeBytes { $0.checksum16() }
+        XCTAssertEqual(checksum, expectedValue, "Checksum didn't match (\(checksum) != \(expectedValue))")
+    }
+
+    func testChecksum16MixedOddLength() {
+        let buffer: [UInt8] = [0xDE, 0xAD, 0xBE, 0xEF, 0x01]
+        let expectedValue = UInt16(0x9D9E)
+        let checksum = buffer.withUnsafeBytes { $0.checksum16() }
+        XCTAssertEqual(checksum, expectedValue, "Checksum didn't match (\(checksum) != \(expectedValue))")
+    }
+
+    func testChecksum16OrderIndependent() {
+        let buffer: [UInt8] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
+        let reordered: [UInt8] = [0x07, 0x08, 0x03, 0x04, 0x01, 0x02, 0x05, 0x06]
+        let checksum = buffer.withUnsafeBytes { $0.checksum16() }
+        let reorderedChecksum = reordered.withUnsafeBytes { $0.checksum16() }
+        XCTAssertEqual(
+            checksum,
+            reorderedChecksum,
+            "Checksum didn't match (\(checksum) != \(reorderedChecksum))"
+        )
+    }
 }


### PR DESCRIPTION
This is a small optimization for UDP `checksum16` .  This change removes roughly 25% of the checksum instructions but we only see a small win of around 14% in the QUICTransfer benchmark:
```
// Before
768.13 M 100.0%	-	 checksum16()

// After
680.36 M 100.0%	-	 checksum16()
```
Assembly look:
<https://godbolt.org/z/GzWP1ea75>