### PR TITLE
Optimize recovery sent packet lookup

### DIFF
--- a/Sources/SwiftNetwork/QUIC/Recovery.swift
+++ b/Sources/SwiftNetwork/QUIC/Recovery.swift
@@ -100,21 +100,58 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
             outstandingPackets.append(PacketContainerEntry(packet, sentTime: sentTime))
         }
 
+        /// Finds the index of `packetNumber` in `outstandingPackets`, or `nil`.
+        ///
+        /// Entries are sorted by packet number but sparse — acknowledged and
+        /// retransmitted packets are removed from the middle — so index and packet
+        /// number drift apart. The strict ordering still means packet numbers rise
+        /// by at least one per slot, which lets the first and last entries bound
+        /// the search window arithmetically before probing anything else:
+        ///
+        /// - from the front: `index <= frontIndex + (target - frontNumber)`
+        /// - from the back:  `index >= backIndex - (backNumber - target)`
+        ///
+        /// When no packets have been dropped between the two ends, those bounds
+        /// meet on the answer and no binary search runs at all. That covers the
+        /// dominant case of acknowledgements arriving in ascending order. Any gaps
+        /// only widen the window, so the binary search below stays a fallback
+        /// rather than the common path.
         @_optimize(speed)
         func indexOfPacketNumber(_ packetNumber: PacketNumber) -> Int? {
-            guard !outstandingPackets.isEmpty else { return nil }
-            var left = 0
-            var right = outstandingPackets.count - 1
+            let entryCount = outstandingPackets.count
+            guard entryCount > 0 else { return nil }
+
+            let target = packetNumber.value
+
+            // Front entry: the overwhelmingly common lookup, since packets are
+            // acknowledged oldest-first.
+            let frontNumber = outstandingPackets[0].packet.number.value
+            if frontNumber == target { return 0 }
+            if frontNumber > target { return nil }
+
+            var right = entryCount - 1
+            let backNumber = outstandingPackets[right].packet.number.value
+            if backNumber == target { return right }
+            if backNumber < target { return nil }
+
+            // Both ends are strictly inside the range now, so narrow the window
+            // using the density bounds described above.
+            var left = 1
+            let fromFront = target - frontNumber
+            if fromFront < Int64(right) {
+                right = Int(fromFront)
+            }
+            let fromBack = backNumber - target
+            if fromBack < Int64(entryCount - 1 - left) {
+                left = entryCount - 1 - Int(fromBack)
+            }
+
             while left <= right {
                 let middle = left + (right - left) / 2
-                let middlePacketNumber = outstandingPackets[middle].packet.number
-                if outstandingPackets[left].packet.number == packetNumber {
-                    return left
-                } else if outstandingPackets[right].packet.number == packetNumber {
-                    return right
-                } else if middlePacketNumber == packetNumber {
+                let middleNumber = outstandingPackets[middle].packet.number.value
+                if middleNumber == target {
                     return middle
-                } else if middlePacketNumber < packetNumber {
+                } else if middleNumber < target {
                     left = middle + 1
                 } else {
                     right = middle - 1
@@ -126,7 +163,14 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
         @_optimize(speed)
         mutating func removeSentPacket(_ packetNumber: PacketNumber) -> PacketContainerEntry? {
             if let index = indexOfPacketNumber(packetNumber) {
-                let removedEntry = outstandingPackets.remove(at: index)
+                // `remove(at:)` is O(count) and runs the full gap-closing analysis
+                // even when there is nothing to shift. Acknowledgements arrive
+                // oldest-first, so the front case dominates; `removeFirst()` is
+                // documented O(1) and just advances the head slot.
+                let removedEntry =
+                    index == 0
+                    ? outstandingPackets.removeFirst()
+                    : outstandingPackets.remove(at: index)
                 if removedEntry.packet.largerPacket, largerPacketCount > 0 {
                     largerPacketCount -= 1
                 }
@@ -1048,7 +1092,12 @@ struct Recovery: ~Copyable, PrefixedLoggable, NonCopyableTimerUser {
                     let lostDuration = lostTime.duration(to: now)
                     if lostDuration > ackedPath.rtt.smoothedRTT {
                         // Remove packet and don't increment index (so the next loop looks at the new value in this index)
-                        innerState.outstandingPackets.remove(at: index)
+                        if index == 0 {
+                            // O(1), unlike the general remove(at:).
+                            innerState.outstandingPackets.removeFirst()
+                        } else {
+                            innerState.outstandingPackets.remove(at: index)
+                        }
                         continue
                     }
                 }

--- a/Tests/QUICTests/RecoveryTests.swift
+++ b/Tests/QUICTests/RecoveryTests.swift
@@ -767,6 +767,149 @@ final class RecoveryTests: XCTestCase {
             )
         }
     }
+
+    // MARK: - Packet index hints
+
+    /// Records a sparse ascending run of packets in the application data space.
+    private func recordSparsePackets(_ packetNumbers: [Int64]) {
+        for number in packetNumbers {
+            var packet = SentPacketRecord()
+            packet.identifier = .init(space: .applicationData, number: PacketNumber(number))
+            packet.isInFlightEligible = true
+            packet.isAckEliciting = true
+            packet.totalLength = 100
+            packet.sentPath = connection.currentPath?.identifier ?? .none
+            sentPacket(packet, connection: connection)
+        }
+    }
+
+    /// Removes an outstanding packet, asserting it was present. `removeSentPacket`
+    /// returns a non-copyable entry, so the result is reduced to a `Bool` here.
+    private func removeOutstanding(
+        _ innerState: inout Recovery.InnerState,
+        _ number: Int64,
+        _ message: String
+    ) {
+        let removed = innerState.removeSentPacket(PacketNumber(number)) != nil
+        XCTAssertTrue(removed, message)
+    }
+
+    /// Every recorded packet must be findable, and absent numbers must not be
+    /// reported as present, regardless of the hints accumulated along the way.
+    func testIndexOfPacketNumberFindsSparseEntries() {
+        let numbers: [Int64] = [4, 5, 9, 10, 11, 20, 21, 40, 41, 42, 100]
+        recordSparsePackets(numbers)
+
+        connection.recovery.withImmutableInnerState(packetNumberSpace: .applicationData) {
+            innerState in
+            for (expectedIndex, number) in numbers.enumerated() {
+                XCTAssertEqual(
+                    innerState.indexOfPacketNumber(PacketNumber(number)),
+                    expectedIndex,
+                    "Packet \(number) should be at index \(expectedIndex)"
+                )
+            }
+            // Numbers in the gaps, and outside the range entirely, are absent.
+            for absent: Int64 in [0, 3, 6, 8, 12, 19, 30, 43, 99, 101, 1000] {
+                XCTAssertNil(
+                    innerState.indexOfPacketNumber(PacketNumber(absent)),
+                    "Packet \(absent) was never recorded"
+                )
+            }
+        }
+    }
+
+    /// Removing from the front — the common in-order acknowledgement case — must
+    /// keep the remaining lookups correct as cached indices shift down.
+    func testIndexOfPacketNumberAfterFrontRemovals() {
+        var remaining: [Int64] = [4, 5, 9, 10, 11, 20, 21, 40, 41, 42, 100]
+        recordSparsePackets(remaining)
+
+        while !remaining.isEmpty {
+            let removed = remaining.removeFirst()
+            connection.recovery.withMutableInnerState(packetNumberSpace: .applicationData) {
+                innerState in
+                removeOutstanding(
+                    &innerState,
+                    removed,
+                    "Packet \(removed) should still be outstanding"
+                )
+                XCTAssertNil(
+                    innerState.indexOfPacketNumber(PacketNumber(removed)),
+                    "Packet \(removed) was just removed"
+                )
+                for (expectedIndex, number) in remaining.enumerated() {
+                    XCTAssertEqual(
+                        innerState.indexOfPacketNumber(PacketNumber(number)),
+                        expectedIndex,
+                        "After removing \(removed), packet \(number) should be at \(expectedIndex)"
+                    )
+                }
+            }
+        }
+    }
+
+    /// Removing from the middle exercises hint invalidation: pairs above the
+    /// removed index shift down, and the pair naming it must be dropped.
+    func testIndexOfPacketNumberAfterInteriorRemovals() {
+        var remaining: [Int64] = [1, 2, 3, 7, 8, 15, 16, 17, 30, 31, 60, 61, 62]
+        recordSparsePackets(remaining)
+
+        // Prime the hints with lookups spread across the deque, then remove from
+        // the middle so the cached indices must be adjusted.
+        for removed: Int64 in [15, 8, 31, 60, 2, 17] {
+            connection.recovery.withMutableInnerState(packetNumberSpace: .applicationData) {
+                innerState in
+                for number in remaining {
+                    _ = innerState.indexOfPacketNumber(PacketNumber(number))
+                }
+                removeOutstanding(
+                    &innerState,
+                    removed,
+                    "Packet \(removed) should still be outstanding"
+                )
+                remaining.removeAll { $0 == removed }
+                for (expectedIndex, number) in remaining.enumerated() {
+                    XCTAssertEqual(
+                        innerState.indexOfPacketNumber(PacketNumber(number)),
+                        expectedIndex,
+                        "After removing \(removed), packet \(number) should be at \(expectedIndex)"
+                    )
+                }
+                XCTAssertNil(innerState.indexOfPacketNumber(PacketNumber(removed)))
+            }
+        }
+    }
+
+    /// Appending after removals must not leave stale hints behind: the deque can
+    /// drain to empty and refill with much larger packet numbers.
+    func testIndexOfPacketNumberAcrossDrainAndRefill() {
+        recordSparsePackets([1, 2, 3])
+        connection.recovery.withMutableInnerState(packetNumberSpace: .applicationData) {
+            innerState in
+            for number: Int64 in [1, 2, 3] {
+                removeOutstanding(&innerState, number, "Packet \(number) should be outstanding")
+            }
+            XCTAssertTrue(innerState.outstandingPackets.isEmpty)
+        }
+
+        let refilled: [Int64] = [500, 501, 700]
+        recordSparsePackets(refilled)
+        connection.recovery.withImmutableInnerState(packetNumberSpace: .applicationData) {
+            innerState in
+            for (expectedIndex, number) in refilled.enumerated() {
+                XCTAssertEqual(
+                    innerState.indexOfPacketNumber(PacketNumber(number)),
+                    expectedIndex
+                )
+            }
+            // The drained packet numbers must not resolve to the refilled entries.
+            for absent: Int64 in [1, 2, 3] {
+                XCTAssertNil(innerState.indexOfPacketNumber(PacketNumber(absent)))
+            }
+        }
+    }
+
 }
 
 #endif


### PR DESCRIPTION
Optimize recovery processing of sent packets:
- Fast path for checking the first packets in the list
- Remove from the deque using the specialized function that is cheaper that remove(at:)


Baseline
```
82.69 M 90.5%	23.64 M	                                    Recovery.InnerState.removeSentPacket(_:)	
31.11 M 34.1%	31.11 M	                                     Recovery.InnerState.indexOfPacketNumber(_:)	
17.93 M 19.6%	-      	                                     specialized UniqueDeque<>.remove(at:)	
17.93 M 19.6%	12.93 M	                                      specialized RigidDeque<>.remove(at:)	
10.00 M 11.0%	10.00 M	                                     outlined enum tag store of PacketContainerEntry?
```

With change
```
63.15 M  8.2%	45.01 M	                                    Recovery.InnerState.removeSentPacket(_:)	
7.14 M   0.9%	7.14 M 	                                     Recovery.InnerState.indexOfPacketNumber(_:)	
7.00 M   0.9%	7.00 M 	                                     outlined enum tag store of PacketContainerEntry?	
3.00 M   0.4%	-      	                                     specialized UniqueDeque<>.removeFirst()	
1.00 M   0.1%	1.00 M 	                                     outlined enum tag store of PacketContainerEntry?	
```