### PR TITLE
SwiftQUIC: PERF: Avoid temporary frame array in the send path

### DIFF
--- a/Sources/SwiftNetwork/Protocols/FrameArray.swift
+++ b/Sources/SwiftNetwork/Protocols/FrameArray.swift
@@ -143,6 +143,14 @@ public struct FrameArray: ~Copyable {
         }
     }
 
+    // Make sure to keep the original capacity of the array to prevent reallocations
+    public mutating func drainArrayKeepingCapacity() -> FrameArray {
+        let count = self.count
+        let returnArray = self
+        self = FrameArray(capacity: count)
+        return returnArray
+    }
+
     public mutating func drainArray(maximumFrameCount: Int? = nil) -> FrameArray {
         if let maximumFrameCount, self.count > maximumFrameCount {
             var returnArray = FrameArray()

--- a/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
@@ -2059,9 +2059,9 @@ extension ManyToManyOutboundDatagramProtocol where Path: AutomaticLowerDatagramP
     }
 
     @inline(always)
-    public func enqueueOutboundFrame(frame: consuming Frame, path: Path) throws(NetworkError) {
+    public func enqueueOutboundFrame(frame: consuming Frame, path: Path) {
         var addPath = path
-        return try addPath.addToLowerSendQueue(frame)
+        return addPath.addToLowerSendQueue(frame)
     }
 
     @inline(always)

--- a/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
@@ -2058,18 +2058,6 @@ extension ManyToManyOutboundDatagramProtocol where Path: AutomaticLowerDatagramP
         return try path.addToLowerSendQueue(datagrams)
     }
 
-    @inline(always)
-    public func enqueueOutboundFrame(frame: consuming Frame, path: Path) {
-        var addPath = path
-        return addPath.addToLowerSendQueue(frame)
-    }
-
-    @inline(always)
-    public func sendEnqueuedOutboundDatagrams(path: Path) throws(NetworkError) {
-        var sendPath = path
-        sendPath.serviceLowerSendQueue()
-    }
-
     public func sendEnqueuedOutboundDatagrams(path pathID: MultiplexingPathIdentifier) throws(NetworkError) {
         guard var path = self.path(for: pathID) else { throw NetworkError.posix(EINVAL) }
         path.serviceLowerSendQueue()

--- a/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
+++ b/Sources/SwiftNetwork/Protocols/ManyToManyProtocol.swift
@@ -2058,6 +2058,18 @@ extension ManyToManyOutboundDatagramProtocol where Path: AutomaticLowerDatagramP
         return try path.addToLowerSendQueue(datagrams)
     }
 
+    @inline(always)
+    public func enqueueOutboundFrame(frame: consuming Frame, path: Path) throws(NetworkError) {
+        var addPath = path
+        return try addPath.addToLowerSendQueue(frame)
+    }
+
+    @inline(always)
+    public func sendEnqueuedOutboundDatagrams(path: Path) throws(NetworkError) {
+        var sendPath = path
+        sendPath.serviceLowerSendQueue()
+    }
+
     public func sendEnqueuedOutboundDatagrams(path pathID: MultiplexingPathIdentifier) throws(NetworkError) {
         guard var path = self.path(for: pathID) else { throw NetworkError.posix(EINVAL) }
         path.serviceLowerSendQueue()
@@ -2116,7 +2128,7 @@ open class MultiplexingDatagramPath<ParentProtocol: ManyToManyOutboundDatagramPr
 
     public let identifier = MultiplexingPathIdentifier()
 
-    public var lowerSendQueue = FrameArray()
+    public var lowerSendQueue = FrameArray(capacity: 10)
     public var lowerReceiveQueue = FrameArray()
 
     public var pathIsPrimary: Bool = false

--- a/Sources/SwiftNetwork/Protocols/ProtocolDatagramHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolDatagramHandlers.swift
@@ -57,12 +57,16 @@ extension AutomaticLowerDatagramProcessing where Self: ~Copyable {
         lowerSendQueue.add(frames: datagrams)
     }
 
+    public mutating func addToLowerSendQueue(_ datagram: consuming Frame) throws(NetworkError) {
+        lowerSendQueue.add(frame: datagram)
+    }
+
     /// Indicates to the lower protocol that datagrams have been added to the send queue.
     ///
     /// Drains `lowerSendQueue` to the lower protocol.
     public mutating func serviceLowerSendQueue() {
         guard !lowerSendQueue.isEmpty else { return }
-        try? lower.invokeSendDatagrams(reference, datagrams: lowerSendQueue.drainArray())
+        try? lower.invokeSendDatagrams(reference, datagrams: lowerSendQueue.drainArrayKeepingCapacity())
     }
 
     /// Indicates that datagrams should be read from the lower protocol.

--- a/Sources/SwiftNetwork/Protocols/ProtocolDatagramHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolDatagramHandlers.swift
@@ -61,6 +61,16 @@ extension AutomaticLowerDatagramProcessing where Self: ~Copyable {
         lowerSendQueue.add(frame: datagram)
     }
 
+    /// Enqueues a single outbound datagram to be sent to the lower protocol.
+    public mutating func enqueueOutboundDatagram(_ datagram: consuming Frame) {
+        addToLowerSendQueue(datagram)
+    }
+
+    /// Enqueues a batch of outbound datagrams to be sent to the lower protocol.
+    public mutating func enqueueOutboundDatagrams(_ datagrams: consuming FrameArray) throws(NetworkError) {
+        try addToLowerSendQueue(datagrams)
+    }
+
     /// Indicates to the lower protocol that datagrams have been added to the send queue.
     ///
     /// Drains `lowerSendQueue` to the lower protocol.
@@ -118,6 +128,20 @@ extension AutomaticUpperDatagramProcessing where Self: ~Copyable {
     /// Appends frames to `upperReceiveQueue`.
     public mutating func addToUpperReceiveQueue(_ datagrams: consuming FrameArray) throws(NetworkError) {
         upperReceiveQueue.add(frames: datagrams)
+    }
+
+    public mutating func addToUpperReceiveQueue(_ datagram: consuming Frame) {
+        upperReceiveQueue.add(frame: datagram)
+    }
+
+    /// Enqueues a single inbound datagram to be delivered to the upper protocol.
+    public mutating func enqueueOutboundDatagram(_ datagram: consuming Frame) {
+        addToUpperReceiveQueue(datagram)
+    }
+
+    /// Enqueues a batch of inbound datagrams to be delivered to the upper protocol.
+    public mutating func enqueueOutboundDatagrams(_ datagrams: consuming FrameArray) throws(NetworkError) {
+        try addToUpperReceiveQueue(datagrams)
     }
 
     /// Indicates to the upper protocol that datagrams have been added to the receive queue.

--- a/Sources/SwiftNetwork/Protocols/ProtocolDatagramHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolDatagramHandlers.swift
@@ -57,7 +57,7 @@ extension AutomaticLowerDatagramProcessing where Self: ~Copyable {
         lowerSendQueue.add(frames: datagrams)
     }
 
-    public mutating func addToLowerSendQueue(_ datagram: consuming Frame) throws(NetworkError) {
+    public mutating func addToLowerSendQueue(_ datagram: consuming Frame) {
         lowerSendQueue.add(frame: datagram)
     }
 

--- a/Sources/SwiftNetwork/Protocols/ProtocolStreamHandlers.swift
+++ b/Sources/SwiftNetwork/Protocols/ProtocolStreamHandlers.swift
@@ -62,6 +62,20 @@ extension AutomaticLowerStreamProcessing where Self: ~Copyable {
         lowerSendQueue.add(frames: streamData)
     }
 
+    public mutating func addToLowerSendQueue(_ streamData: consuming Frame) {
+        lowerSendQueue.add(frame: streamData)
+    }
+
+    /// Enqueues a single outbound frame of stream data to be sent to the lower protocol.
+    public mutating func enqueueOutboundFrame(_ frame: consuming Frame) {
+        addToLowerSendQueue(frame)
+    }
+
+    /// Enqueues a batch of outbound stream data to be sent to the lower protocol.
+    public mutating func enqueueOutboundFrameArray(_ frameArray: consuming FrameArray) throws(NetworkError) {
+        try addToLowerSendQueue(frameArray)
+    }
+
     /// Indicates to the lower protocol that stream data has been added to the send queue.
     ///
     /// Drains `lowerSendQueue` to the lower protocol.
@@ -126,6 +140,20 @@ extension AutomaticUpperStreamProcessing where Self: ~Copyable {
     /// Appends frames to `upperReceiveQueue`.
     public mutating func addToUpperReceiveQueue(_ streamData: consuming FrameArray) throws(NetworkError) {
         upperReceiveQueue.add(frames: streamData)
+    }
+
+    public mutating func addToUpperReceiveQueue(_ streamData: consuming Frame) {
+        upperReceiveQueue.add(frame: streamData)
+    }
+
+    /// Enqueues a single inbound frame of stream data to be delivered to the upper protocol.
+    public mutating func enqueueOutboundFrame(_ frame: consuming Frame) {
+        addToUpperReceiveQueue(frame)
+    }
+
+    /// Enqueues a batch of inbound stream data to be delivered to the upper protocol.
+    public mutating func enqueueOutboundFrameArray(_ frameArray: consuming FrameArray) throws(NetworkError) {
+        try addToUpperReceiveQueue(frameArray)
     }
 
     /// Indicates to the upper protocol that stream data has been added to the receive queue.

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -3231,11 +3231,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
     }
 
     private func sendOutboundFrames(on path: QUICPath) {
-        do throws(NetworkError) {
-            try self.sendEnqueuedOutboundDatagrams(path: path)
-        } catch {
-            log.error("Failed to send outbound datagrams: \(error)")
-        }
+        var sendPath = path
+        sendPath.serviceLowerSendQueue()
     }
 
     // Shared by sendApplicationFrames and sendFramesInternal to build the datagram batch.
@@ -3899,8 +3896,8 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         }
 
         QUICSignpost.outbound(id: signpostID, length: totalBytesWrittenInFrame)
-
-        enqueueOutboundFrame(frame: outFrame, path: path)
+        var sendPath = path
+        sendPath.enqueueOutboundDatagram(outFrame)
         return true
     }
 
@@ -5334,16 +5331,9 @@ extension QUICConnection {
             return
         }
 
-        do throws(NetworkError) {
-            try self.enqueueOutboundDatagrams(
-                path: path.identifier,
-                datagrams: .init(frame: outFrame)
-            )
-            try self.sendEnqueuedOutboundDatagrams(path: path.identifier)
-        } catch {
-            log.error("Failed to send version negotiation frame with error: \(error)")
-            return
-        }
+        var sendPath = path
+        sendPath.enqueueOutboundDatagram(outFrame)
+        sendPath.serviceLowerSendQueue()
         log.info("Sent version negotiation packet")
     }
 
@@ -5408,16 +5398,9 @@ extension QUICConnection {
             outFrame.finalize(success: false)
             return
         }
-        do throws(NetworkError) {
-            try self.enqueueOutboundDatagrams(
-                path: path.identifier,
-                datagrams: .init(frame: outFrame)
-            )
-            try self.sendEnqueuedOutboundDatagrams(path: path.identifier)
-        } catch {
-            log.error("Failed to send retry frame with error: \(error)")
-            return
-        }
+        var sendPath = path
+        sendPath.enqueueOutboundDatagram(outFrame)
+        sendPath.serviceLowerSendQueue()
         log.info("Sent retry packet")
     }
 }

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -3900,7 +3900,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
 
         QUICSignpost.outbound(id: signpostID, length: totalBytesWrittenInFrame)
 
-        try? enqueueOutboundFrame(frame: outFrame, path: path)
+        enqueueOutboundFrame(frame: outFrame, path: path)
         return true
     }
 

--- a/Sources/SwiftNetwork/QUIC/QUICConnection.swift
+++ b/Sources/SwiftNetwork/QUIC/QUICConnection.swift
@@ -3230,14 +3230,9 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         return outboundBatch
     }
 
-    private func sendOutboundFrames(_ outboundFrames: consuming FrameArray, on path: QUICPath) {
-        guard !outboundFrames.isEmpty else { return }
+    private func sendOutboundFrames(on path: QUICPath) {
         do throws(NetworkError) {
-            try self.enqueueOutboundDatagrams(
-                path: path.identifier,
-                datagrams: outboundFrames
-            )
-            try self.sendEnqueuedOutboundDatagrams(path: path.identifier)
+            try self.sendEnqueuedOutboundDatagrams(path: path)
         } catch {
             log.error("Failed to send outbound datagrams: \(error)")
         }
@@ -3277,7 +3272,6 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         availableCongestionWindow: inout UInt64,
         totalSendBytes: inout UInt64,
         datagramBatch: inout FrameArray,
-        outboundFrames: inout FrameArray,
         sentPackets: inout NetworkUniqueDeque<SentPacketRecord>,
         protector: inout Protector,
         stats: inout Statistics,
@@ -3298,7 +3292,6 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
                     totalSendBytes: &totalSendBytes,
                     retransmission: retransmission,
                     datagramBatch: &datagramBatch,
-                    outboundFrames: &outboundFrames,
                     protector: &protector,
                     stats: &stats,
                     ecn: &ecn
@@ -3386,7 +3379,6 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             }
         }
 
-        var outboundFrameArray = FrameArray(capacity: datagramBatch.count)
         // keyState can only be .phase0 or .phase1 here: initial keys are discarded and the
         // handshake is confirmed, so .earlyData is no longer possible.
         let packetKeyState: PacketKeyState = self.keyState == .phase1 ? .phase1 : .phase0
@@ -3400,16 +3392,13 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             availableCongestionWindow: &availableCongestionWindow,
             totalSendBytes: &totalSendBytes,
             datagramBatch: &datagramBatch,
-            outboundFrames: &outboundFrameArray,
             sentPackets: &sentPackets,
             protector: &protector,
             stats: &stats,
             ecn: &ecn,
             applicationPendingItems: &applicationPendingItems
         )
-        if !outboundFrameArray.isEmpty {
-            sendOutboundFrames(outboundFrameArray, on: path)
-        }
+        sendOutboundFrames(on: path)
         return true
     }
 
@@ -3458,7 +3447,6 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
                     applicationPendingItems: &applicationPendingItems
                 )
             }
-            var outboundFrameArray = FrameArray()
             let success = buildSinglePacketForKeyState(
                 self.keyState,
                 pendingItems: &pendingItems,
@@ -3469,14 +3457,11 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
                 totalSendBytes: &totalSendBytes,
                 retransmission: retransmission,
                 datagramBatch: &datagramBatch,
-                outboundFrames: &outboundFrameArray,
                 protector: &protector,
                 stats: &stats,
                 ecn: &ecn
             )
-            if !outboundFrameArray.isEmpty {
-                sendOutboundFrames(outboundFrameArray, on: path)
-            }
+            sendOutboundFrames(on: path)
             return success
         }
 
@@ -3502,7 +3487,6 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             }
         }
 
-        var outboundFrameArray = FrameArray(capacity: datagramBatch.count)
         if !initialKeysDiscarded {
             while initialPendingItems.hasPendingItems {
                 if initialKeysDiscarded {
@@ -3521,7 +3505,6 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
                         totalSendBytes: &totalSendBytes,
                         retransmission: retransmission,
                         datagramBatch: &datagramBatch,
-                        outboundFrames: &outboundFrameArray,
                         protector: &protector,
                         stats: &stats,
                         ecn: &ecn
@@ -3559,7 +3542,6 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
                     totalSendBytes: &totalSendBytes,
                     retransmission: retransmission,
                     datagramBatch: &datagramBatch,
-                    outboundFrames: &outboundFrameArray,
                     protector: &protector,
                     stats: &stats,
                     ecn: &ecn
@@ -3590,16 +3572,13 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
             availableCongestionWindow: &availableCongestionWindow,
             totalSendBytes: &totalSendBytes,
             datagramBatch: &datagramBatch,
-            outboundFrames: &outboundFrameArray,
             sentPackets: &sentPackets,
             protector: &protector,
             stats: &stats,
             ecn: &ecn,
             applicationPendingItems: &applicationPendingItems
         )
-        if !outboundFrameArray.isEmpty {
-            sendOutboundFrames(outboundFrameArray, on: path)
-        }
+        sendOutboundFrames(on: path)
         return true
     }
 
@@ -3613,7 +3592,6 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
         totalSendBytes: inout UInt64,
         retransmission: Bool,
         datagramBatch: inout FrameArray,
-        outboundFrames: inout FrameArray,
         protector: inout Protector,
         stats: inout Statistics,
         ecn: inout ECN
@@ -3922,7 +3900,7 @@ public final class QUICConnection: ManyToManyApplicationStreamProtocol,
 
         QUICSignpost.outbound(id: signpostID, length: totalBytesWrittenInFrame)
 
-        outboundFrames.add(frame: outFrame)
+        try? enqueueOutboundFrame(frame: outFrame, path: path)
         return true
     }
 


### PR DESCRIPTION
This one is a double performance win, we save around 150 megacycles and we avoid a temporary allocation for FrameArray each time SwiftQUIC sends.
Today, each time SwiftQUIC sends frames it builds a temporary outboundFrameArray to add all of these frames in and then adds these frames to the lowerSendQueue.
We can just add these frames directly to the lowerSendQueue and take a CPU win too as long as we keep the capacity of the lowerSendQueue.

Top of tree:
```
29.97 G  88.8%	4.50 M  	  QUICConnection.buildSinglePacketForKeyState()	
29.87 G  88.5%	240.58 M	  specialized QUICConnection.buildSinglePacketForKeyState()	
220.14 M 0.7%	35.41 M 	  FrameArray.add(frame:)	


33.03 G 42.6%	8.00 M 	      QUICConnection.sendApplicationFrames()	
31.13 G 40.1%	44.91 M	       QUICConnection.runApplicationBurstLoop()	
1.55 G  2.0%	1.00 M 	       QUICConnection.sendOutboundFrames(_:on:)	
```
With this change:
```

29.49 G  88.5%	4.85 M  	   QUICConnection.buildSinglePacketForKeyState()	
29.44 G  88.4%	213.60 M	   specialized QUICConnection.buildSinglePacketForKeyState()	
172.28 M 0.5%	6.00 M  	   specialized ManyToManyOutboundDatagramProtocol<>.enqueueOutboundFrame(frame:path:)	

33.68 G 43.9%	1.00 M 	       QUICConnection.sendFrames()	
1.44 G  1.9%	-      	        QUICConnection.sendOutboundFrames(on:)	
```