### PR TITLE
NetworkClock: fix duration arithmetic and improve descriptions

### DIFF
--- a/Sources/SwiftNetwork/QUIC/FlowControl.swift
+++ b/Sources/SwiftNetwork/QUIC/FlowControl.swift
@@ -788,7 +788,7 @@ extension QUICStreamInstance {
                     shift = 1
                 }
                 log.datapath(
-                    "Estimated BDP \(receiveHighWaterMarkCount)B, current RTT \(rtt)us, estimated bandwidth 8 * \(receiveHighWaterMarkCount) / \(rtt) Mbps"
+                    "Estimated BDP \(receiveHighWaterMarkCount)B, current RTT \(rtt), estimated bandwidth 8 * \(receiveHighWaterMarkCount) / \(rtt.microseconds) Mbps"
                 )
 
                 let (incr, overflow) = (receiveHighWaterMarkCount << shift)

--- a/Sources/SwiftNetwork/Utilities/NetworkClock.swift
+++ b/Sources/SwiftNetwork/Utilities/NetworkClock.swift
@@ -25,6 +25,19 @@
 public struct NetworkDuration: DurationProtocol, Hashable, Equatable, CustomStringConvertible {
     public private(set) var nanoseconds: Int64
 
+    // These are computed properties wrapping literals, and deliberately not
+    // `static let`s. A `static let` becomes a lazily initialised global, so every
+    // read carries a one-time-init guard, whereas a computed property returning a
+    // literal constant-folds at each use site. Deriving them from
+    // `System.Time.NSEC_PER_USEC` and friends would not fold either, because those
+    // are themselves `static let`s.
+    private static var nanosecondsPerMicrosecond: Int64 { 1_000 }
+    private static var nanosecondsPerMillisecond: Int64 { 1_000_000 }
+    private static var nanosecondsPerSecond: Int64 { 1_000_000_000 }
+    private static var nanosecondsPerMinute: Int64 { 60 * nanosecondsPerSecond }
+    private static var nanosecondsPerHour: Int64 { 60 * nanosecondsPerMinute }
+    private static var nanosecondsPerDay: Int64 { 24 * nanosecondsPerHour }
+
     init(nanoseconds: Int64) {
         self.nanoseconds = nanoseconds
     }
@@ -58,7 +71,7 @@ public struct NetworkDuration: DurationProtocol, Hashable, Equatable, CustomStri
     }
 
     static func * (lhs: Double, rhs: NetworkDuration) -> NetworkDuration {
-        NetworkDuration(nanoseconds: rhs.nanoseconds * Int64(lhs))
+        NetworkDuration(nanoseconds: Int64(Double(rhs.nanoseconds) * lhs))
     }
 
     static func * (lhs: NetworkDuration, rhs: Double) -> NetworkDuration {
@@ -66,15 +79,15 @@ public struct NetworkDuration: DurationProtocol, Hashable, Equatable, CustomStri
     }
 
     static func >> (lhs: NetworkDuration, rhs: Int) -> NetworkDuration {
-        NetworkDuration(nanoseconds: Int64(lhs.nanoseconds >> rhs))
+        NetworkDuration(nanoseconds: lhs.nanoseconds >> rhs)
     }
 
     static func << (lhs: NetworkDuration, rhs: Int) -> NetworkDuration {
-        NetworkDuration(nanoseconds: Int64(lhs.nanoseconds << rhs))
+        NetworkDuration(nanoseconds: lhs.nanoseconds << rhs)
     }
 
     public static func / (lhs: NetworkDuration, rhs: NetworkDuration) -> Double {
-        Double(lhs.nanoseconds / rhs.nanoseconds)
+        Double(lhs.nanoseconds) / Double(rhs.nanoseconds)
     }
 
     public static func < (lhs: NetworkDuration, rhs: NetworkDuration) -> Bool {
@@ -102,98 +115,120 @@ public struct NetworkDuration: DurationProtocol, Hashable, Equatable, CustomStri
     }
 
     public static func microseconds<T>(_ microseconds: T) -> NetworkDuration where T: BinaryInteger {
-        NetworkDuration(nanoseconds: Int64(microseconds) * 1000)
+        NetworkDuration(nanoseconds: Int64(microseconds) * NetworkDuration.nanosecondsPerMicrosecond)
     }
 
     public static func microseconds(_ microseconds: Double) -> NetworkDuration {
-        NetworkDuration(nanoseconds: Int64(microseconds * 1000))
+        NetworkDuration(nanoseconds: Int64(microseconds * Double(NetworkDuration.nanosecondsPerMicrosecond)))
     }
 
     public static func milliseconds<T>(_ milliseconds: T) -> NetworkDuration where T: BinaryInteger {
-        NetworkDuration(nanoseconds: Int64(milliseconds) * 1_000_000)
+        NetworkDuration(nanoseconds: Int64(milliseconds) * NetworkDuration.nanosecondsPerMillisecond)
     }
 
     public static func milliseconds(_ milliseconds: Double) -> NetworkDuration {
-        NetworkDuration(nanoseconds: Int64(milliseconds * 1_000_000))
+        NetworkDuration(nanoseconds: Int64(milliseconds * Double(NetworkDuration.nanosecondsPerMillisecond)))
     }
 
     public static func seconds<T>(_ seconds: T) -> NetworkDuration where T: BinaryInteger {
-        NetworkDuration(nanoseconds: Int64(seconds) * 1_000_000_000)
+        NetworkDuration(nanoseconds: Int64(seconds) * NetworkDuration.nanosecondsPerSecond)
     }
 
     public static func minutes<T>(_ minutes: T) -> NetworkDuration where T: BinaryInteger {
-        NetworkDuration(nanoseconds: (Int64(minutes) * 60 * 1_000_000_000))
+        NetworkDuration(nanoseconds: Int64(minutes) * NetworkDuration.nanosecondsPerMinute)
+    }
+
+    public static func hours<T>(_ hours: T) -> NetworkDuration where T: BinaryInteger {
+        NetworkDuration(nanoseconds: Int64(hours) * NetworkDuration.nanosecondsPerHour)
+    }
+
+    public static func days<T>(_ days: T) -> NetworkDuration where T: BinaryInteger {
+        NetworkDuration(nanoseconds: Int64(days) * NetworkDuration.nanosecondsPerDay)
+    }
+
+    // Render a duration of a minute or more as a whole coarse unit plus, when
+    // non-zero, a whole sub-unit: "2 h", "1 h 30 min", "1 min 15 s".
+    private func coarseDescription() -> String? {
+        let units: [3 of (size: Int64, name: String, subSize: Int64, subName: String)] = [
+            (NetworkDuration.nanosecondsPerDay, "d", NetworkDuration.nanosecondsPerHour, "h"),
+            (NetworkDuration.nanosecondsPerHour, "h", NetworkDuration.nanosecondsPerMinute, "min"),
+            (NetworkDuration.nanosecondsPerMinute, "min", NetworkDuration.nanosecondsPerSecond, "s"),
+        ]
+        for index in units.indices {
+            let unit = units[index]
+            let value = nanoseconds / unit.size
+            guard value != 0 else { continue }
+            let sub = abs((nanoseconds % unit.size) / unit.subSize)
+            return sub == 0
+                ? "\(value) \(unit.name)"
+                : "\(value) \(unit.name) \(sub) \(unit.subName)"
+        }
+        return nil
     }
 
     public var description: String {
-        // Ideally we would use:
-        //     formatted(.units(allowed: [.seconds, .milliseconds, .microseconds, .nanoseconds]))
-        // However, that requires Foundation, so we implement our own description.
-        if self.nanoseconds >= 0 {
-            if self.seconds > 0 {
-                return NetworkDuration.fractionalDescription(
-                    unit: "s",
-                    value: self.seconds,
-                    thousandth: self.milliseconds
-                )
-            } else if self.milliseconds > 0 {
-                return NetworkDuration.fractionalDescription(
-                    unit: "ms",
-                    value: self.milliseconds,
-                    thousandth: self.microseconds
-                )
-            } else if self.microseconds > 0 {
-                return "\(self.microseconds) μs"
-            } else {
-                return "\(nanoseconds) ns"
-            }
+        coarseDescription() ?? fineDescription
+    }
+
+    // Description using no unit coarser than seconds.
+    fileprivate var fineDescription: String {
+        if self.seconds != 0 {
+            return NetworkDuration.fractionalDescription(
+                unit: "s",
+                value: self.seconds,
+                thousandth: self.milliseconds
+            )
+        } else if self.milliseconds != 0 {
+            return NetworkDuration.fractionalDescription(
+                unit: "ms",
+                value: self.milliseconds,
+                thousandth: self.microseconds
+            )
+        } else if self.microseconds != 0 {
+            return NetworkDuration.fractionalDescription(
+                unit: "μs",
+                value: self.microseconds,
+                thousandth: self.nanoseconds
+            )
         } else {
-            if self.seconds <= -1 {
-                return NetworkDuration.fractionalDescription(
-                    unit: "s",
-                    value: self.seconds,
-                    thousandth: self.milliseconds
-                )
-            } else if self.milliseconds <= -1 {
-                return NetworkDuration.fractionalDescription(
-                    unit: "ms",
-                    value: self.milliseconds,
-                    thousandth: self.microseconds
-                )
-            } else if self.microseconds <= -1 {
-                return "\(self.microseconds) μs"
-            } else {
-                return "\(nanoseconds) ns"
-            }
+            return "\(nanoseconds) ns"
         }
     }
 
     private static func fractionalDescription(unit: String, value: Int64, thousandth: Int64) -> String {
-        let fractional = ((value >= 0) ? 1 : -1) * (thousandth % 1000)
-        if fractional % 100 == 0 {
-            return "\(value).\(fractional / 100) \(unit)"
-        } else if fractional % 10 == 0 {
-            let twoDigits = fractional / 10
-            let padded = (twoDigits <= 9) ? "0\(twoDigits)" : "\(twoDigits)"
-            return "\(value).\(padded) \(unit)"
-        } else {
-            let hundreds = fractional / 100
-            let tens = (fractional / 10) % 10
-            let ones = fractional % 10
+        let fractional = abs(thousandth % 1000)
+        let hundreds = fractional / 100
+        let tens = (fractional / 10) % 10
+        let ones = fractional % 10
+        if ones != 0 {
             return "\(value).\(hundreds)\(tens)\(ones) \(unit)"
+        } else if tens != 0 {
+            return "\(value).\(hundreds)\(tens) \(unit)"
+        } else {
+            return "\(value).\(hundreds) \(unit)"
         }
     }
 
     public var seconds: Int64 {
-        nanoseconds / 1_000_000_000
+        nanoseconds / NetworkDuration.nanosecondsPerSecond
     }
 
     public var milliseconds: Int64 {
-        nanoseconds / 1_000_000
+        nanoseconds / NetworkDuration.nanosecondsPerMillisecond
+    }
+
+    // The number of whole milliseconds in this duration, rounded up.
+    // Zero and negative durations clamp to zero.
+    public var roundedUpMilliseconds: Int64 {
+        guard nanoseconds > 0 else {
+            return 0
+        }
+        return (nanoseconds + NetworkDuration.nanosecondsPerMillisecond - 1)
+            / NetworkDuration.nanosecondsPerMillisecond
     }
 
     public var microseconds: Int64 {
-        nanoseconds / 1000
+        nanoseconds / NetworkDuration.nanosecondsPerMicrosecond
     }
 
     // Returns the number of microseconds round to the nearest integer.
@@ -201,12 +236,8 @@ public struct NetworkDuration: DurationProtocol, Hashable, Equatable, CustomStri
         if nanoseconds == 0 {
             return self
         }
-        let nanosecondsPerMicrosecond: Int64 = 1000
-        let halfway = nanosecondsPerMicrosecond / 2
-        let roundedMicroseconds =
-            ((nanoseconds + halfway) / nanosecondsPerMicrosecond)
-
-        return .microseconds(roundedMicroseconds)
+        let halfway = (NetworkDuration.nanosecondsPerMicrosecond / 2) * self.nanoseconds.signum()
+        return .microseconds((self.nanoseconds + halfway) / NetworkDuration.nanosecondsPerMicrosecond)
     }
 }
 
@@ -294,8 +325,8 @@ public struct NetworkClock: Clock {
             NetworkClock.Instant(lhs.time - rhs)
         }
 
-        public static func - (lhs: Self, rhs: NetworkClock.Instant) -> Self {
-            NetworkClock.Instant(lhs.time - rhs.time)
+        public static func - (lhs: Self, rhs: NetworkClock.Instant) -> NetworkDuration {
+            lhs.time - rhs.time
         }
 
         init(milliseconds: Int64) {
@@ -343,7 +374,10 @@ public struct NetworkClock: Clock {
         }
 
         public var description: String {
-            time.description
+            // A NetworkClock.Instant is a time *since* an epoch rather
+            // than an elapsed span, so rendering it with
+            // coarse units makes it read like a duration.
+            time.fineDescription
         }
     }
 

--- a/Tests/QUICTests/CubicTests.swift
+++ b/Tests/QUICTests/CubicTests.swift
@@ -466,7 +466,7 @@ final class CubicTests: XCTestCase {
         let timeDifference = sendTimeAbsolute - initialBurstAbsoluteTime
         // This packet should get the default pacing rate of 10ms because the rate is low
         XCTAssertTrue(
-            timeDifference.time.milliseconds
+            timeDifference.milliseconds
                 == Constants.maxBurstIntervalKernelPacing.milliseconds
         )
     }

--- a/Tests/QUICTests/PacerTests.swift
+++ b/Tests/QUICTests/PacerTests.swift
@@ -155,7 +155,7 @@ final class PacerTests: XCTestCase {
         let timeDifference = sendTimeAbsolute - initialBurstAbsoluteTime
         // We should see a pacing time less than maxBurstIntervalKernelPacing (Should be around 1-2ms)
         XCTAssertTrue(
-            timeDifference.time.milliseconds <= Constants.maxBurstIntervalKernelPacing.milliseconds
+            timeDifference.milliseconds <= Constants.maxBurstIntervalKernelPacing.milliseconds
         )
     }
 }

--- a/Tests/SwiftNetworkTests/SwiftNetworkClockTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkClockTests.swift
@@ -88,7 +88,7 @@ final class SwiftNetworkClockTests: NetTestCase {
         XCTAssertEqual(NetworkDuration.milliseconds(1776).description, "1.776 s")
         XCTAssertEqual(NetworkDuration.milliseconds(2).description, "2.0 ms")
         XCTAssertEqual(NetworkDuration.microseconds(2020).description, "2.02 ms")
-        XCTAssertEqual(NetworkDuration.microseconds(3).description, "3 μs")
+        XCTAssertEqual(NetworkDuration.microseconds(3).description, "3.0 μs")
         XCTAssertEqual(NetworkDuration.nanoseconds(4).description, "4 ns")
     }
 
@@ -102,8 +102,68 @@ final class SwiftNetworkClockTests: NetTestCase {
         XCTAssertEqual(NetworkDuration.milliseconds(-1776).description, "-1.776 s")
         XCTAssertEqual(NetworkDuration.milliseconds(-2).description, "-2.0 ms")
         XCTAssertEqual(NetworkDuration.microseconds(-2020).description, "-2.02 ms")
-        XCTAssertEqual(NetworkDuration.microseconds(-3).description, "-3 μs")
+        XCTAssertEqual(NetworkDuration.microseconds(-3).description, "-3.0 μs")
         XCTAssertEqual(NetworkDuration.nanoseconds(-4).description, "-4 ns")
+    }
+
+    // Sub-microsecond remainders must survive, as they do for s and ms.
+    func testDurationDescriptionFractionalMicroseconds() throws {
+        XCTAssertEqual(NetworkDuration.nanoseconds(1500).description, "1.5 μs")
+        XCTAssertEqual(NetworkDuration.nanoseconds(1010).description, "1.01 μs")
+        XCTAssertEqual(NetworkDuration.nanoseconds(1999).description, "1.999 μs")
+        XCTAssertEqual(NetworkDuration.nanoseconds(-1500).description, "-1.5 μs")
+        XCTAssertEqual(NetworkDuration.nanoseconds(-1999).description, "-1.999 μs")
+        XCTAssertEqual(NetworkDuration.nanoseconds(999).description, "999 ns")
+        XCTAssertEqual(NetworkDuration.nanoseconds(-999).description, "-999 ns")
+    }
+
+    // A minute or more renders as whole coarse units, optionally with one whole
+    // sub-unit.
+    func testDurationDescriptionCoarseUnits() throws {
+        XCTAssertEqual(NetworkDuration.seconds(60).description, "1 min")
+        XCTAssertEqual(NetworkDuration.seconds(75).description, "1 min 15 s")
+        XCTAssertEqual(NetworkDuration.minutes(1).description, "1 min")
+        XCTAssertEqual(NetworkDuration.minutes(59).description, "59 min")
+        XCTAssertEqual(NetworkDuration.minutes(60).description, "1 h")
+        XCTAssertEqual(NetworkDuration.minutes(90).description, "1 h 30 min")
+        XCTAssertEqual(NetworkDuration.minutes(120).description, "2 h")
+        XCTAssertEqual(NetworkDuration.hours(2).description, "2 h")
+        XCTAssertEqual(NetworkDuration.hours(23).description, "23 h")
+        XCTAssertEqual(NetworkDuration.hours(24).description, "1 d")
+        XCTAssertEqual(NetworkDuration.hours(26).description, "1 d 2 h")
+        XCTAssertEqual(NetworkDuration.days(24).description, "24 d")
+        // Just below a minute still uses the decimal seconds form.
+        XCTAssertEqual(NetworkDuration.milliseconds(59_999).description, "59.999 s")
+    }
+
+    func testNegativeDurationDescriptionCoarseUnits() throws {
+        XCTAssertEqual(NetworkDuration.seconds(-60).description, "-1 min")
+        XCTAssertEqual(NetworkDuration.seconds(-75).description, "-1 min 15 s")
+        XCTAssertEqual(NetworkDuration.minutes(-90).description, "-1 h 30 min")
+        XCTAssertEqual(NetworkDuration.minutes(-120).description, "-2 h")
+        XCTAssertEqual(NetworkDuration.hours(-26).description, "-1 d 2 h")
+        XCTAssertEqual(NetworkDuration.days(-24).description, "-24 d")
+    }
+
+    func testDurationScalingByDouble() throws {
+        let oneSecond = NetworkDuration.seconds(1)
+        XCTAssertEqual(0.5 * oneSecond, .milliseconds(500))
+        XCTAssertEqual(oneSecond * 0.5, .milliseconds(500))
+        XCTAssertEqual(0.5 * oneSecond, oneSecond * 0.5)
+        XCTAssertEqual(0.001 * oneSecond, .milliseconds(1))
+        XCTAssertEqual(2.5 * oneSecond, .milliseconds(2500))
+        XCTAssertEqual(2.5 * oneSecond, oneSecond * 2.5)
+        XCTAssertEqual(-0.5 * oneSecond, .milliseconds(-500))
+        XCTAssertEqual(0.0 * oneSecond, .zero)
+    }
+
+    func testDurationRatio() throws {
+        let oneSecond = NetworkDuration.seconds(1)
+        XCTAssertEqual(NetworkDuration.milliseconds(500) / oneSecond, 0.5, accuracy: 1e-9)
+        XCTAssertEqual(NetworkDuration.milliseconds(1500) / oneSecond, 1.5, accuracy: 1e-9)
+        XCTAssertEqual(oneSecond / oneSecond, 1.0, accuracy: 1e-9)
+        XCTAssertEqual(NetworkDuration.microseconds(1) / oneSecond, 1e-6, accuracy: 1e-12)
+        XCTAssertEqual(NetworkDuration.milliseconds(-500) / oneSecond, -0.5, accuracy: 1e-9)
     }
 
     func testDurationRoundedMicroseconds() throws {
@@ -158,6 +218,114 @@ final class SwiftNetworkClockTests: NetTestCase {
         XCTAssertTrue(instant >= instantMinus200)
     }
 
+    func testDurationCompoundAssignment() throws {
+        var duration: NetworkDuration = .seconds(1)
+        duration += .seconds(2)
+        XCTAssertEqual(duration, .seconds(3))
+        duration -= .seconds(1)
+        XCTAssertEqual(duration, .seconds(2))
+        duration -= .seconds(3)
+        XCTAssertEqual(duration, .seconds(-1))
+    }
+
+    func testDurationRoundedMicrosecondsNegative() throws {
+        XCTAssertEqual(NetworkDuration.nanoseconds(-1600).roundedMicroseconds, .microseconds(-2))
+        XCTAssertEqual(NetworkDuration.nanoseconds(-1500).roundedMicroseconds, .microseconds(-2))
+        XCTAssertEqual(NetworkDuration.nanoseconds(-1400).roundedMicroseconds, .microseconds(-1))
+        XCTAssertEqual(NetworkDuration.nanoseconds(-500).roundedMicroseconds, .microseconds(-1))
+        XCTAssertEqual(NetworkDuration.nanoseconds(-499).roundedMicroseconds, .zero)
+        XCTAssertEqual(NetworkDuration.nanoseconds(500).roundedMicroseconds, .microseconds(1))
+        XCTAssertEqual(NetworkDuration.nanoseconds(499).roundedMicroseconds, .zero)
+        XCTAssertEqual(NetworkDuration.zero.roundedMicroseconds, .zero)
+    }
+
+    func testInstantDifferenceIsADuration() throws {
+        let instant = NetworkClock.Instant(microseconds: 1000)
+        let later = instant.advanced(by: .microseconds(200))
+
+        let elapsed: NetworkDuration = later - instant
+        XCTAssertEqual(elapsed, .microseconds(200))
+        XCTAssertEqual(instant - later, .microseconds(-200))
+        XCTAssertEqual(later - instant, instant.duration(to: later))
+        XCTAssertEqual(instant - instant, .zero)
+    }
+
+    func testInstantDescriptionCapsAtSeconds() throws {
+        XCTAssertEqual(NetworkClock.Instant(NetworkDuration.hours(2)).description, "7200.0 s")
+        XCTAssertEqual(NetworkClock.Instant(NetworkDuration.days(1)).description, "86400.0 s")
+        XCTAssertEqual(NetworkDuration.hours(2).description, "2 h")
+        XCTAssertEqual(NetworkDuration.days(1).description, "1 d")
+        XCTAssertEqual(NetworkClock.Instant(microseconds: 1500).description, "1.5 ms")
+    }
+
+    func testInstantInitializersAndConstants() throws {
+        XCTAssertEqual(NetworkClock.Instant(milliseconds: 5).time, .milliseconds(5))
+        XCTAssertEqual(NetworkClock.Instant(microseconds: 6).time, .microseconds(6))
+        XCTAssertEqual(NetworkClock.Instant(nanoseconds: 7).time, .nanoseconds(7))
+        XCTAssertEqual(NetworkClock.Instant(NetworkDuration.microseconds(9)).time, .microseconds(9))
+
+        XCTAssertEqual(NetworkClock.Instant.zero.time, .zero)
+        XCTAssertEqual(NetworkClock.Instant.maximum.time, .nanoseconds(Int64.max))
+        XCTAssertTrue(NetworkClock.Instant.zero < NetworkClock.Instant(microseconds: 1))
+        XCTAssertTrue(NetworkClock.Instant.maximum > NetworkClock.Instant(microseconds: 1))
+    }
+
+    func testInstantNowAbsoluteIsMonotonic() throws {
+        let first = NetworkClock.Instant.nowAbsolute
+        let second = NetworkClock.Instant.nowAbsolute
+        XCTAssertNotEqual(first.time, .zero)
+        XCTAssertTrue(second >= first)
+    }
+
+    func testDurationShiftsCurrentSemantics() throws {
+        XCTAssertEqual(NetworkDuration.seconds(4) >> 1, .seconds(2))
+        XCTAssertEqual(NetworkDuration.seconds(1) << 1, .seconds(2))
+
+        // Arithmetic shift floors; division truncates toward zero.
+        XCTAssertEqual(NetworkDuration.nanoseconds(-3) >> 1, .nanoseconds(-2))
+        XCTAssertEqual(NetworkDuration.nanoseconds(-3) / 2, .nanoseconds(-1))
+
+        // Overshifting left yields zero rather than trapping.
+        XCTAssertEqual(NetworkDuration.seconds(1) << 64, .zero)
+        // And an overflowing shift wraps into a negative duration.
+        let overflowed: Int64 = (NetworkDuration.seconds(1) << 34).nanoseconds
+        XCTAssertTrue(overflowed < Int64(0))
+        // Overshifting right saturates a negative duration at -1 ns.
+        XCTAssertEqual(NetworkDuration.seconds(-1) >> 64, .nanoseconds(-1))
+    }
+
+    func testRoundedUpMillisecondsRoundsAnyFractionUp() {
+        XCTAssertEqual(NetworkDuration.microseconds(2187).roundedUpMilliseconds, 3)
+        XCTAssertEqual(NetworkDuration.microseconds(3761).roundedUpMilliseconds, 4)
+        XCTAssertEqual(NetworkDuration.microseconds(1).roundedUpMilliseconds, 1)
+        XCTAssertEqual(NetworkDuration.microseconds(999).roundedUpMilliseconds, 1)
+    }
+
+    func testRoundedUpMillisecondsExactValuesAreUnchanged() {
+        XCTAssertEqual(NetworkDuration.milliseconds(2).roundedUpMilliseconds, 2)
+        XCTAssertEqual(NetworkDuration.milliseconds(210).roundedUpMilliseconds, 210)
+        XCTAssertEqual(NetworkDuration.seconds(1).roundedUpMilliseconds, 1000)
+    }
+
+    func testRoundedUpMillisecondsClampsZeroAndNegative() {
+        XCTAssertEqual(NetworkDuration.zero.roundedUpMilliseconds, 0)
+        XCTAssertEqual(NetworkDuration.microseconds(-1).roundedUpMilliseconds, 0)
+        XCTAssertEqual(NetworkDuration.seconds(-9).roundedUpMilliseconds, 0)
+    }
+
+    // Rounding up never returns less than truncation, and never more than one extra ms.
+    func testRoundedUpMillisecondsNeverPrecedesDeadline() {
+        for microseconds in stride(from: Int64(1), through: 5000, by: 37) {
+            let duration = NetworkDuration.microseconds(microseconds)
+            let roundedUp = duration.roundedUpMilliseconds
+            XCTAssertGreaterThanOrEqual(roundedUp, duration.milliseconds)
+            XCTAssertLessThanOrEqual(roundedUp, duration.milliseconds + 1)
+            XCTAssertGreaterThanOrEqual(
+                NetworkDuration.milliseconds(roundedUp).nanoseconds,
+                duration.nanoseconds
+            )
+        }
+    }
 }
 
 #if !NETWORK_INTERNAL_TESTS


### PR DESCRIPTION
- Fix float scaling, division, and shift operators to avoid premature integer truncation and preserve precision
- Add hours/days factories, coarse-unit descriptions, fractional microseconds, and roundedUpMilliseconds helper
- Make Instant subtraction return a NetworkDuration and render Instants using fine (sub-minute) units
- Cache nanosecond-per-unit constants and expand test coverage