### PR TITLE
Count leading zeroes a few bytes at a time

### DIFF
--- a/Sources/SwiftNetwork/QUIC/QUICFrame.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICFrame.swift
@@ -736,21 +736,36 @@ struct FramePadding: ~Copyable, QUICFrameProtocol {
     private mutating func countZeros(frame: inout Frame) throws(QUICError) {
         var extraPadding = 0
 
-        if let bytes = frame.span {
-            let count = bytes.count
-            for byte in 0..<count {
-                if bytes[byte] == 0x00 {
-                    extraPadding += 1
-                } else {
-                    break
-                }
-            }
+        if let bytes = frame.bytes {
+            extraPadding = Self.countLeadingZeroBytes(bytes)
         }
 
         guard frame.claim(fromStart: extraPadding) else {
             throw QUICError.frameParse(FrameParseError.parsingError)
         }
         self.extraPadding = extraPadding
+    }
+
+    private static func countLeadingZeroBytes(_ bytes: RawSpan) -> Int {
+        let count = bytes.byteCount
+        let wordSize = MemoryLayout<UInt64>.size
+        var offset = 0
+
+        while offset &+ wordSize <= count {
+            let word = bytes.unsafeLoadUnaligned(fromByteOffset: offset, as: UInt64.self)
+
+            if word == 0 {
+                offset &+= wordSize
+            } else {
+                return offset &+ (UInt64(littleEndian: word).trailingZeroBitCount / 8)
+            }
+        }
+
+        while offset < count, bytes[offset] == 0x00 {
+            offset &+= 1
+        }
+
+        return offset
     }
 
     static func write(frame: inout Frame, length: Int) throws(QUICError) {

--- a/Tests/QUICTests/QUICFrameTests.swift
+++ b/Tests/QUICTests/QUICFrameTests.swift
@@ -93,6 +93,27 @@ class QUICFrameTests: XCTestCase {
         frame.finalize(success: true)
     }
 
+    func testPaddingInitStopsAtFirstNonZeroByte() throws {
+        // Offset 0 is the frame type byte, so start at 1
+        for sentinelOffset in 1..<23 {
+            var bytes = [UInt8](repeating: 0x00, count: 23)
+            bytes[sentinelOffset] = 0xff
+
+            var frame = Frame(copyBuffer: bytes)
+            let paddingFrame = try FramePadding(frame: &frame, packetNumberSpace: .applicationData)
+            XCTAssertEqual(paddingFrame.extraPadding, sentinelOffset - 1)
+            frame.finalize(success: true)
+        }
+    }
+
+    func testPaddingInitAllZeroes() throws {
+        let bytes = [UInt8](repeating: 0x00, count: 23)
+        var frame = Frame(copyBuffer: bytes)
+        let paddingFrame = try FramePadding(frame: &frame, packetNumberSpace: .applicationData)
+        XCTAssertEqual(paddingFrame.extraPadding, 22)
+        frame.finalize(success: true)
+    }
+
     func testPaddingWritingOneByte() throws {
         let expectedBytes: [UInt8] = [0x00]
         var frame = Frame(count: expectedBytes.count)


### PR DESCRIPTION
`QUICFrame.countZeroes()` shows up in a few benchmarks as using ~1.5% of CPU. It can be made a little faster by loading and checking 8 bytes at a time. For long runs of zeros (1200) it's ~4.5x faster, for very short runs (< 8) it's no worse.