### PR TITLE
Guard and protect against faults/crashes on invalid requests

### DIFF
--- a/Sources/SwiftNetwork/Utilities/Deserializer.swift
+++ b/Sources/SwiftNetwork/Utilities/Deserializer.swift
@@ -617,12 +617,12 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
             return
         }
 
-        // Fast fail if total available bytes across all spans is insufficient
-        guard availableByteCount - totalBytesParsed >= byteCount else {
-            try invalidate(.bufferTooShort)
-        }
-
         guard hasRoom(byteCount) else {
+            // Fast fail if total available bytes across all spans is insufficient
+            guard availableByteCount - totalBytesParsed >= byteCount else {
+                try invalidate(.bufferTooShort)
+            }
+
             // Allocate scratch space and read across spans
             var scratch = [UInt8](repeating: 0, count: byteCount)
             var filled = 0
@@ -727,12 +727,12 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
             return
         }
 
-        // Fast fail if total available bytes across all spans is insufficient
-        guard availableByteCount - totalBytesParsed >= length else {
-            try invalidate(.bufferTooShort)
-        }
-
         guard hasRoom(length) else {
+            // Fast fail if total available bytes across all spans is insufficient
+            guard availableByteCount - totalBytesParsed >= length else {
+                try invalidate(.bufferTooShort)
+            }
+
             // Compare across span boundaries
             var matched = 0
             while matched < length {

--- a/Sources/SwiftNetwork/Utilities/Deserializer.swift
+++ b/Sources/SwiftNetwork/Utilities/Deserializer.swift
@@ -535,7 +535,7 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     @inline(always)
     public mutating func vle<T: FixedWidthInteger>(_ value: inout T) throws(DeserializationError) {
         guard let parsedValue = T(exactly: try decodeVariableLength().0) else {
-            throw .parsingFailed
+            try invalidate(.parsingFailed)
         }
         value = parsedValue
     }
@@ -544,7 +544,7 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     @inline(always)
     public mutating func vle<T: FixedWidthInteger>(_ value: inout T?) throws(DeserializationError) {
         guard let parsedValue = T(exactly: try decodeVariableLength().0) else {
-            throw .parsingFailed
+            try invalidate(.parsingFailed)
         }
         value = parsedValue
     }
@@ -583,7 +583,10 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
         _ size: inout Int
     ) throws(DeserializationError) {
         let variable = try decodeVariableLength()
-        value = T(variable.0)
+        guard let parsedValue = T(exactly: variable.0) else {
+            try invalidate(.parsingFailed)
+        }
+        value = parsedValue
         size = variable.1
     }
 
@@ -612,6 +615,11 @@ public struct Deserializer<Factory: DeserializerSpanFactory & ~Copyable & ~Escap
     public mutating func fixedLengthUTF8(_ value: inout String, byteCount: Int) throws(DeserializationError) {
         guard byteCount > 0 else {
             return
+        }
+
+        // Fast fail if total available bytes across all spans is insufficient
+        guard availableByteCount - totalBytesParsed >= byteCount else {
+            try invalidate(.bufferTooShort)
         }
 
         guard hasRoom(byteCount) else {

--- a/Tests/SwiftNetworkTests/SwiftNetworkSerializerTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkSerializerTests.swift
@@ -908,6 +908,19 @@ final class SwiftNetworkSerializerTests: NetTestCase {
         }
     }
 
+    func testDeserializeVLEWithSizeOverflowsTargetType() {
+        // 300 requires the 2-byte VLE encoding but doesn't fit in UInt8.
+        let buffer = Serializer.serialize { write in
+            write.vle(UInt64(300))
+        }
+        var value: UInt8 = 0
+        var size = 0
+        let result = Deserializer.deserialize(buffer) { read throws(DeserializationError) in
+            try read.vleWithSize(&value, &size)
+        }
+        XCTAssertEqual(result, .error(.parsingFailed), "Should fail with parsingFailed instead of trapping")
+    }
+
     func testSerializeUUID() {
         var toWrite = TestStruct()
         toWrite.uuidBytes = SystemUUID()
@@ -2697,7 +2710,20 @@ final class SwiftNetworkSerializerTests: NetTestCase {
         }
 
         XCTAssertEqual(result, .error(.bufferTooShort), "Should fail with bufferTooShort")
-        XCTAssertEqual(factory.index, 2)
+        // The total-available check fails before a second span is pulled.
+        XCTAssertEqual(factory.index, 1)
+    }
+
+    func testDeserializeStreamFixedLengthUTF8InsaneAsk() {
+        // Make sure a request for an insane amount of bytes doesn't cause an alloc that would lead to a crash
+        var factory = TestSpanFactory([[0x41, 0x42], [0x43]])
+
+        var str = ""
+        let result = Deserializer<TestSpanFactory>.deserialize(&factory) { read throws(DeserializationError) in
+            try read.fixedLengthUTF8(&str, byteCount: Int.max)
+        }
+
+        XCTAssertEqual(result, .error(.bufferTooShort), "Should fail fast instead of allocating byteCount bytes")
     }
 
     func testDeserializeStreamStringFragmented() {

--- a/Tests/SwiftNetworkTests/SwiftNetworkSerializerTests.swift
+++ b/Tests/SwiftNetworkTests/SwiftNetworkSerializerTests.swift
@@ -2714,8 +2714,8 @@ final class SwiftNetworkSerializerTests: NetTestCase {
         XCTAssertEqual(factory.index, 1)
     }
 
-    func testDeserializeStreamFixedLengthUTF8InsaneAsk() {
-        // Make sure a request for an insane amount of bytes doesn't cause an alloc that would lead to a crash
+    func testDeserializeStreamFixedLengthUTF8UnreasonableAsk() {
+        // Make sure a request for an unreasonable amount of bytes will not lead to a crash / massive alloc
         var factory = TestSpanFactory([[0x41, 0x42], [0x43]])
 
         var str = ""


### PR DESCRIPTION

- Make sure to not cause a fault when asking for a VLE to be put into too small of a type
- Make sure when deserializing uint8/bytes that a request does not exceed the bytes that are in the span or fast fail
- Add unit tests for these two conditions